### PR TITLE
Avoid discovery errors for inner classes not annotated with `@Nested`

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.13.2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.13.2.adoc
@@ -35,7 +35,8 @@ on GitHub.
 [[release-notes-5.13.2-junit-jupiter-bug-fixes]]
 ==== Bug Fixes
 
-* ❓
+* Stop reporting discovery issues for cyclic inner class hierarchies not annotated with
+  `@Nested`.
 
 [[release-notes-5.13.2-junit-jupiter-deprecations-and-breaking-changes]]
 ==== Deprecations and Breaking Changes

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/predicates/TestClassPredicates.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/predicates/TestClassPredicates.java
@@ -28,6 +28,7 @@ import org.apiguardian.api.API;
 import org.junit.jupiter.api.ClassTemplate;
 import org.junit.jupiter.api.Nested;
 import org.junit.platform.commons.util.ReflectionUtils;
+import org.junit.platform.commons.util.ReflectionUtils.CycleErrorHandling;
 import org.junit.platform.engine.DiscoveryIssue;
 import org.junit.platform.engine.support.descriptor.ClassSource;
 import org.junit.platform.engine.support.discovery.DiscoveryIssueReporter;
@@ -94,14 +95,16 @@ public class TestClassPredicates {
 	}
 
 	private boolean hasNestedTests(Class<?> candidate, Set<Class<?>> seen) {
+		var hasAnnotatedClass = isNestedClassPresent(candidate, this.isAnnotatedWithNested,
+			CycleErrorHandling.THROW_EXCEPTION);
+		if (hasAnnotatedClass) {
+			return true;
+		}
 		return isNestedClassPresent( //
 			candidate, //
-			isNotSame(candidate).and(
-				this.isAnnotatedWithNested.or(it -> isInnerClass(it) && looksLikeIntendedTestClass(it, seen))));
-	}
-
-	private static Predicate<Class<?>> isNotSame(Class<?> candidate) {
-		return clazz -> candidate != clazz;
+			it -> isInnerClass(it) && looksLikeIntendedTestClass(it, seen), //
+			CycleErrorHandling.ABORT_VISIT //
+		);
 	}
 
 	private static Condition<Class<?>> isNotPrivateUnlessAbstract(String prefix, DiscoveryIssueReporter issueReporter) {

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/discovery/DiscoveryTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/discovery/DiscoveryTests.java
@@ -289,6 +289,13 @@ class DiscoveryTests extends AbstractJupiterTestEngineTests {
 	}
 
 	@Test
+	void ignoresUnrelatedClassDefinitionCycles() {
+		var results = discoverTestsForClass(UnrelatedRecursiveHierarchyTestCase.class);
+
+		assertThat(results.getDiscoveryIssues()).isEmpty();
+	}
+
+	@Test
 	void reportsWarningsForInvalidTags() throws NoSuchMethodException {
 
 		var results = discoverTestsForClass(InvalidTagsTestCase.class);
@@ -439,6 +446,20 @@ class DiscoveryTests extends AbstractJupiterTestEngineTests {
 		private class InvalidTestClassSubclassTestCase extends InvalidTestClassTestCase {
 		}
 
+	}
+
+	@SuppressWarnings("JUnitMalformedDeclaration")
+	static class UnrelatedRecursiveHierarchyTestCase {
+
+		@Test
+		void test() {
+		}
+
+		@SuppressWarnings({ "InnerClassMayBeStatic", "unused" })
+		class Inner {
+			class Recursive extends Inner {
+			}
+		}
 	}
 
 	@SuppressWarnings("JUnitMalformedDeclaration")

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/discovery/predicates/TestClassPredicatesTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/discovery/predicates/TestClassPredicatesTests.java
@@ -11,7 +11,6 @@
 package org.junit.jupiter.engine.discovery.predicates;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -24,7 +23,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
 import org.junit.jupiter.api.TestTemplate;
-import org.junit.platform.commons.JUnitException;
 import org.junit.platform.engine.DiscoveryIssue;
 import org.junit.platform.engine.DiscoveryIssue.Severity;
 import org.junit.platform.engine.support.descriptor.ClassSource;
@@ -218,11 +216,7 @@ public class TestClassPredicatesTests {
 		 */
 		@Test
 		void recursiveHierarchies() {
-			assertThatExceptionOfType(JUnitException.class)//
-					.isThrownBy(() -> predicates.looksLikeIntendedTestClass(TestCases.OuterClass.class))//
-					.withMessage("Detected cycle in inner class hierarchy between %s and %s",
-						TestCases.OuterClass.RecursiveInnerClass.class.getName(), TestCases.OuterClass.class.getName());
-
+			assertTrue(predicates.looksLikeIntendedTestClass(TestCases.OuterClass.class));
 			assertTrue(predicates.isValidStandaloneTestClass(TestCases.OuterClass.class));
 			assertThat(discoveryIssues).isEmpty();
 

--- a/platform-tests/src/test/java/org/junit/platform/commons/util/ReflectionUtilsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/util/ReflectionUtilsTests.java
@@ -71,6 +71,7 @@ import org.junit.platform.commons.PreconditionViolationException;
 import org.junit.platform.commons.logging.LogRecordListener;
 import org.junit.platform.commons.support.Resource;
 import org.junit.platform.commons.test.TestClassLoader;
+import org.junit.platform.commons.util.ReflectionUtils.CycleErrorHandling;
 import org.junit.platform.commons.util.ReflectionUtilsTests.NestedClassTests.ClassWithNestedClasses.Nested1;
 import org.junit.platform.commons.util.ReflectionUtilsTests.NestedClassTests.ClassWithNestedClasses.Nested2;
 import org.junit.platform.commons.util.ReflectionUtilsTests.NestedClassTests.ClassWithNestedClasses.Nested3;
@@ -1054,9 +1055,10 @@ class ReflectionUtilsTests {
 		@Test
 		void isNestedClassPresentPreconditions() {
 			// @formatter:off
-			assertThrows(PreconditionViolationException.class, () -> ReflectionUtils.isNestedClassPresent(null, null));
-			assertThrows(PreconditionViolationException.class, () -> ReflectionUtils.isNestedClassPresent(null, clazz -> true));
-			assertThrows(PreconditionViolationException.class, () -> ReflectionUtils.isNestedClassPresent(getClass(), null));
+			assertThrows(PreconditionViolationException.class, () -> ReflectionUtils.isNestedClassPresent(null, null, null));
+			assertThrows(PreconditionViolationException.class, () -> ReflectionUtils.isNestedClassPresent(null, clazz -> true, CycleErrorHandling.THROW_EXCEPTION));
+			assertThrows(PreconditionViolationException.class, () -> ReflectionUtils.isNestedClassPresent(getClass(), null, CycleErrorHandling.ABORT_VISIT));
+			assertThrows(PreconditionViolationException.class, () -> ReflectionUtils.isNestedClassPresent(getClass(), clazz -> true, null));
 			// @formatter:on
 		}
 
@@ -1073,12 +1075,12 @@ class ReflectionUtilsTests {
 
 			assertThat(ReflectionUtils.findNestedClasses(ClassWithNestedClasses.class, clazz -> clazz.getName().contains("1")))
 					.containsExactly(Nested1.class);
-			assertThat(ReflectionUtils.isNestedClassPresent(ClassWithNestedClasses.class, clazz -> clazz.getName().contains("1")))
+			assertThat(ReflectionUtils.isNestedClassPresent(ClassWithNestedClasses.class, clazz -> clazz.getName().contains("1"), CycleErrorHandling.THROW_EXCEPTION))
 					.isTrue();
 
 			assertThat(ReflectionUtils.findNestedClasses(ClassWithNestedClasses.class, ReflectionUtils::isStatic))
 					.containsExactly(Nested3.class);
-			assertThat(ReflectionUtils.isNestedClassPresent(ClassWithNestedClasses.class, ReflectionUtils::isStatic))
+			assertThat(ReflectionUtils.isNestedClassPresent(ClassWithNestedClasses.class, ReflectionUtils::isStatic, CycleErrorHandling.THROW_EXCEPTION))
 					.isTrue();
 
 			assertThat(findNestedClasses(ClassExtendingClassWithNestedClasses.class))
@@ -1105,12 +1107,14 @@ class ReflectionUtilsTests {
 			// predicate should prevent cycle detection.
 			// See https://github.com/junit-team/junit5/issues/2249
 			assertThat(ReflectionUtils.findNestedClasses(OuterClass.class, clazz -> false)).isEmpty();
-			assertThat(ReflectionUtils.isNestedClassPresent(OuterClass.class, clazz -> false)).isFalse();
+			assertThat(ReflectionUtils.isNestedClassPresent(OuterClass.class, clazz -> false,
+				CycleErrorHandling.THROW_EXCEPTION)).isFalse();
 
 			// RecursiveInnerInnerClass is part of a recursive hierarchy, but the non-matching
 			// predicate should prevent cycle detection.
 			assertThat(ReflectionUtils.findNestedClasses(RecursiveInnerInnerClass.class, clazz -> false)).isEmpty();
-			assertThat(ReflectionUtils.isNestedClassPresent(RecursiveInnerInnerClass.class, clazz -> false)).isFalse();
+			assertThat(ReflectionUtils.isNestedClassPresent(RecursiveInnerInnerClass.class, clazz -> false,
+				CycleErrorHandling.THROW_EXCEPTION)).isFalse();
 
 			// Sibling types don't actually result in cycles.
 			assertThat(findNestedClasses(StaticNestedSiblingClass.class))//
@@ -1153,7 +1157,7 @@ class ReflectionUtilsTests {
 		}
 
 		private static boolean isNestedClassPresent(Class<?> clazz) {
-			return ReflectionUtils.isNestedClassPresent(clazz, c -> true);
+			return ReflectionUtils.isNestedClassPresent(clazz, c -> true, CycleErrorHandling.THROW_EXCEPTION);
 		}
 
 		private void assertNestedCycle(Class<?> from, Class<?> to) {


### PR DESCRIPTION
## Overview

- **Fix `StackOverflowError`**
- **Avoid discovery errors for inner classes not annotated with `@Nested`**

Resolves #4661.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://docs.junit.org/snapshot/user-guide/) and [Release Notes](https://docs.junit.org/snapshot/user-guide/#release-notes)
