### PR TITLE
Avoid reporting discovery warnings for abstract inner classes with tests

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.13.2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.13.2.adoc
@@ -37,6 +37,8 @@ repository on GitHub.
 
 * Stop reporting discovery issues for cyclic inner class hierarchies not annotated with
   `@Nested`.
+* Stop reporting discovery issues for _abstract_ inner classes that contain test methods
+  but are not annotated with `@Nested`.
 
 [[release-notes-5.13.2-junit-jupiter-deprecations-and-breaking-changes]]
 ==== Deprecations and Breaking Changes

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/ClassSelectorResolver.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/ClassSelectorResolver.java
@@ -19,6 +19,7 @@ import static org.junit.platform.commons.support.HierarchyTraversalMode.TOP_DOWN
 import static org.junit.platform.commons.support.ReflectionSupport.findMethods;
 import static org.junit.platform.commons.util.FunctionUtils.where;
 import static org.junit.platform.commons.util.ReflectionUtils.isInnerClass;
+import static org.junit.platform.commons.util.ReflectionUtils.isNotAbstract;
 import static org.junit.platform.commons.util.ReflectionUtils.streamNestedClasses;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectUniqueId;
 import static org.junit.platform.engine.support.discovery.SelectorResolver.Resolution.unresolved;
@@ -113,7 +114,8 @@ class ClassSelectorResolver implements SelectorResolver {
 					parent -> Optional.of(newMemberClassTestDescriptor(parent, nestedClass))));
 			}
 		}
-		else if (isInnerClass(nestedClass) && predicates.looksLikeIntendedTestClass(nestedClass)) {
+		else if (isInnerClass(nestedClass) && isNotAbstract(nestedClass)
+				&& predicates.looksLikeIntendedTestClass(nestedClass)) {
 			String message = "Inner class '%s' looks like it was intended to be a test class but will not be executed. It must be static or annotated with @Nested.".formatted(
 				nestedClass.getName());
 			issueReporter.reportIssue(DiscoveryIssue.builder(Severity.WARNING, message) //

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/NestedTestClassesTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/NestedTestClassesTests.java
@@ -230,6 +230,13 @@ class NestedTestClassesTests extends AbstractJupiterTestEngineTests {
 		executionResults.testEvents().assertStatistics(stats -> stats.started(1).succeeded(1));
 	}
 
+	@Test
+	void doesNotReportDiscoveryIssueForAbstractInnerClass() {
+		var discoveryIssues = discoverTestsForClass(ConcreteWithExtendedInnerClassTestCase.class).getDiscoveryIssues();
+
+		assertThat(discoveryIssues).isEmpty();
+	}
+
 	private void assertNestedCycle(Class<?> start, Class<?> from, Class<?> to) {
 		var results = executeTestsForClass(start);
 		var expectedMessage = "Cause: org.junit.platform.commons.JUnitException: Detected cycle in inner class hierarchy between %s and %s".formatted(
@@ -417,6 +424,21 @@ class NestedTestClassesTests extends AbstractJupiterTestEngineTests {
 				void nested() {
 				}
 			}
+		}
+	}
+
+	static class AbstractBaseWithInnerClassTestCase {
+		@SuppressWarnings("InnerClassMayBeStatic")
+		abstract class AbstractInnerClass {
+			@Test
+			void test() {
+			}
+		}
+	}
+
+	static class ConcreteWithExtendedInnerClassTestCase extends AbstractBaseWithInnerClassTestCase {
+		@Nested
+		class NestedTests extends AbstractInnerClass {
 		}
 	}
 


### PR DESCRIPTION
## Overview

Resolves #4635.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://docs.junit.org/snapshot/user-guide/) and [Release Notes](https://docs.junit.org/snapshot/user-guide/#release-notes)
