### PR TITLE
Fix typo in TempDirFactory javadoc

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/io/TempDirFactory.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/io/TempDirFactory.java
@@ -73,7 +73,7 @@ public interface TempDirFactory extends Closeable {
 
 	/**
 	 * Standard {@link TempDirFactory} implementation which delegates to
-	 * {@link Files#createTempDirectory} using {@code "junit-,"} as prefix.
+	 * {@link Files#createTempDirectory} using {@code "junit-"} as prefix.
 	 *
 	 * <p>The created temporary directory is always created in the default
 	 * file system with the system's default temporary directory as its parent.


### PR DESCRIPTION
## Overview

Fix typo in `TempDirFactory` javadoc

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://docs.junit.org/snapshot/user-guide/) and [Release Notes](https://docs.junit.org/snapshot/user-guide/#release-notes)
