### PR TITLE
Introduce `Converter` in `junit-platform-commons`

### DIFF
--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/aggregator/DefaultArgumentsAccessor.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/aggregator/DefaultArgumentsAccessor.java
@@ -20,6 +20,7 @@ import java.util.function.BiFunction;
 import org.apiguardian.api.API;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.params.converter.DefaultArgumentConverter;
+import org.junit.platform.commons.support.conversion.TypeDescriptor;
 import org.junit.platform.commons.util.ClassUtils;
 import org.junit.platform.commons.util.Preconditions;
 
@@ -45,7 +46,8 @@ public class DefaultArgumentsAccessor implements ArgumentsAccessor {
 		Preconditions.notNull(classLoader, "ClassLoader must not be null");
 
 		BiFunction<@Nullable Object, Class<?>, @Nullable Object> converter = (source,
-				targetType) -> DefaultArgumentConverter.INSTANCE.convert(source, targetType, classLoader);
+				targetType) -> DefaultArgumentConverter.INSTANCE.convert(source, TypeDescriptor.forClass(targetType),
+					classLoader);
 		return new DefaultArgumentsAccessor(converter, invocationIndex, arguments);
 	}
 

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/converter/DefaultArgumentConverter.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/converter/DefaultArgumentConverter.java
@@ -26,8 +26,10 @@ import org.apiguardian.api.API;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.params.support.FieldContext;
+import org.junit.platform.commons.support.conversion.ConversionContext;
 import org.junit.platform.commons.support.conversion.ConversionException;
 import org.junit.platform.commons.support.conversion.ConversionSupport;
+import org.junit.platform.commons.support.conversion.TypeDescriptor;
 import org.junit.platform.commons.util.ReflectionUtils;
 
 /**
@@ -41,7 +43,7 @@ import org.junit.platform.commons.util.ReflectionUtils;
  * {@link File}, {@link BigDecimal}, {@link BigInteger}, {@link Currency},
  * {@link Locale}, {@link URI}, {@link URL}, {@link UUID}, etc.
  *
- * <p>If the source and target types are identical the source object will not
+ * <p>If the source and target types are identical, the source object will not
  * be modified.
  *
  * @since 5.0
@@ -58,49 +60,42 @@ public class DefaultArgumentConverter implements ArgumentConverter {
 
 	@Override
 	public final @Nullable Object convert(@Nullable Object source, ParameterContext context) {
-		Class<?> targetType = context.getParameter().getType();
 		ClassLoader classLoader = getClassLoader(context.getDeclaringExecutable().getDeclaringClass());
-		return convert(source, targetType, classLoader);
+		return convert(source, TypeDescriptor.forParameter(context.getParameter()), classLoader);
 	}
 
 	@Override
 	public final @Nullable Object convert(@Nullable Object source, FieldContext context)
 			throws ArgumentConversionException {
-
-		Class<?> targetType = context.getField().getType();
 		ClassLoader classLoader = getClassLoader(context.getField().getDeclaringClass());
-		return convert(source, targetType, classLoader);
+		return convert(source, TypeDescriptor.forField(context.getField()), classLoader);
 	}
 
-	public final @Nullable Object convert(@Nullable Object source, Class<?> targetType, ClassLoader classLoader) {
+	public final @Nullable Object convert(@Nullable Object source, TypeDescriptor targetType, ClassLoader classLoader) {
 		if (source == null) {
 			if (targetType.isPrimitive()) {
 				throw new ArgumentConversionException(
-					"Cannot convert null to primitive value of type " + targetType.getTypeName());
+					"Cannot convert null to primitive value of type " + targetType.getType().getTypeName());
 			}
 			return null;
 		}
 
-		if (ReflectionUtils.isAssignableTo(source, targetType)) {
+		if (ReflectionUtils.isAssignableTo(source, targetType.getType())) {
 			return source;
 		}
 
-		if (source instanceof String string) {
-			try {
-				return convert(string, targetType, classLoader);
-			}
-			catch (ConversionException ex) {
-				throw new ArgumentConversionException(ex.getMessage(), ex);
-			}
+		try {
+			ConversionContext context = new ConversionContext(source, targetType, classLoader);
+			return delegateConversion(source, context);
 		}
-
-		throw new ArgumentConversionException("No built-in converter for source type %s and target type %s".formatted(
-			source.getClass().getTypeName(), targetType.getTypeName()));
+		catch (ConversionException ex) {
+			throw new ArgumentConversionException(ex.getMessage(), ex);
+		}
 	}
 
 	@Nullable
-	Object convert(@Nullable String source, Class<?> targetType, ClassLoader classLoader) {
-		return ConversionSupport.convert(source, targetType, classLoader);
+	Object delegateConversion(@Nullable Object source, ConversionContext context) {
+		return ConversionSupport.convert(source, context);
 	}
 
 }

--- a/junit-platform-commons/src/main/java/module-info.java
+++ b/junit-platform-commons/src/main/java/module-info.java
@@ -56,5 +56,6 @@ module org.junit.platform.commons {
 			org.junit.platform.suite.engine,
 			org.junit.platform.testkit,
 			org.junit.vintage.engine;
+	uses org.junit.platform.commons.support.conversion.Converter;
 	uses org.junit.platform.commons.support.scanning.ClasspathScanner;
 }

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/conversion/ConversionContext.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/conversion/ConversionContext.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2015-2025 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.commons.support.conversion;
+
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.junit.platform.commons.util.ClassLoaderUtils.getDefaultClassLoader;
+
+import org.apiguardian.api.API;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * {@code ConversionContext} encapsulates the <em>context</em> in which the
+ * current conversion is being executed.
+ *
+ * <p>{@link Converter Converters} are provided an instance of
+ * {@code ConversionContext} to perform their work.
+ *
+ * @param sourceType the descriptor of the source type
+ * @param targetType the descriptor of the type the source should be converted into
+ * @param classLoader the {@code ClassLoader} to use
+ *
+ * @since 6.0
+ * @see Converter
+ */
+@API(status = EXPERIMENTAL, since = "6.0")
+public record ConversionContext(TypeDescriptor sourceType, TypeDescriptor targetType, ClassLoader classLoader) {
+
+	/**
+	 * Create a new {@code ConversionContext}, expecting an instance of the
+	 * source instead of its type descriptor.
+	 *
+	 * @param source the source instance; may be {@code null}
+	 * @param targetType the descriptor of the type the source should be converted into
+	 * @param classLoader the {@code ClassLoader} to use; may be {@code null} to
+	 * use the default {@code ClassLoader}
+	 */
+	public ConversionContext(@Nullable Object source, TypeDescriptor targetType, @Nullable ClassLoader classLoader) {
+		this(TypeDescriptor.forInstance(source), targetType,
+			classLoader != null ? classLoader : getDefaultClassLoader());
+	}
+
+}

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/conversion/ConversionException.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/conversion/ConversionException.java
@@ -15,6 +15,7 @@ import static org.apiguardian.api.API.Status.MAINTAINED;
 import java.io.Serial;
 
 import org.apiguardian.api.API;
+import org.jspecify.annotations.Nullable;
 import org.junit.platform.commons.JUnitException;
 
 /**
@@ -33,7 +34,7 @@ public class ConversionException extends JUnitException {
 		super(message);
 	}
 
-	public ConversionException(String message, Throwable cause) {
+	public ConversionException(String message, @Nullable Throwable cause) {
 		super(message, cause);
 	}
 

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/conversion/Converter.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/conversion/Converter.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2015-2025 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.commons.support.conversion;
+
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+
+import org.apiguardian.api.API;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * {@code Converter} is an abstraction that allows an input object to
+ * be converted to an instance of a different class.
+ *
+ * <p>Implementations are loaded via the {@link java.util.ServiceLoader} and must
+ * follow the service provider requirements. They should not make any assumptions
+ * regarding when they are instantiated or how often they are called. Since
+ * instances may potentially be cached and called from different threads, they
+ * should be thread-safe.
+ *
+ * <p>Extend {@link SimpleConverter} if your implementation always converts
+ * from a given source type into a given target type and does not need access to
+ * the {@link ClassLoader} to perform the conversion.
+ *
+ * @param <S> the type of the source to convert
+ * @param <T> the type the source should be converted into
+ *
+ * @since 6.0
+ * @see ConversionSupport
+ * @see SimpleConverter
+ */
+@API(status = EXPERIMENTAL, since = "6.0")
+public interface Converter<S, T extends @Nullable Object> {
+
+	/**
+	 * Determine if the supplied conversion context is supported.
+	 *
+	 * @param context the context for the conversion; never {@code null}
+	 * @return {@code true} if the conversion is supported
+	 */
+	boolean canConvert(ConversionContext context);
+
+	/**
+	 * Convert the supplied source object according to the supplied conversion context.
+	 * <p>This method will only be invoked if {@link #canConvert(ConversionContext)}
+	 * returns {@code true} for the same context.
+	 *
+	 * @param source the source object to convert; may be {@code null}
+	 * but only if the target type is a reference type
+	 * @param context the context for the conversion; never {@code null}
+	 * @return the converted object; may be {@code null} but only if the target
+	 * type is a reference type
+	 * @throws ConversionException if an error occurs during the conversion
+	 */
+	T convert(@Nullable S source, ConversionContext context) throws ConversionException;
+
+}

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/conversion/DefaultConverter.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/conversion/DefaultConverter.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2015-2025 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.commons.support.conversion;
+
+import static org.apiguardian.api.API.Status.INTERNAL;
+
+import java.io.File;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.net.URI;
+import java.net.URL;
+import java.util.Currency;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.apiguardian.api.API;
+import org.jspecify.annotations.Nullable;
+import org.junit.platform.commons.util.ClassLoaderUtils;
+
+/**
+ * {@code DefaultConversionService} is the default implementation of the
+ * {@link Converter} API.
+ *
+ * <p>The {@code DefaultConversionService} is able to convert from strings to a
+ * number of primitive types and their corresponding wrapper types (Byte, Short,
+ * Integer, Long, Float, and Double), date and time types from the
+ * {@code java.time} package, and some additional common Java types such as
+ * {@link File}, {@link BigDecimal}, {@link BigInteger}, {@link Currency},
+ * {@link Locale}, {@link URI}, {@link URL}, {@link UUID}, etc.
+ *
+ * <p>If the source and target types are identical, the source object will not
+ * be modified.
+ *
+ * @since 6.0
+ */
+@API(status = INTERNAL, since = "6.0")
+public class DefaultConverter implements Converter<String, @Nullable Object> {
+
+	static final DefaultConverter INSTANCE = new DefaultConverter();
+
+	private static final List<Converter<String, ?>> stringToObjectConverters = List.of( //
+		new StringToBooleanConverter(), //
+		new StringToCharacterConverter(), //
+		new StringToNumberConverter(), //
+		new StringToClassConverter(), //
+		new StringToEnumConverter(), //
+		new StringToJavaTimeConverter(), //
+		new StringToCommonJavaTypesConverter(), //
+		new FallbackStringToObjectConverter() //
+	);
+
+	private DefaultConverter() {
+		// nothing to initialize
+	}
+
+	/**
+	 * Determine if the supplied conversion context is supported.
+	 * <p>FIXME add more content from {@link Converter#convert} about the conversion algorithm
+	 *
+	 * @param context the context for the conversion; never {@code null}
+	 * @return {@code true} if the conversion is supported
+	 */
+	@Override
+	public boolean canConvert(ConversionContext context) {
+		if (context.sourceType().equals(TypeDescriptor.NONE)) {
+			return !context.targetType().isPrimitive();
+		}
+
+		if (!String.class.equals(context.sourceType().getType())) {
+			return false;
+		}
+
+		if (String.class.equals(context.targetType().getType())) {
+			return true;
+		}
+
+		return stringToObjectConverters.stream().anyMatch(candidate -> candidate.canConvert(context));
+	}
+
+	/**
+	 * Convert the supplied source {@link String} into an instance of the specified
+	 * target type.
+	 * <p>If the target type is {@code String}, the source {@code String} will not
+	 * be modified.
+	 * <p>Some forms of conversion require a {@link ClassLoader}. If none is
+	 * provided, the {@linkplain ClassLoaderUtils#getDefaultClassLoader() default
+	 * ClassLoader} will be used.
+	 * <p>This method is able to convert strings into primitive types and their
+	 * corresponding wrapper types ({@link Boolean}, {@link Character}, {@link Byte},
+	 * {@link Short}, {@link Integer}, {@link Long}, {@link Float}, and
+	 * {@link Double}), enum constants, date and time types from the
+	 * {@code java.time} package, as well as common Java types such as {@link Class},
+	 * {@link java.io.File}, {@link java.nio.file.Path}, {@link java.nio.charset.Charset},
+	 * {@link java.math.BigDecimal}, {@link java.math.BigInteger},
+	 * {@link java.util.Currency}, {@link java.util.Locale}, {@link java.util.UUID},
+	 * {@link java.net.URI}, and {@link java.net.URL}.
+	 * <p>If the target type is not covered by any of the above, a convention-based
+	 * conversion strategy will be used to convert the source {@code String} into the
+	 * given target type by invoking a static factory method or factory constructor
+	 * defined in the target type. The search algorithm used in this strategy is
+	 * outlined below.
+	 * <h4>Search Algorithm</h4>
+	 * <ol>
+	 * <li>Search for a single, non-private static factory method in the target
+	 * type that converts from a String to the target type. Use the factory method
+	 * if present.</li>
+	 * <li>Search for a single, non-private constructor in the target type that
+	 * accepts a String. Use the constructor if present.</li>
+	 * </ol>
+	 * <p>If multiple suitable factory methods are discovered, they will be ignored.
+	 * If neither a single factory method nor a single constructor is found, the
+	 * convention-based conversion strategy will not apply.
+	 *
+	 * @param source the source {@link String} to convert; may be {@code null}
+	 * but only if the target type is a reference type
+	 * @param context the context for the conversion; never {@code null}
+	 * @return the converted object; may be {@code null} but only if the target
+	 * type is a reference type
+	 * @throws ConversionException if an error occurs during the conversion
+	 */
+	@Override
+	public @Nullable Object convert(@Nullable String source, ConversionContext context) throws ConversionException {
+		if (source == null) {
+			if (context.targetType().isPrimitive()) {
+				throw new ConversionException("Cannot convert null to primitive value of type " + context.targetType());
+			}
+			return null;
+		}
+
+		if (String.class.equals(context.targetType().getType())) {
+			return source;
+		}
+
+		Optional<Converter<String, ?>> converter = stringToObjectConverters.stream().filter(
+			candidate -> candidate.canConvert(context)).findFirst();
+		if (converter.isPresent()) {
+			try {
+				return converter.get().convert(source, context);
+			}
+			catch (Exception ex) {
+				if (ex instanceof ConversionException conversionException) {
+					// simply rethrow it
+					throw conversionException;
+				}
+				// else
+				throw new ConversionException(
+					"Failed to convert String \"%s\" to type %s".formatted(source, context.targetType()), ex);
+			}
+		}
+
+		throw new ConversionException(
+			"No built-in converter for source type java.lang.String and target type " + context.targetType());
+	}
+
+}

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/conversion/FallbackStringToObjectConverter.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/conversion/FallbackStringToObjectConverter.java
@@ -30,7 +30,7 @@ import org.jspecify.annotations.Nullable;
 import org.junit.platform.commons.util.Preconditions;
 
 /**
- * {@code FallbackStringToObjectConverter} is a {@link StringToObjectConverter}
+ * {@code FallbackStringToObjectConverter} is a {@link StringToTargetTypeConverter}
  * that provides a fallback conversion strategy for converting from a
  * {@link String} to a given target type by invoking a static factory method
  * or factory constructor defined in the target type.
@@ -57,7 +57,7 @@ import org.junit.platform.commons.util.Preconditions;
  * @since 1.11
  * @see ConversionSupport
  */
-class FallbackStringToObjectConverter implements StringToObjectConverter {
+class FallbackStringToObjectConverter extends StringToTargetTypeConverter<@Nullable Object> {
 
 	/**
 	 * Implementation of the NULL Object Pattern.
@@ -76,12 +76,13 @@ class FallbackStringToObjectConverter implements StringToObjectConverter {
 		= new ConcurrentHashMap<>(64);
 
 	@Override
-	public boolean canConvertTo(Class<?> targetType) {
+	boolean canConvert(Class<?> targetType) {
 		return findFactoryExecutable(targetType) != NULL_EXECUTABLE;
 	}
 
 	@Override
-	public @Nullable Object convert(String source, Class<?> targetType) throws Exception {
+	@Nullable
+	Object convert(String source, Class<?> targetType) {
 		Function<String, @Nullable Object> executable = findFactoryExecutable(targetType);
 		Preconditions.condition(executable != NULL_EXECUTABLE,
 			"Illegal state: convert() must not be called if canConvert() returned false");

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/conversion/SimpleConverter.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/conversion/SimpleConverter.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2015-2025 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.commons.support.conversion;
+
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+
+import org.apiguardian.api.API;
+import org.jspecify.annotations.Nullable;
+import org.junit.platform.commons.util.Preconditions;
+
+/**
+ * {@code SimpleConverter} is an abstract base class for {@link Converter}
+ * implementations that always convert objects of a given source type into a
+ * given target type.
+ *
+ * @param <S> the type of the source argument to convert
+ * @param <T> the type of the target object to create from the source
+ * @since 6.0
+ */
+@API(status = EXPERIMENTAL, since = "6.0")
+public abstract class SimpleConverter<S, T extends @Nullable Object> implements Converter<S, T> {
+
+	private final Class<S> sourceType;
+	private final Class<T> targetType;
+
+	/**
+	 * Create a new {@code SimpleConverter}.
+	 *
+	 * @param sourceType the type of the argument to convert; never {@code null}
+	 * @param targetType the type of the target object to create from the source;
+	 * never {@code null}
+	 */
+	protected SimpleConverter(Class<S> sourceType, Class<T> targetType) {
+		this.sourceType = Preconditions.notNull(sourceType, "sourceType must not be null");
+		this.targetType = Preconditions.notNull(targetType, "targetType must not be null");
+	}
+
+	@Override
+	public final boolean canConvert(ConversionContext context) {
+		// FIXME adjust for subtypes
+		return !context.sourceType().equals(TypeDescriptor.NONE) //
+				&& this.sourceType == context.sourceType().getType() //
+				&& this.targetType == context.targetType().getType();
+	}
+
+	@Override
+	public final T convert(@Nullable S source, ConversionContext context) {
+		Preconditions.notNull(source, "source cannot be null");
+		return convert(source);
+	}
+
+	/**
+	 * Convert the supplied {@code source} object of type {@code S} into an object
+	 * of type {@code T}.
+	 *
+	 * @param source the source object to convert; never {@code null}
+	 * @return the converted object; may be {@code null} but only if the target
+	 * type is a reference type
+	 * @throws ConversionException if an error occurs during the conversion
+	 */
+	protected abstract T convert(S source) throws ConversionException;
+
+}

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/conversion/StringToBooleanConverter.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/conversion/StringToBooleanConverter.java
@@ -12,15 +12,15 @@ package org.junit.platform.commons.support.conversion;
 
 import org.junit.platform.commons.util.Preconditions;
 
-class StringToBooleanConverter implements StringToObjectConverter {
+class StringToBooleanConverter extends StringToWrapperTypeConverter<Boolean> {
 
 	@Override
-	public boolean canConvertTo(Class<?> targetType) {
+	boolean canConvert(Class<?> targetType) {
 		return targetType == Boolean.class;
 	}
 
 	@Override
-	public Object convert(String source, Class<?> targetType) {
+	Boolean convert(String source, Class<?> targetType) throws ConversionException {
 		boolean isTrue = "true".equalsIgnoreCase(source);
 		Preconditions.condition(isTrue || "false".equalsIgnoreCase(source),
 			() -> "String must be 'true' or 'false' (ignoring case): " + source);

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/conversion/StringToCharacterConverter.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/conversion/StringToCharacterConverter.java
@@ -12,15 +12,15 @@ package org.junit.platform.commons.support.conversion;
 
 import org.junit.platform.commons.util.Preconditions;
 
-class StringToCharacterConverter implements StringToObjectConverter {
+class StringToCharacterConverter extends StringToWrapperTypeConverter<Character> {
 
 	@Override
-	public boolean canConvertTo(Class<?> targetType) {
+	boolean canConvert(Class<?> targetType) {
 		return targetType == Character.class;
 	}
 
 	@Override
-	public Object convert(String source, Class<?> targetType) {
+	Character convert(String source, Class<?> targetType) throws ConversionException {
 		Preconditions.condition(source.length() == 1, () -> "String must have length of 1: " + source);
 		return source.charAt(0);
 	}

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/conversion/StringToClassConverter.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/conversion/StringToClassConverter.java
@@ -12,24 +12,21 @@ package org.junit.platform.commons.support.conversion;
 
 import org.jspecify.annotations.Nullable;
 import org.junit.platform.commons.support.ReflectionSupport;
+import org.junit.platform.commons.util.Preconditions;
 
-class StringToClassConverter implements StringToObjectConverter {
+class StringToClassConverter implements Converter<String, Class<?>> {
 
 	@Override
-	public boolean canConvertTo(Class<?> targetType) {
-		return targetType == Class.class;
+	public boolean canConvert(ConversionContext context) {
+		return !context.sourceType().equals(TypeDescriptor.NONE) && context.targetType().getType() == Class.class;
 	}
 
 	@Override
-	public Object convert(String source, Class<?> targetType) throws Exception {
-		throw new UnsupportedOperationException("Invoke convert(String, Class<?>, ClassLoader) instead");
-	}
-
-	@Override
-	public @Nullable Object convert(String className, Class<?> targetType, ClassLoader classLoader) throws Exception {
+	public Class<?> convert(@Nullable String className, ConversionContext context) {
+		Preconditions.notNull(className, "className cannot be null");
 		// @formatter:off
-		return ReflectionSupport.tryToLoadClass(className, classLoader)
-				.getOrThrow(cause -> new ConversionException(
+		return ReflectionSupport.tryToLoadClass(className, context.classLoader())
+				.getNonNullOrThrow(cause -> new ConversionException(
 						"Failed to convert String \"" + className + "\" to type java.lang.Class", cause));
 		// @formatter:on
 	}

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/conversion/StringToCommonJavaTypesConverter.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/conversion/StringToCommonJavaTypesConverter.java
@@ -25,7 +25,7 @@ import java.util.function.Function;
 
 import org.junit.platform.commons.util.Preconditions;
 
-class StringToCommonJavaTypesConverter implements StringToObjectConverter {
+class StringToCommonJavaTypesConverter extends StringToTargetTypeConverter<Object> {
 
 	private static final Map<Class<?>, Function<String, ?>> CONVERTERS = Map.of( //
 		// java.io and java.nio
@@ -42,12 +42,12 @@ class StringToCommonJavaTypesConverter implements StringToObjectConverter {
 	);
 
 	@Override
-	public boolean canConvertTo(Class<?> targetType) {
+	boolean canConvert(Class<?> targetType) {
 		return CONVERTERS.containsKey(targetType);
 	}
 
 	@Override
-	public Object convert(String source, Class<?> targetType) throws Exception {
+	Object convert(String source, Class<?> targetType) {
 		Function<String, ?> converter = Preconditions.notNull(CONVERTERS.get(targetType),
 			() -> "No registered converter for %s".formatted(targetType.getName()));
 		return converter.apply(source);

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/conversion/StringToEnumConverter.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/conversion/StringToEnumConverter.java
@@ -10,16 +10,17 @@
 
 package org.junit.platform.commons.support.conversion;
 
-class StringToEnumConverter implements StringToObjectConverter {
+@SuppressWarnings("rawtypes")
+class StringToEnumConverter extends StringToTargetTypeConverter<Enum> {
 
 	@Override
-	public boolean canConvertTo(Class<?> targetType) {
+	boolean canConvert(Class<?> targetType) {
 		return targetType.isEnum();
 	}
 
+	@SuppressWarnings("unchecked")
 	@Override
-	@SuppressWarnings({ "unchecked", "rawtypes" })
-	public Object convert(String source, Class targetType) throws Exception {
+	Enum convert(String source, Class targetType) throws ConversionException {
 		return Enum.valueOf(targetType, source);
 	}
 

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/conversion/StringToJavaTimeConverter.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/conversion/StringToJavaTimeConverter.java
@@ -31,7 +31,7 @@ import java.util.function.Function;
 
 import org.junit.platform.commons.util.Preconditions;
 
-class StringToJavaTimeConverter implements StringToObjectConverter {
+class StringToJavaTimeConverter extends StringToTargetTypeConverter<Object> {
 
 	private static final Map<Class<?>, Function<String, ?>> CONVERTERS = Map.ofEntries( //
 		entry(Duration.class, Duration::parse), //
@@ -51,12 +51,12 @@ class StringToJavaTimeConverter implements StringToObjectConverter {
 	);
 
 	@Override
-	public boolean canConvertTo(Class<?> targetType) {
+	boolean canConvert(Class<?> targetType) {
 		return CONVERTERS.containsKey(targetType);
 	}
 
 	@Override
-	public Object convert(String source, Class<?> targetType) throws Exception {
+	Object convert(String source, Class<?> targetType) throws ConversionException {
 		Function<String, ?> converter = Preconditions.notNull(CONVERTERS.get(targetType),
 			() -> "No registered converter for %s".formatted(targetType.getName()));
 		return converter.apply(source);

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/conversion/StringToNumberConverter.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/conversion/StringToNumberConverter.java
@@ -17,9 +17,9 @@ import java.util.function.Function;
 
 import org.junit.platform.commons.util.Preconditions;
 
-class StringToNumberConverter implements StringToObjectConverter {
+class StringToNumberConverter extends StringToWrapperTypeConverter<Number> {
 
-	private static final Map<Class<?>, Function<String, ?>> CONVERTERS = Map.of( //
+	private static final Map<Class<? extends Number>, Function<String, ? extends Number>> CONVERTERS = Map.of( //
 		Byte.class, Byte::decode, //
 		Short.class, Short::decode, //
 		Integer.class, Integer::decode, //
@@ -34,13 +34,13 @@ class StringToNumberConverter implements StringToObjectConverter {
 	);
 
 	@Override
-	public boolean canConvertTo(Class<?> targetType) {
+	boolean canConvert(Class<?> targetType) {
 		return CONVERTERS.containsKey(targetType);
 	}
 
 	@Override
-	public Object convert(String source, Class<?> targetType) {
-		Function<String, ?> converter = Preconditions.notNull(CONVERTERS.get(targetType),
+	Number convert(String source, Class<?> targetType) throws ConversionException {
+		Function<String, ? extends Number> converter = Preconditions.notNull(CONVERTERS.get(targetType),
 			() -> "No registered converter for %s".formatted(targetType.getName()));
 		return converter.apply(source.replace("_", ""));
 	}

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/conversion/StringToTargetTypeConverter.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/conversion/StringToTargetTypeConverter.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2015-2025 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.commons.support.conversion;
+
+import org.jspecify.annotations.Nullable;
+import org.junit.platform.commons.util.Preconditions;
+
+/**
+ * Internal API for converting arguments of type {@link String} to a specified
+ * target type.
+ */
+abstract class StringToTargetTypeConverter<T extends @Nullable Object> implements Converter<String, T> {
+
+	@Override
+	public final boolean canConvert(ConversionContext context) {
+		return !context.sourceType().equals(TypeDescriptor.NONE) && canConvert(context.targetType().getType());
+	}
+
+	/**
+	 * Determine if this converter can convert from a {@link String} to the
+	 * supplied target type.
+	 */
+	abstract boolean canConvert(Class<?> targetType);
+
+	@Override
+	public final T convert(@Nullable String source, ConversionContext context) {
+		Preconditions.notNull(source, "source cannot be null");
+		return convert(source, context.targetType().getType());
+	}
+
+	/**
+	 * Convert the supplied {@link String} to the supplied target type.
+	 *
+	 * <p>This method will only be invoked if {@link #canConvert(Class)}
+	 * returns {@code true} for the same target type.
+	 */
+	abstract T convert(String source, Class<?> targetType);
+
+}

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/conversion/TypeDescriptor.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/conversion/TypeDescriptor.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2015-2025 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.commons.support.conversion;
+
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Parameter;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.apiguardian.api.API;
+import org.jspecify.annotations.Nullable;
+import org.junit.platform.commons.util.Preconditions;
+import org.junit.platform.commons.util.ReflectionUtils;
+
+/**
+ *
+ *
+ * @since 6.0
+ */
+@API(status = EXPERIMENTAL, since = "6.0")
+public final class TypeDescriptor {
+
+	/**
+	 * {@code TypeDescriptor} returned when no value is available.
+	 */
+	public static final TypeDescriptor NONE = new TypeDescriptor(null);
+
+	private final @Nullable Class<?> type;
+
+	public static TypeDescriptor forClass(Class<?> clazz) {
+		Preconditions.notNull(clazz, () -> "clazz must not be null");
+		return new TypeDescriptor(clazz);
+	}
+
+	public static TypeDescriptor forInstance(@Nullable Object instance) {
+		return instance != null ? forClass(instance.getClass()) : NONE;
+	}
+
+	public static TypeDescriptor forField(Field field) {
+		Preconditions.notNull(field, "field must not be null");
+		return forClass(field.getType());
+	}
+
+	public static TypeDescriptor forParameter(Parameter parameter) {
+		Preconditions.notNull(parameter, "parameter must not be null");
+		return forClass(parameter.getType());
+	}
+
+	private TypeDescriptor(@Nullable Class<?> type) {
+		this.type = type;
+	}
+
+	public Class<?> getType() {
+		if (type == null) {
+			throw new NoSuchElementException("No type present");
+		}
+		return type;
+	}
+
+	/**
+	 * Get the wrapper type of this type descriptor, if available.
+	 *
+	 * <p>If this type descriptor represents a primitive type, this method
+	 * returns the corresponding wrapped type. Otherwise, this method returns
+	 * {@link Optional#empty() empty()}.
+	 *
+	 * @return an {@code Optional} containing the wrapper type; never
+	 * {@code null} but potentially empty
+	 */
+	// FIXME [NullAway] parameter type of referenced method is @NonNull, but parameter in functional interface method java.util.function.Function.apply(T) is @Nullable
+	@SuppressWarnings("NullAway")
+	public Optional<Class<?>> getWrapperType() {
+		return Optional.ofNullable(type).map(ReflectionUtils::getWrapperType);
+	}
+
+	public boolean isPrimitive() {
+		return type != null && type.isPrimitive();
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		TypeDescriptor that = (TypeDescriptor) o;
+		return Objects.equals(this.type, that.type);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hashCode(type);
+	}
+
+	@Override
+	public String toString() {
+		return type != null ? type.getName() : "'null'";
+	}
+
+}

--- a/jupiter-tests/src/test/java/org/junit/jupiter/params/converter/LocaleConverter.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/params/converter/LocaleConverter.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2015-2025 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.params.converter;
+
+import java.util.Locale;
+
+import org.junit.platform.commons.support.conversion.SimpleConverter;
+
+// FIXME move to ConversionSupportIntegrationTests
+public class LocaleConverter extends SimpleConverter<String, Locale> {
+
+	public LocaleConverter() {
+		super(String.class, Locale.class);
+	}
+
+	@Override
+	protected Locale convert(String source) {
+		return Locale.forLanguageTag(source);
+	}
+
+}

--- a/jupiter-tests/src/test/resources/META-INF/services/org.junit.platform.commons.support.conversion.Converter
+++ b/jupiter-tests/src/test/resources/META-INF/services/org.junit.platform.commons.support.conversion.Converter
@@ -1,0 +1,1 @@
+org.junit.jupiter.params.converter.LocaleConverter

--- a/platform-tests/src/test/java/org/junit/platform/commons/support/conversion/FallbackStringToObjectConverterTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/support/conversion/FallbackStringToObjectConverterTests.java
@@ -123,13 +123,13 @@ class FallbackStringToObjectConverterTests {
 	@Test
 	@DisplayName("Cannot convert String to Diary because Diary has neither a static factory method nor a factory constructor")
 	void cannotConvertStringToDiary() {
-		assertThat(converter.canConvertTo(Diary.class)).isFalse();
+		assertThat(converter.canConvert(Diary.class)).isFalse();
 	}
 
 	@Test
 	@DisplayName("Cannot convert String to Magazine because Magazine has multiple static factory methods")
 	void cannotConvertStringToMagazine() {
-		assertThat(converter.canConvertTo(Magazine.class)).isFalse();
+		assertThat(converter.canConvert(Magazine.class)).isFalse();
 	}
 
 	// -------------------------------------------------------------------------
@@ -160,7 +160,7 @@ class FallbackStringToObjectConverterTests {
 	}
 
 	private static void assertConverts(String input, Class<?> targetType, Object expectedOutput) throws Exception {
-		assertCanConvertTo(targetType);
+		assertCanConvert(targetType);
 
 		var result = converter.convert(input, targetType);
 
@@ -171,7 +171,7 @@ class FallbackStringToObjectConverterTests {
 
 	private static void assertConvertsRecord1(String input, Record1 expected) throws Exception {
 		Class<?> targetType = Record1.class;
-		assertCanConvertTo(targetType);
+		assertCanConvert(targetType);
 
 		Record1 result = (Record1) converter.convert(input, targetType);
 
@@ -181,15 +181,15 @@ class FallbackStringToObjectConverterTests {
 
 	private static void assertConvertsRecord2(String input, Record2 expected) throws Exception {
 		Class<?> targetType = Record2.class;
-		assertCanConvertTo(targetType);
+		assertCanConvert(targetType);
 
 		var result = converter.convert(input, targetType);
 
 		assertThat(result).isEqualTo(expected);
 	}
 
-	private static void assertCanConvertTo(Class<?> targetType) {
-		assertThat(converter.canConvertTo(targetType)).as("canConvertTo(%s)", targetType.getSimpleName()).isTrue();
+	private static void assertCanConvert(Class<?> targetType) {
+		assertThat(converter.canConvert(targetType)).as("canConvertTo(%s)", targetType.getSimpleName()).isTrue();
 	}
 
 	static class Book {

--- a/platform-tests/src/test/java/org/junit/platform/commons/support/conversion/TypeDescriptorTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/support/conversion/TypeDescriptorTests.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2015-2025 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.commons.support.conversion;
+
+import static org.junit.jupiter.api.EqualsAndHashCodeAssertions.assertEqualsAndHashCode;
+
+import org.junit.jupiter.api.Test;
+
+class TypeDescriptorTests {
+
+	@Test
+	void equalsAndHashCode() {
+		var typeDescriptor1 = TypeDescriptor.forClass(String.class);
+		var typeDescriptor2 = TypeDescriptor.forClass(String.class);
+		var typeDescriptor3 = TypeDescriptor.forClass(Object.class);
+
+		assertEqualsAndHashCode(typeDescriptor1, typeDescriptor2, typeDescriptor3);
+	}
+
+}

--- a/platform-tooling-support-tests/projects/jar-describe-module/junit-platform-commons.expected.txt
+++ b/platform-tooling-support-tests/projects/jar-describe-module/junit-platform-commons.expected.txt
@@ -13,6 +13,7 @@ requires kotlin.stdlib static
 requires kotlinx.coroutines.core static
 requires org.apiguardian.api static transitive
 requires org.jspecify static transitive
+uses org.junit.platform.commons.support.conversion.Converter
 uses org.junit.platform.commons.support.scanning.ClasspathScanner
 qualified exports org.junit.platform.commons.logging to org.junit.jupiter.api org.junit.jupiter.engine org.junit.jupiter.migrationsupport org.junit.jupiter.params org.junit.platform.console org.junit.platform.engine org.junit.platform.launcher org.junit.platform.reporting org.junit.platform.suite.api org.junit.platform.suite.engine org.junit.platform.testkit org.junit.vintage.engine
 qualified exports org.junit.platform.commons.util to org.junit.jupiter.api org.junit.jupiter.engine org.junit.jupiter.migrationsupport org.junit.jupiter.params org.junit.platform.console org.junit.platform.engine org.junit.platform.launcher org.junit.platform.reporting org.junit.platform.suite.api org.junit.platform.suite.engine org.junit.platform.testkit org.junit.vintage.engine


### PR DESCRIPTION
## Overview

* Resolves #853
* Relates to #2702
* Relates to #3605
* Relates to #4514

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
