### PR TITLE
Promote experimental APIs to maintained for 5.13.x

### DIFF
--- a/documentation/src/docs/asciidoc/user-guide/api-evolution.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/api-evolution.adoc
@@ -40,7 +40,7 @@ value of lower stability.
 [[api-evolution-experimental-apis]]
 === Experimental APIs
 
-The following table lists which APIs are currently designated as _experimental_ via
+The following tables list which APIs are currently designated as _experimental_ via
 `@API(status = EXPERIMENTAL)`. Caution should be taken when relying on such APIs.
 
 include::{experimentalApisTableFile}[]
@@ -48,7 +48,7 @@ include::{experimentalApisTableFile}[]
 [[api-evolution-deprecated-apis]]
 === Deprecated APIs
 
-The following table lists which APIs are currently designated as _deprecated_ via
+The following tables list which APIs are currently designated as _deprecated_ via
 `@API(status = DEPRECATED)`. You should avoid using deprecated APIs whenever possible,
 since such APIs will likely be removed in an upcoming release.
 

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AutoClose.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AutoClose.java
@@ -10,7 +10,7 @@
 
 package org.junit.jupiter.api;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
@@ -78,7 +78,7 @@ import org.apiguardian.api.API;
 @Target({ ElementType.ANNOTATION_TYPE, ElementType.FIELD })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-@API(status = EXPERIMENTAL, since = "5.11")
+@API(status = MAINTAINED, since = "5.13.3")
 public @interface AutoClose {
 
 	/**

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/ClassTemplate.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/ClassTemplate.java
@@ -10,7 +10,7 @@
 
 package org.junit.jupiter.api;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
@@ -66,7 +66,7 @@ import org.junit.platform.commons.annotation.Testable;
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @Inherited
-@API(status = EXPERIMENTAL, since = "5.13")
+@API(status = MAINTAINED, since = "5.13.3")
 @Testable
 public @interface ClassTemplate {
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DisplayNameGenerator.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DisplayNameGenerator.java
@@ -12,7 +12,6 @@ package org.junit.jupiter.api;
 
 import static java.util.Collections.emptyList;
 import static org.apiguardian.api.API.Status.DEPRECATED;
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.INTERNAL;
 import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
@@ -333,7 +332,7 @@ public interface DisplayNameGenerator {
 		 */
 		@Target({ ElementType.TYPE, ElementType.METHOD })
 		@Retention(RetentionPolicy.RUNTIME)
-		@API(status = EXPERIMENTAL, since = "5.13")
+		@API(status = MAINTAINED, since = "5.13.3")
 		public @interface SentenceFragment {
 
 			/**

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DisplayNameGenerator.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DisplayNameGenerator.java
@@ -14,6 +14,7 @@ import static java.util.Collections.emptyList;
 import static org.apiguardian.api.API.Status.DEPRECATED;
 import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.INTERNAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
 import static org.junit.platform.commons.support.AnnotationSupport.findAnnotation;
 import static org.junit.platform.commons.support.ModifierSupport.isStatic;
@@ -128,7 +129,7 @@ public interface DisplayNameGenerator {
 	 * @return the display name for the nested class; never blank
 	 * @since 5.12
 	 */
-	@API(status = EXPERIMENTAL, since = "5.12")
+	@API(status = MAINTAINED, since = "5.13.3")
 	default String generateDisplayNameForNestedClass(List<Class<?>> enclosingInstanceTypes, Class<?> nestedClass) {
 		return generateDisplayNameForNestedClass(nestedClass);
 	}
@@ -177,7 +178,7 @@ public interface DisplayNameGenerator {
 	 * @return the display name for the test; never blank
 	 * @since 5.12
 	 */
-	@API(status = EXPERIMENTAL, since = "5.12")
+	@API(status = MAINTAINED, since = "5.13.3")
 	default String generateDisplayNameForMethod(List<Class<?>> enclosingInstanceTypes, Class<?> testClass,
 			Method testMethod) {
 		return generateDisplayNameForMethod(testClass, testMethod);

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DynamicTest.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DynamicTest.java
@@ -12,7 +12,6 @@ package org.junit.jupiter.api;
 
 import static java.util.Spliterator.ORDERED;
 import static java.util.Spliterators.spliteratorUnknownSize;
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import java.net.URI;
@@ -249,7 +248,7 @@ public class DynamicTest extends DynamicNode {
 	 * @see #stream(Stream)
 	 * @see NamedExecutable
 	 */
-	@API(status = EXPERIMENTAL, since = "5.11")
+	@API(status = MAINTAINED, since = "5.13.3")
 	public static <T extends Named<E>, E extends Executable> Stream<DynamicTest> stream(
 			Iterator<? extends T> iterator) {
 		Preconditions.notNull(iterator, "iterator must not be null");
@@ -279,7 +278,7 @@ public class DynamicTest extends DynamicNode {
 	 * @see #stream(Iterator)
 	 * @see NamedExecutable
 	 */
-	@API(status = EXPERIMENTAL, since = "5.11")
+	@API(status = MAINTAINED, since = "5.13.3")
 	public static <T extends Named<E>, E extends Executable> Stream<DynamicTest> stream(
 			Stream<? extends T> inputStream) {
 		Preconditions.notNull(inputStream, "inputStream must not be null");

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/NamedExecutable.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/NamedExecutable.java
@@ -10,7 +10,7 @@
 
 package org.junit.jupiter.api;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import java.util.Iterator;
 import java.util.stream.Stream;
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.function.Executable;
  * @see DynamicTest#stream(Iterator)
  */
 @FunctionalInterface
-@API(status = EXPERIMENTAL, since = "5.11")
+@API(status = MAINTAINED, since = "5.13.3")
 public interface NamedExecutable extends Named<Executable>, Executable {
 	@Override
 	default String getName() {

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/RepeatedTest.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/RepeatedTest.java
@@ -10,7 +10,7 @@
 
 package org.junit.jupiter.api;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.lang.annotation.Documented;
@@ -191,7 +191,7 @@ public @interface RepeatedTest {
 	 * @return the failure threshold; must be greater than zero and less than the
 	 * total number of repetitions
 	 */
-	@API(status = EXPERIMENTAL, since = "5.10")
+	@API(status = MAINTAINED, since = "5.13.3")
 	int failureThreshold() default Integer.MAX_VALUE;
 
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/RepetitionInfo.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/RepetitionInfo.java
@@ -10,7 +10,7 @@
 
 package org.junit.jupiter.api;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import org.apiguardian.api.API;
@@ -58,7 +58,7 @@ public interface RepetitionInfo {
 	 * @since 5.10
 	 * @see #getFailureThreshold()
 	 */
-	@API(status = EXPERIMENTAL, since = "5.10")
+	@API(status = MAINTAINED, since = "5.13.3")
 	int getFailureCount();
 
 	/**
@@ -68,7 +68,7 @@ public interface RepetitionInfo {
 	 * @since 5.10
 	 * @see RepeatedTest#failureThreshold()
 	 */
-	@API(status = EXPERIMENTAL, since = "5.10")
+	@API(status = MAINTAINED, since = "5.13.3")
 	int getFailureThreshold();
 
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/TestReporter.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/TestReporter.java
@@ -11,7 +11,7 @@
 package org.junit.jupiter.api;
 
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.io.IOException;
@@ -98,7 +98,7 @@ public interface TestReporter {
 	 * {@link MediaType#APPLICATION_OCTET_STREAM} if unknown
 	 * @since 5.12
 	 */
-	@API(status = EXPERIMENTAL, since = "5.12")
+	@API(status = MAINTAINED, since = "5.13.3")
 	default void publishFile(Path file, MediaType mediaType) {
 		Preconditions.condition(Files.exists(file), () -> "file must exist: " + file);
 		Preconditions.condition(Files.isRegularFile(file), () -> "file must be a regular file: " + file);
@@ -115,7 +115,7 @@ public interface TestReporter {
 	 * @param directory the file to be attached; never {@code null} or blank
 	 * @since 5.12
 	 */
-	@API(status = EXPERIMENTAL, since = "5.12")
+	@API(status = MAINTAINED, since = "5.13.3")
 	default void publishDirectory(Path directory) {
 		Preconditions.condition(Files.exists(directory), () -> "directory must exist: " + directory);
 		Preconditions.condition(Files.isDirectory(directory), () -> "directory must be a directory: " + directory);
@@ -153,7 +153,7 @@ public interface TestReporter {
 	 * @param action the action to be executed to write the file; never {@code null}
 	 * @since 5.12
 	 */
-	@API(status = EXPERIMENTAL, since = "5.12")
+	@API(status = MAINTAINED, since = "5.13.3")
 	default void publishFile(String name, MediaType mediaType, ThrowingConsumer<Path> action) {
 		throw new UnsupportedOperationException();
 	}
@@ -171,7 +171,7 @@ public interface TestReporter {
 	 * @param action the action to be executed to write the file; never {@code null}
 	 * @since 5.12
 	 */
-	@API(status = EXPERIMENTAL, since = "5.12")
+	@API(status = MAINTAINED, since = "5.13.3")
 	default void publishDirectory(String name, ThrowingConsumer<Path> action) {
 		throw new UnsupportedOperationException();
 	}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Timeout.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Timeout.java
@@ -10,7 +10,7 @@
 
 package org.junit.jupiter.api;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.lang.annotation.Documented;
@@ -329,7 +329,7 @@ public @interface Timeout {
 	 *
 	 * @since 5.9
 	 */
-	@API(status = EXPERIMENTAL, since = "5.9")
+	@API(status = MAINTAINED, since = "5.13.3")
 	String DEFAULT_TIMEOUT_THREAD_MODE_PROPERTY_NAME = "junit.jupiter.execution.timeout.thread.mode.default";
 
 	/**

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledForJreRange.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledForJreRange.java
@@ -10,7 +10,7 @@
 
 package org.junit.jupiter.api.condition;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.lang.annotation.Documented;
@@ -138,7 +138,7 @@ public @interface DisabledForJreRange {
 	 * @see JRE#version()
 	 * @see Runtime.Version#feature()
 	 */
-	@API(status = EXPERIMENTAL, since = "5.12")
+	@API(status = MAINTAINED, since = "5.13.3")
 	int minVersion() default -1;
 
 	/**
@@ -157,7 +157,7 @@ public @interface DisabledForJreRange {
 	 * @see JRE#version()
 	 * @see Runtime.Version#feature()
 	 */
-	@API(status = EXPERIMENTAL, since = "5.12")
+	@API(status = MAINTAINED, since = "5.13.3")
 	int maxVersion() default -1;
 
 	/**

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledOnJre.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledOnJre.java
@@ -10,7 +10,7 @@
 
 package org.junit.jupiter.api.condition;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.lang.annotation.Documented;
@@ -110,7 +110,7 @@ public @interface DisabledOnJre {
 	 * @see JRE#version()
 	 * @see Runtime.Version#feature()
 	 */
-	@API(status = EXPERIMENTAL, since = "5.12")
+	@API(status = MAINTAINED, since = "5.13.3")
 	int[] versions() default {};
 
 	/**

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledForJreRange.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledForJreRange.java
@@ -10,7 +10,7 @@
 
 package org.junit.jupiter.api.condition;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.lang.annotation.Documented;
@@ -138,7 +138,7 @@ public @interface EnabledForJreRange {
 	 * @see JRE#version()
 	 * @see Runtime.Version#feature()
 	 */
-	@API(status = EXPERIMENTAL, since = "5.12")
+	@API(status = MAINTAINED, since = "5.13.3")
 	int minVersion() default -1;
 
 	/**
@@ -157,7 +157,7 @@ public @interface EnabledForJreRange {
 	 * @see JRE#version()
 	 * @see Runtime.Version#feature()
 	 */
-	@API(status = EXPERIMENTAL, since = "5.12")
+	@API(status = MAINTAINED, since = "5.13.3")
 	int maxVersion() default -1;
 
 	/**

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledOnJre.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledOnJre.java
@@ -10,7 +10,7 @@
 
 package org.junit.jupiter.api.condition;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.lang.annotation.Documented;
@@ -110,7 +110,7 @@ public @interface EnabledOnJre {
 	 * @see JRE#version()
 	 * @see Runtime.Version#feature()
 	 */
-	@API(status = EXPERIMENTAL, since = "5.12")
+	@API(status = MAINTAINED, since = "5.13.3")
 	int[] versions() default {};
 
 	/**

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/AfterClassTemplateInvocationCallback.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/AfterClassTemplateInvocationCallback.java
@@ -10,7 +10,7 @@
 
 package org.junit.jupiter.api.extension;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import org.apiguardian.api.API;
 import org.junit.jupiter.api.ClassTemplate;
@@ -60,7 +60,7 @@ import org.junit.jupiter.api.ClassTemplate;
  * @see AfterTestExecutionCallback
  */
 @FunctionalInterface
-@API(status = EXPERIMENTAL, since = "5.13")
+@API(status = MAINTAINED, since = "5.13.3")
 public interface AfterClassTemplateInvocationCallback extends Extension {
 
 	/**

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/AnnotatedElementContext.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/AnnotatedElementContext.java
@@ -10,7 +10,7 @@
 
 package org.junit.jupiter.api.extension;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
@@ -33,7 +33,7 @@ import org.junit.platform.commons.support.AnnotationSupport;
  *
  * @since 5.10
  */
-@API(status = EXPERIMENTAL, since = "5.10")
+@API(status = MAINTAINED, since = "5.13.3")
 public interface AnnotatedElementContext {
 
 	/**

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/BeforeClassTemplateInvocationCallback.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/BeforeClassTemplateInvocationCallback.java
@@ -10,7 +10,7 @@
 
 package org.junit.jupiter.api.extension;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import org.apiguardian.api.API;
 import org.junit.jupiter.api.ClassTemplate;
@@ -60,7 +60,7 @@ import org.junit.jupiter.api.ClassTemplate;
  * @see AfterTestExecutionCallback
  */
 @FunctionalInterface
-@API(status = EXPERIMENTAL, since = "5.13")
+@API(status = MAINTAINED, since = "5.13.3")
 public interface BeforeClassTemplateInvocationCallback extends Extension {
 
 	/**

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ClassTemplateInvocationContext.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ClassTemplateInvocationContext.java
@@ -11,7 +11,7 @@
 package org.junit.jupiter.api.extension;
 
 import static java.util.Collections.emptyList;
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import java.util.List;
 
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.ClassTemplate;
  * @see ClassTemplate
  * @see ClassTemplateInvocationContextProvider
  */
-@API(status = EXPERIMENTAL, since = "5.13")
+@API(status = MAINTAINED, since = "5.13.3")
 public interface ClassTemplateInvocationContext {
 
 	/**

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ClassTemplateInvocationContextProvider.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ClassTemplateInvocationContextProvider.java
@@ -10,7 +10,7 @@
 
 package org.junit.jupiter.api.extension;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import java.util.stream.Stream;
 
@@ -58,7 +58,7 @@ import org.junit.jupiter.api.ClassTemplate;
  * @see ClassTemplate
  * @see ClassTemplateInvocationContext
  */
-@API(status = EXPERIMENTAL, since = "5.13")
+@API(status = MAINTAINED, since = "5.13.3")
 public interface ClassTemplateInvocationContextProvider extends Extension {
 
 	/**

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExtensionContext.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExtensionContext.java
@@ -14,6 +14,7 @@ import static java.util.Collections.unmodifiableList;
 import static org.apiguardian.api.API.Status.DEPRECATED;
 import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.INTERNAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.lang.reflect.AnnotatedElement;
@@ -156,7 +157,7 @@ public interface ExtensionContext {
 	 * @since 5.12.1
 	 * @see org.junit.platform.commons.support.AnnotationSupport#findAnnotation(Class, Class, List)
 	 */
-	@API(status = EXPERIMENTAL, since = "5.12.1")
+	@API(status = MAINTAINED, since = "5.13.3")
 	List<Class<?>> getEnclosingTestClasses();
 
 	/**
@@ -412,7 +413,7 @@ public interface ExtensionContext {
 	 * @since 5.12
 	 * @see org.junit.platform.engine.EngineExecutionListener#fileEntryPublished
 	 */
-	@API(status = EXPERIMENTAL, since = "5.12")
+	@API(status = MAINTAINED, since = "5.13.3")
 	void publishFile(String name, MediaType mediaType, ThrowingConsumer<Path> action);
 
 	/**
@@ -428,7 +429,7 @@ public interface ExtensionContext {
 	 * @since 5.12
 	 * @see org.junit.platform.engine.EngineExecutionListener#fileEntryPublished
 	 */
-	@API(status = EXPERIMENTAL, since = "5.12")
+	@API(status = MAINTAINED, since = "5.13.3")
 	void publishDirectory(String name, ThrowingConsumer<Path> action);
 
 	/**

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExtensionContext.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExtensionContext.java
@@ -12,7 +12,6 @@ package org.junit.jupiter.api.extension;
 
 import static java.util.Collections.unmodifiableList;
 import static org.apiguardian.api.API.Status.DEPRECATED;
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.INTERNAL;
 import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
@@ -465,7 +464,7 @@ public interface ExtensionContext {
 	 * @see StoreScope
 	 * @see #getStore(Namespace)
 	 */
-	@API(status = EXPERIMENTAL, since = "5.13")
+	@API(status = MAINTAINED, since = "5.13.3")
 	Store getStore(StoreScope scope, Namespace namespace);
 
 	/**
@@ -822,7 +821,7 @@ public interface ExtensionContext {
 	 * @since 5.13
 	 * @see #getStore(StoreScope, Namespace)
 	 */
-	@API(status = EXPERIMENTAL, since = "5.13")
+	@API(status = MAINTAINED, since = "5.13.3")
 	enum StoreScope {
 
 		/**

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExtensionContextException.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExtensionContextException.java
@@ -10,7 +10,7 @@
 
 package org.junit.jupiter.api.extension;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import org.apiguardian.api.API;
@@ -33,7 +33,7 @@ public class ExtensionContextException extends JUnitException {
 		super(message);
 	}
 
-	@API(status = EXPERIMENTAL, since = "5.10")
+	@API(status = MAINTAINED, since = "5.13.3")
 	public ExtensionContextException(String message, Throwable cause) {
 		super(message, cause);
 	}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/MediaType.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/MediaType.java
@@ -11,7 +11,7 @@
 package org.junit.jupiter.api.extension;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import java.nio.charset.Charset;
 import java.nio.file.Path;
@@ -34,7 +34,7 @@ import org.junit.platform.commons.util.Preconditions;
  * @see TestReporter#publishFile(String, MediaType, ThrowingConsumer)
  * @see ExtensionContext#publishFile(String, MediaType, ThrowingConsumer)
  */
-@API(status = EXPERIMENTAL, since = "5.12")
+@API(status = MAINTAINED, since = "5.13.3")
 public class MediaType {
 
 	private static final Pattern PATTERN;

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ParameterContext.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ParameterContext.java
@@ -10,7 +10,7 @@
 
 package org.junit.jupiter.api.extension;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.lang.annotation.Annotation;
@@ -94,7 +94,7 @@ public interface ParameterContext extends AnnotatedElementContext {
 	 * {@inheritDoc}
 	 * @since 5.10
 	 */
-	@API(status = EXPERIMENTAL, since = "5.10")
+	@API(status = MAINTAINED, since = "5.13.3")
 	@Override
 	default AnnotatedElement getAnnotatedElement() {
 		return getParameter();

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/PreInterruptCallback.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/PreInterruptCallback.java
@@ -10,7 +10,7 @@
 
 package org.junit.jupiter.api.extension;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import org.apiguardian.api.API;
 
@@ -28,7 +28,7 @@ import org.apiguardian.api.API;
  * @since 5.12
  * @see org.junit.jupiter.api.Timeout
  */
-@API(status = EXPERIMENTAL, since = "5.12")
+@API(status = MAINTAINED, since = "5.13.3")
 public interface PreInterruptCallback extends Extension {
 
 	/**
@@ -39,7 +39,7 @@ public interface PreInterruptCallback extends Extension {
 	 *
 	 * @since 5.12
 	 */
-	@API(status = EXPERIMENTAL, since = "5.12")
+	@API(status = MAINTAINED, since = "5.13.3")
 	String THREAD_DUMP_ENABLED_PROPERTY_NAME = "junit.jupiter.execution.timeout.threaddump.enabled";
 
 	/**
@@ -54,7 +54,7 @@ public interface PreInterruptCallback extends Extension {
 	 * @since 5.12
 	 * @see PreInterruptContext
 	 */
-	@API(status = EXPERIMENTAL, since = "5.12")
+	@API(status = MAINTAINED, since = "5.13.3")
 	void beforeThreadInterrupt(PreInterruptContext preInterruptContext, ExtensionContext extensionContext)
 			throws Exception;
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/PreInterruptContext.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/PreInterruptContext.java
@@ -10,7 +10,7 @@
 
 package org.junit.jupiter.api.extension;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import org.apiguardian.api.API;
 
@@ -21,7 +21,7 @@ import org.apiguardian.api.API;
  * @since 5.12
  * @see PreInterruptCallback
  */
-@API(status = EXPERIMENTAL, since = "5.12")
+@API(status = MAINTAINED, since = "5.13.3")
 public interface PreInterruptContext {
 
 	/**
@@ -30,6 +30,6 @@ public interface PreInterruptContext {
 	 * @return the Thread; never {@code null}
 	 * @since 5.12
 	 */
-	@API(status = EXPERIMENTAL, since = "5.12")
+	@API(status = MAINTAINED, since = "5.13.3")
 	Thread getThreadToInterrupt();
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/TemplateInvocationValidationException.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/TemplateInvocationValidationException.java
@@ -10,7 +10,7 @@
 
 package org.junit.jupiter.api.extension;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import org.apiguardian.api.API;
 import org.junit.platform.commons.JUnitException;
@@ -24,7 +24,7 @@ import org.junit.platform.commons.JUnitException;
  *
  * @since 5.13
  */
-@API(status = EXPERIMENTAL, since = "5.13")
+@API(status = MAINTAINED, since = "5.13.3")
 public class TemplateInvocationValidationException extends JUnitException {
 
 	private static final long serialVersionUID = 1L;

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/TestInstantiationAwareExtension.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/TestInstantiationAwareExtension.java
@@ -11,7 +11,7 @@
 package org.junit.jupiter.api.extension;
 
 import static org.apiguardian.api.API.Status.DEPRECATED;
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import org.apiguardian.api.API;
 import org.junit.jupiter.api.TestInstance;
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.extension.ExtensionContext.Store;
  * @see TestInstancePostProcessor
  * @see TestInstanceFactory
  */
-@API(status = EXPERIMENTAL, since = "5.12")
+@API(status = MAINTAINED, since = "5.13.3")
 public interface TestInstantiationAwareExtension extends Extension {
 
 	/**
@@ -89,7 +89,7 @@ public interface TestInstantiationAwareExtension extends Extension {
 	 *                    configuration parameters; never {@code null}
 	 * @since 5.12
 	 */
-	@API(status = EXPERIMENTAL, since = "5.12")
+	@API(status = MAINTAINED, since = "5.13.3")
 	default ExtensionContextScope getTestInstantiationExtensionContextScope(ExtensionContext rootContext) {
 		return ExtensionContextScope.DEFAULT;
 	}
@@ -102,7 +102,7 @@ public interface TestInstantiationAwareExtension extends Extension {
 	 * @since 5.12
 	 * @see TestInstantiationAwareExtension#getTestInstantiationExtensionContextScope
 	 */
-	@API(status = EXPERIMENTAL, since = "5.12")
+	@API(status = MAINTAINED, since = "5.13.3")
 	enum ExtensionContextScope {
 
 		/**

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/TestTemplateInvocationContext.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/TestTemplateInvocationContext.java
@@ -11,7 +11,7 @@
 package org.junit.jupiter.api.extension;
 
 import static java.util.Collections.emptyList;
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.util.List;
@@ -77,7 +77,7 @@ public interface TestTemplateInvocationContext {
 	 * @param context The invocation-level extension context.
 	 * @since 5.13
 	 */
-	@API(status = EXPERIMENTAL, since = "5.13")
+	@API(status = MAINTAINED, since = "5.13.3")
 	default void prepareInvocation(ExtensionContext context) {
 	}
 

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/TestTemplateInvocationContextProvider.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/TestTemplateInvocationContextProvider.java
@@ -10,7 +10,7 @@
 
 package org.junit.jupiter.api.extension;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.util.stream.Stream;
@@ -111,7 +111,7 @@ public interface TestTemplateInvocationContextProvider extends Extension {
 	 *
 	 * @since 5.12
 	 */
-	@API(status = EXPERIMENTAL, since = "5.12")
+	@API(status = MAINTAINED, since = "5.13.3")
 	default boolean mayReturnZeroTestTemplateInvocationContexts(ExtensionContext context) {
 		return false;
 	}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/io/TempDir.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/io/TempDir.java
@@ -11,7 +11,7 @@
 package org.junit.jupiter.api.io;
 
 import static org.apiguardian.api.API.Status.DEPRECATED;
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.io.File;
@@ -120,7 +120,7 @@ public @interface TempDir {
 	 *
 	 * @since 5.10
 	 */
-	@API(status = EXPERIMENTAL, since = "5.10")
+	@API(status = MAINTAINED, since = "5.13.3")
 	String DEFAULT_FACTORY_PROPERTY_NAME = "junit.jupiter.tempdir.factory.default";
 
 	/**
@@ -142,7 +142,7 @@ public @interface TempDir {
 	 * @since 5.10
 	 * @see TempDirFactory
 	 */
-	@API(status = EXPERIMENTAL, since = "5.10")
+	@API(status = MAINTAINED, since = "5.13.3")
 	Class<? extends TempDirFactory> factory() default TempDirFactory.class;
 
 	/**
@@ -176,7 +176,7 @@ public @interface TempDir {
 	 *
 	 * @since 5.9
 	 */
-	@API(status = EXPERIMENTAL, since = "5.9")
+	@API(status = MAINTAINED, since = "5.13.3")
 	String DEFAULT_CLEANUP_MODE_PROPERTY_NAME = "junit.jupiter.tempdir.cleanup.mode.default";
 
 	/**

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/io/TempDirFactory.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/io/TempDirFactory.java
@@ -10,7 +10,7 @@
 
 package org.junit.jupiter.api.io;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -45,7 +45,7 @@ import org.junit.jupiter.api.extension.ExtensionContext;
  * @see TempDir @TempDir
  */
 @FunctionalInterface
-@API(status = EXPERIMENTAL, since = "5.10")
+@API(status = MAINTAINED, since = "5.13.3")
 public interface TempDirFactory extends Closeable {
 
 	/**

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/parallel/Execution.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/parallel/Execution.java
@@ -10,7 +10,7 @@
 
 package org.junit.jupiter.api.parallel;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.lang.annotation.ElementType;
@@ -77,7 +77,7 @@ public @interface Execution {
 	 *
 	 * @since 5.4
 	 */
-	@API(status = EXPERIMENTAL, since = "5.9")
+	@API(status = MAINTAINED, since = "5.13.3")
 	String DEFAULT_EXECUTION_MODE_PROPERTY_NAME = "junit.jupiter.execution.parallel.mode.default";
 
 	/**
@@ -96,7 +96,7 @@ public @interface Execution {
 	 *
 	 * @since 5.4
 	 */
-	@API(status = EXPERIMENTAL, since = "5.9")
+	@API(status = MAINTAINED, since = "5.13.3")
 	String DEFAULT_CLASSES_EXECUTION_MODE_PROPERTY_NAME = "junit.jupiter.execution.parallel.mode.classes.default";
 
 	/**

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/parallel/ResourceLock.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/parallel/ResourceLock.java
@@ -10,7 +10,7 @@
 
 package org.junit.jupiter.api.parallel;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.lang.annotation.ElementType;
@@ -118,7 +118,7 @@ public @interface ResourceLock {
 	 * @see ResourceLocksProvider.Lock
 	 * @since 5.12
 	 */
-	@API(status = EXPERIMENTAL, since = "5.12")
+	@API(status = MAINTAINED, since = "5.13.3")
 	Class<? extends ResourceLocksProvider>[] providers() default {};
 
 	/**
@@ -132,7 +132,7 @@ public @interface ResourceLock {
 	 * @see ResourceLockTarget
 	 * @since 5.12
 	 */
-	@API(status = EXPERIMENTAL, since = "5.12")
+	@API(status = MAINTAINED, since = "5.13.3")
 	ResourceLockTarget target() default ResourceLockTarget.SELF;
 
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/parallel/ResourceLockTarget.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/parallel/ResourceLockTarget.java
@@ -10,7 +10,7 @@
 
 package org.junit.jupiter.api.parallel;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import org.apiguardian.api.API;
 
@@ -20,7 +20,7 @@ import org.apiguardian.api.API;
  * @since 5.12
  * @see ResourceLock#target()
  */
-@API(status = EXPERIMENTAL, since = "5.12")
+@API(status = MAINTAINED, since = "5.13.3")
 public enum ResourceLockTarget {
 
 	/**

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/parallel/ResourceLocksProvider.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/parallel/ResourceLocksProvider.java
@@ -11,7 +11,7 @@
 package org.junit.jupiter.api.parallel;
 
 import static java.util.Collections.emptySet;
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import java.lang.reflect.Method;
 import java.util.List;
@@ -40,7 +40,7 @@ import org.junit.platform.commons.util.ToStringBuilder;
  * @see ResourceAccessMode
  * @see Lock
  */
-@API(status = EXPERIMENTAL, since = "5.12")
+@API(status = MAINTAINED, since = "5.13.3")
 public interface ResourceLocksProvider {
 
 	/**

--- a/junit-jupiter-api/src/main/kotlin/org/junit/jupiter/api/Assertions.kt
+++ b/junit-jupiter-api/src/main/kotlin/org/junit/jupiter/api/Assertions.kt
@@ -12,7 +12,7 @@
 package org.junit.jupiter.api
 
 import org.apiguardian.api.API
-import org.apiguardian.api.API.Status.EXPERIMENTAL
+import org.apiguardian.api.API.Status.MAINTAINED
 import org.apiguardian.api.API.Status.STABLE
 import org.junit.jupiter.api.function.Executable
 import org.junit.jupiter.api.function.ThrowingSupplier
@@ -36,7 +36,7 @@ fun fail(
  * @see Assertions.fail
  */
 @OptIn(ExperimentalContracts::class)
-@API(since = "5.12", status = EXPERIMENTAL)
+@API(status = MAINTAINED, since = "5.13.3")
 @JvmName("fail_nonNullableLambda")
 fun fail(message: () -> String): Nothing {
     contract {
@@ -122,7 +122,7 @@ fun assertAll(
  * @see Assertions.assertNull
  */
 @OptIn(ExperimentalContracts::class)
-@API(since = "5.12", status = EXPERIMENTAL)
+@API(status = MAINTAINED, since = "5.13.3")
 fun assertNull(actual: Any?) {
     contract {
         returns() implies (actual == null)
@@ -144,7 +144,7 @@ fun assertNull(actual: Any?) {
  * @see Assertions.assertNull
  */
 @OptIn(ExperimentalContracts::class)
-@API(since = "5.12", status = EXPERIMENTAL)
+@API(status = MAINTAINED, since = "5.13.3")
 fun assertNull(
     actual: Any?,
     message: String
@@ -169,7 +169,7 @@ fun assertNull(
  * @see Assertions.assertNull
  */
 @OptIn(ExperimentalContracts::class)
-@API(since = "5.12", status = EXPERIMENTAL)
+@API(status = MAINTAINED, since = "5.13.3")
 fun assertNull(
     actual: Any?,
     messageSupplier: () -> String
@@ -196,7 +196,7 @@ fun assertNull(
  * @see Assertions.assertNotNull
  */
 @OptIn(ExperimentalContracts::class)
-@API(since = "5.12", status = EXPERIMENTAL)
+@API(status = MAINTAINED, since = "5.13.3")
 fun assertNotNull(actual: Any?) {
     contract {
         returns() implies (actual != null)
@@ -218,7 +218,7 @@ fun assertNotNull(actual: Any?) {
  * @see Assertions.assertNotNull
  */
 @OptIn(ExperimentalContracts::class)
-@API(since = "5.12", status = EXPERIMENTAL)
+@API(status = MAINTAINED, since = "5.13.3")
 fun assertNotNull(
     actual: Any?,
     message: String
@@ -243,7 +243,7 @@ fun assertNotNull(
  * @see Assertions.assertNotNull
  */
 @OptIn(ExperimentalContracts::class)
-@API(since = "5.12", status = EXPERIMENTAL)
+@API(status = MAINTAINED, since = "5.13.3")
 fun assertNotNull(
     actual: Any?,
     messageSupplier: () -> String
@@ -568,7 +568,7 @@ fun <R> assertTimeoutPreemptively(
  * @since 5.11
  */
 @OptIn(ExperimentalContracts::class)
-@API(status = EXPERIMENTAL, since = "5.11")
+@API(status = MAINTAINED, since = "5.13.3")
 inline fun <reified T : Any> assertInstanceOf(
     actualValue: Any?,
     message: String? = null
@@ -593,7 +593,7 @@ inline fun <reified T : Any> assertInstanceOf(
  * @since 5.11
  */
 @OptIn(ExperimentalContracts::class)
-@API(status = EXPERIMENTAL, since = "5.11")
+@API(status = MAINTAINED, since = "5.13.3")
 inline fun <reified T : Any> assertInstanceOf(
     actualValue: Any?,
     noinline message: () -> String

--- a/junit-jupiter-api/src/templates/resources/main/org/junit/jupiter/api/condition/JRE.java.jte
+++ b/junit-jupiter-api/src/templates/resources/main/org/junit/jupiter/api/condition/JRE.java.jte
@@ -8,7 +8,7 @@ ${licenseHeader}
 package org.junit.jupiter.api.condition;
 
 import static org.apiguardian.api.API.Status.DEPRECATED;
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.lang.reflect.Method;
@@ -52,7 +52,7 @@ public enum JRE {
 	 *
 	 * @since 5.12
 	 */
-	@API(status = EXPERIMENTAL, since = "5.12")
+	@API(status = MAINTAINED, since = "5.13.3")
 	UNDEFINED(-1),
 @for(var jre : jres)
 	/**
@@ -153,7 +153,7 @@ public enum JRE {
 	 * @see Runtime.Version#feature()
 	 * @see #currentVersionNumber()
 	 */
-	@API(status = EXPERIMENTAL, since = "5.12")
+	@API(status = MAINTAINED, since = "5.13.3")
 	public int version() {
 		return this.version;
 	}
@@ -204,7 +204,7 @@ public enum JRE {
 	 * @see Runtime.Version#feature()
 	 * @see #currentJre()
 	 */
-	@API(status = EXPERIMENTAL, since = "5.12")
+	@API(status = MAINTAINED, since = "5.13.3")
 	public static int currentVersionNumber() {
 		return CURRENT_VERSION;
 	}
@@ -218,7 +218,7 @@ public enum JRE {
 	 * @since 5.12
 	 * @see Runtime.Version#feature()
 	 */
-	@API(status = EXPERIMENTAL, since = "5.12")
+	@API(status = MAINTAINED, since = "5.13.3")
 	public static boolean isCurrentVersion(int version) {
 		return version == CURRENT_VERSION;
 	}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/Constants.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/Constants.java
@@ -12,6 +12,7 @@ package org.junit.jupiter.engine;
 
 import static org.apiguardian.api.API.Status.DEPRECATED;
 import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
 import static org.junit.platform.engine.support.hierarchical.DefaultParallelExecutionConfigurationStrategy.CONFIG_CUSTOM_CLASS_PROPERTY_NAME;
 import static org.junit.platform.engine.support.hierarchical.DefaultParallelExecutionConfigurationStrategy.CONFIG_DYNAMIC_FACTOR_PROPERTY_NAME;
@@ -190,7 +191,7 @@ public final class Constants {
 	 *
 	 * @since 5.12
 	 */
-	@API(status = EXPERIMENTAL, since = "5.12")
+	@API(status = MAINTAINED, since = "5.13.3")
 	public static final String EXTENSIONS_TIMEOUT_THREAD_DUMP_ENABLED_PROPERTY_NAME = JupiterConfiguration.EXTENSIONS_TIMEOUT_THREAD_DUMP_ENABLED_PROPERTY_NAME;
 
 	/**
@@ -276,7 +277,7 @@ public final class Constants {
 	 *
 	 * @since 5.10
 	 */
-	@API(status = EXPERIMENTAL, since = "5.10")
+	@API(status = MAINTAINED, since = "5.13.3")
 	public static final String PARALLEL_CONFIG_FIXED_MAX_POOL_SIZE_PROPERTY_NAME = PARALLEL_CONFIG_PREFIX
 			+ CONFIG_FIXED_MAX_POOL_SIZE_PROPERTY_NAME;
 
@@ -294,7 +295,7 @@ public final class Constants {
 	 *
 	 * @since 5.10
 	 */
-	@API(status = EXPERIMENTAL, since = "5.10")
+	@API(status = MAINTAINED, since = "5.13.3")
 	public static final String PARALLEL_CONFIG_FIXED_SATURATE_PROPERTY_NAME = PARALLEL_CONFIG_PREFIX
 			+ CONFIG_FIXED_SATURATE_PROPERTY_NAME;
 
@@ -452,7 +453,7 @@ public final class Constants {
 	 * @see Timeout
 	 * @see Timeout.ThreadMode
 	 */
-	@API(status = EXPERIMENTAL, since = "5.9")
+	@API(status = MAINTAINED, since = "5.13.3")
 	public static final String DEFAULT_TIMEOUT_THREAD_MODE_PROPERTY_NAME = Timeout.DEFAULT_TIMEOUT_THREAD_MODE_PROPERTY_NAME;
 
 	/**
@@ -462,7 +463,7 @@ public final class Constants {
 	 * @since 5.10
 	 * @see TempDir#DEFAULT_FACTORY_PROPERTY_NAME
 	 */
-	@API(status = EXPERIMENTAL, since = "5.10")
+	@API(status = MAINTAINED, since = "5.13.3")
 	public static final String DEFAULT_TEMP_DIR_FACTORY_PROPERTY_NAME = TempDir.DEFAULT_FACTORY_PROPERTY_NAME;
 
 	/**
@@ -472,7 +473,7 @@ public final class Constants {
 	 * @since 5.12
 	 * @see org.junit.jupiter.api.extension.TestInstantiationAwareExtension
 	 */
-	@API(status = EXPERIMENTAL, since = "5.12")
+	@API(status = MAINTAINED, since = "5.13.3")
 	public static final String DEFAULT_TEST_CLASS_INSTANCE_CONSTRUCTION_EXTENSION_CONTEXT_SCOPE_PROPERTY_NAME = ExtensionContextScope.DEFAULT_SCOPE_PROPERTY_NAME;
 
 	private Constants() {

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/Constants.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/Constants.java
@@ -11,7 +11,6 @@
 package org.junit.jupiter.engine;
 
 import static org.apiguardian.api.API.Status.DEPRECATED;
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
 import static org.junit.platform.engine.support.hierarchical.DefaultParallelExecutionConfigurationStrategy.CONFIG_CUSTOM_CLASS_PROPERTY_NAME;
@@ -218,7 +217,7 @@ public final class Constants {
 	 *
 	 * @since 5.13
 	 */
-	@API(status = EXPERIMENTAL, since = "5.13")
+	@API(status = MAINTAINED, since = "5.13.3")
 	public static final String CLOSING_STORED_AUTO_CLOSEABLE_ENABLED_PROPERTY_NAME = JupiterConfiguration.CLOSING_STORED_AUTO_CLOSEABLE_ENABLED_PROPERTY_NAME;
 
 	/**

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/AfterParameterizedClassInvocation.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/AfterParameterizedClassInvocation.java
@@ -10,7 +10,7 @@
 
 package org.junit.jupiter.params;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
@@ -157,7 +157,7 @@ import org.junit.jupiter.params.aggregator.ArgumentsAccessor;
 @Target({ ElementType.ANNOTATION_TYPE, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-@API(status = EXPERIMENTAL, since = "5.13")
+@API(status = MAINTAINED, since = "5.13.3")
 @ClassTemplateInvocationLifecycleMethod(classTemplateAnnotation = ParameterizedClass.class, lifecycleMethodAnnotation = AfterParameterizedClassInvocation.class)
 public @interface AfterParameterizedClassInvocation {
 

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ArgumentCountValidationMode.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ArgumentCountValidationMode.java
@@ -10,6 +10,8 @@
 
 package org.junit.jupiter.params;
 
+import static org.apiguardian.api.API.Status.MAINTAINED;
+
 import org.apiguardian.api.API;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 
@@ -28,7 +30,7 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
  * @see ParameterizedClass#argumentCountValidation()
  * @see ParameterizedTest#argumentCountValidation()
  */
-@API(status = API.Status.EXPERIMENTAL, since = "5.12")
+@API(status = MAINTAINED, since = "5.13.3")
 public enum ArgumentCountValidationMode {
 
 	/**

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/BeforeParameterizedClassInvocation.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/BeforeParameterizedClassInvocation.java
@@ -10,7 +10,7 @@
 
 package org.junit.jupiter.params;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
@@ -158,7 +158,7 @@ import org.junit.jupiter.params.aggregator.ArgumentsAccessor;
 @Target({ ElementType.ANNOTATION_TYPE, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-@API(status = EXPERIMENTAL, since = "5.13")
+@API(status = MAINTAINED, since = "5.13.3")
 @ClassTemplateInvocationLifecycleMethod(classTemplateAnnotation = ParameterizedClass.class, lifecycleMethodAnnotation = BeforeParameterizedClassInvocation.class)
 public @interface BeforeParameterizedClassInvocation {
 

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/Parameter.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/Parameter.java
@@ -10,7 +10,7 @@
 
 package org.junit.jupiter.params;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
@@ -41,7 +41,7 @@ import org.junit.jupiter.params.aggregator.ArgumentsAccessor;
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.ANNOTATION_TYPE, ElementType.FIELD })
 @Documented
-@API(status = EXPERIMENTAL, since = "5.13")
+@API(status = MAINTAINED, since = "5.13.3")
 public @interface Parameter {
 
 	/**

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedClass.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedClass.java
@@ -10,7 +10,7 @@
 
 package org.junit.jupiter.params;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
@@ -149,7 +149,7 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @Inherited
-@API(status = EXPERIMENTAL, since = "5.13")
+@API(status = MAINTAINED, since = "5.13.3")
 @ClassTemplate
 @ExtendWith(ParameterizedClassExtension.class)
 @SuppressWarnings("exports")

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedInvocationConstants.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedInvocationConstants.java
@@ -10,7 +10,6 @@
 
 package org.junit.jupiter.params;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import org.apiguardian.api.API;
@@ -88,7 +87,7 @@ public class ParameterizedInvocationConstants {
 	 * @see #ARGUMENT_SET_NAME_OR_ARGUMENTS_WITH_NAMES_PLACEHOLDER
 	 * @see org.junit.jupiter.params.provider.Arguments#argumentSet(String, Object...)
 	 */
-	@API(status = EXPERIMENTAL, since = "5.11")
+	@API(status = MAINTAINED, since = "5.13.3")
 	public static final String ARGUMENT_SET_NAME_PLACEHOLDER = "{argumentSetName}";
 
 	/**
@@ -106,7 +105,7 @@ public class ParameterizedInvocationConstants {
 	 * @see #DEFAULT_DISPLAY_NAME
 	 * @see org.junit.jupiter.params.provider.Arguments#argumentSet(String, Object...)
 	 */
-	@API(status = EXPERIMENTAL, since = "5.11")
+	@API(status = MAINTAINED, since = "5.13.3")
 	public static final String ARGUMENT_SET_NAME_OR_ARGUMENTS_WITH_NAMES_PLACEHOLDER = "{argumentSetNameOrArgumentsWithNames}";
 
 	/**

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTest.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTest.java
@@ -11,7 +11,7 @@
 package org.junit.jupiter.params;
 
 import static org.apiguardian.api.API.Status.DEPRECATED;
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.lang.annotation.Documented;
@@ -313,7 +313,7 @@ public @interface ParameterizedTest {
 	 *
 	 * @since 5.12
 	 */
-	@API(status = EXPERIMENTAL, since = "5.12")
+	@API(status = MAINTAINED, since = "5.13.3")
 	boolean allowZeroInvocations() default false;
 
 	/**
@@ -334,7 +334,7 @@ public @interface ParameterizedTest {
 	 * @since 5.12
 	 * @see ArgumentCountValidationMode
 	 */
-	@API(status = EXPERIMENTAL, since = "5.12")
+	@API(status = MAINTAINED, since = "5.13.3")
 	ArgumentCountValidationMode argumentCountValidation() default ArgumentCountValidationMode.DEFAULT;
 
 }

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/aggregator/ArgumentsAggregator.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/aggregator/ArgumentsAggregator.java
@@ -10,7 +10,7 @@
 
 package org.junit.jupiter.params.aggregator;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import org.apiguardian.api.API;
@@ -82,7 +82,7 @@ public interface ArgumentsAggregator {
 	 * aggregation
 	 * @since 5.13
 	 */
-	@API(status = EXPERIMENTAL, since = "5.13")
+	@API(status = MAINTAINED, since = "5.13.3")
 	default Object aggregateArguments(ArgumentsAccessor accessor, FieldContext context)
 			throws ArgumentsAggregationException {
 		throw new JUnitException(

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/aggregator/SimpleArgumentsAggregator.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/aggregator/SimpleArgumentsAggregator.java
@@ -10,7 +10,7 @@
 
 package org.junit.jupiter.params.aggregator;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import org.apiguardian.api.API;
 import org.junit.jupiter.api.extension.AnnotatedElementContext;
@@ -25,7 +25,7 @@ import org.junit.jupiter.params.support.FieldContext;
  * @since 5.0
  * @see ArgumentsAggregator
  */
-@API(status = EXPERIMENTAL, since = "5.13")
+@API(status = MAINTAINED, since = "5.13.3")
 public abstract class SimpleArgumentsAggregator implements ArgumentsAggregator {
 
 	public SimpleArgumentsAggregator() {

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/converter/AnnotationBasedArgumentConverter.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/converter/AnnotationBasedArgumentConverter.java
@@ -10,7 +10,7 @@
 
 package org.junit.jupiter.params.converter;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import java.lang.annotation.Annotation;
 
@@ -30,7 +30,7 @@ import org.junit.platform.commons.util.Preconditions;
  * @see AnnotationConsumer
  * @see SimpleArgumentConverter
  */
-@API(status = EXPERIMENTAL, since = "5.10")
+@API(status = MAINTAINED, since = "5.13.3")
 public abstract class AnnotationBasedArgumentConverter<A extends Annotation>
 		implements ArgumentConverter, AnnotationConsumer<A> {
 

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/converter/ArgumentConverter.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/converter/ArgumentConverter.java
@@ -10,7 +10,7 @@
 
 package org.junit.jupiter.params.converter;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import org.apiguardian.api.API;
@@ -83,7 +83,7 @@ public interface ArgumentConverter {
 	 * conversion
 	 * @since 5.13
 	 */
-	@API(status = EXPERIMENTAL, since = "5.13")
+	@API(status = MAINTAINED, since = "5.13.3")
 	default Object convert(Object source, FieldContext context) throws ArgumentConversionException {
 		throw new JUnitException(
 			String.format("ArgumentConverter does not override the convert(Object, FieldContext) method. "

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/converter/JavaTimeConversionPattern.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/converter/JavaTimeConversionPattern.java
@@ -10,7 +10,7 @@
 
 package org.junit.jupiter.params.converter;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.lang.annotation.Documented;
@@ -57,7 +57,7 @@ public @interface JavaTimeConversionPattern {
 	 *
 	 * @since 5.12
 	 */
-	@API(status = EXPERIMENTAL, since = "5.12")
+	@API(status = MAINTAINED, since = "5.13.3")
 	boolean nullable() default false;
 
 }

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/AnnotationBasedArgumentsProvider.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/AnnotationBasedArgumentsProvider.java
@@ -11,7 +11,7 @@
 package org.junit.jupiter.params.provider;
 
 import static org.apiguardian.api.API.Status.DEPRECATED;
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
@@ -38,7 +38,7 @@ import org.junit.platform.commons.util.Preconditions;
  * @see org.junit.jupiter.params.provider.ArgumentsProvider
  * @see org.junit.jupiter.params.support.AnnotationConsumer
  */
-@API(status = EXPERIMENTAL, since = "5.10")
+@API(status = MAINTAINED, since = "5.13.3")
 public abstract class AnnotationBasedArgumentsProvider<A extends Annotation>
 		implements ArgumentsProvider, AnnotationConsumer<A> {
 

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/Arguments.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/Arguments.java
@@ -10,7 +10,7 @@
 
 package org.junit.jupiter.params.provider;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import org.apiguardian.api.API;
@@ -118,7 +118,7 @@ public interface Arguments {
 	 * @see org.junit.jupiter.params.ParameterizedTest#ARGUMENT_SET_NAME_PLACEHOLDER
 	 * @see org.junit.jupiter.params.ParameterizedTest#ARGUMENT_SET_NAME_OR_ARGUMENTS_WITH_NAMES_PLACEHOLDER
 	 */
-	@API(status = EXPERIMENTAL, since = "5.11")
+	@API(status = MAINTAINED, since = "5.13.3")
 	static ArgumentSet argumentSet(String name, Object... arguments) {
 		return new ArgumentSet(name, arguments);
 	}
@@ -132,7 +132,7 @@ public interface Arguments {
 	 * @see org.junit.jupiter.params.ParameterizedTest#ARGUMENT_SET_NAME_PLACEHOLDER
 	 * @see org.junit.jupiter.params.ParameterizedTest#ARGUMENT_SET_NAME_OR_ARGUMENTS_WITH_NAMES_PLACEHOLDER
 	 */
-	@API(status = EXPERIMENTAL, since = "5.11")
+	@API(status = MAINTAINED, since = "5.13.3")
 	final class ArgumentSet implements Arguments {
 
 		private final String name;

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/ArgumentsProvider.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/ArgumentsProvider.java
@@ -11,7 +11,7 @@
 package org.junit.jupiter.params.provider;
 
 import static org.apiguardian.api.API.Status.DEPRECATED;
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.util.stream.Stream;
@@ -72,7 +72,7 @@ public interface ArgumentsProvider {
 	 * @return a stream of arguments; never {@code null}
 	 * @since 5.13
 	 */
-	@API(status = EXPERIMENTAL, since = "5.13")
+	@API(status = MAINTAINED, since = "5.13.3")
 	default Stream<? extends Arguments> provideArguments(ParameterDeclarations parameters, ExtensionContext context)
 			throws Exception {
 		try {

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/EnumSource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/EnumSource.java
@@ -11,7 +11,7 @@
 package org.junit.jupiter.params.provider;
 
 import static java.util.stream.Collectors.toSet;
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.lang.annotation.Documented;
@@ -109,7 +109,7 @@ public @interface EnumSource {
 	 *
 	 * @since 5.12
 	 */
-	@API(status = EXPERIMENTAL, since = "5.12")
+	@API(status = MAINTAINED, since = "5.13.3")
 	String from() default "";
 
 	/**
@@ -125,7 +125,7 @@ public @interface EnumSource {
 	 *
 	 * @since 5.12
 	 */
-	@API(status = EXPERIMENTAL, since = "5.12")
+	@API(status = MAINTAINED, since = "5.13.3")
 	String to() default "";
 
 	/**
@@ -188,7 +188,7 @@ public @interface EnumSource {
 		 * @since 5.9
 		 * @see java.util.stream.Stream#noneMatch(java.util.function.Predicate)
 		 */
-		@API(status = EXPERIMENTAL, since = "5.9")
+		@API(status = MAINTAINED, since = "5.13.3")
 		MATCH_NONE(Mode::validatePatterns, (name, patterns) -> patterns.stream().noneMatch(name::matches));
 
 		private final Validator validator;

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/FieldSource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/FieldSource.java
@@ -10,7 +10,7 @@
 
 package org.junit.jupiter.params.provider;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
@@ -134,7 +134,7 @@ import org.apiguardian.api.API;
 @Documented
 @Inherited
 @Repeatable(FieldSources.class)
-@API(status = EXPERIMENTAL, since = "5.11")
+@API(status = MAINTAINED, since = "5.13.3")
 @ArgumentsSource(FieldArgumentsProvider.class)
 @SuppressWarnings("exports")
 public @interface FieldSource {

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/FieldSources.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/FieldSources.java
@@ -10,7 +10,7 @@
 
 package org.junit.jupiter.params.provider;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
@@ -41,7 +41,7 @@ import org.apiguardian.api.API;
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @Inherited
-@API(status = EXPERIMENTAL, since = "5.11")
+@API(status = MAINTAINED, since = "5.13.3")
 public @interface FieldSources {
 
 	/**

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/support/FieldContext.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/support/FieldContext.java
@@ -10,7 +10,7 @@
 
 package org.junit.jupiter.params.support;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import java.lang.reflect.Field;
 
@@ -28,7 +28,7 @@ import org.junit.jupiter.params.ParameterizedClass;
  * @see ParameterizedClass
  * @see Parameter
  */
-@API(status = EXPERIMENTAL, since = "5.13")
+@API(status = MAINTAINED, since = "5.13.3")
 public interface FieldContext extends AnnotatedElementContext {
 
 	/**

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/support/ParameterDeclaration.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/support/ParameterDeclaration.java
@@ -10,7 +10,7 @@
 
 package org.junit.jupiter.params.support;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import java.lang.reflect.AnnotatedElement;
 import java.util.Optional;
@@ -24,7 +24,7 @@ import org.apiguardian.api.API;
  * @since 5.13
  * @see ParameterDeclarations
  */
-@API(status = EXPERIMENTAL, since = "5.13")
+@API(status = MAINTAINED, since = "5.13.3")
 public interface ParameterDeclaration {
 
 	/**

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/support/ParameterDeclarations.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/support/ParameterDeclarations.java
@@ -10,7 +10,7 @@
 
 package org.junit.jupiter.params.support;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import java.lang.reflect.AnnotatedElement;
 import java.util.List;
@@ -40,7 +40,7 @@ import org.junit.jupiter.params.aggregator.ArgumentsAccessor;
  * @see org.junit.jupiter.params.ParameterizedClass
  * @see org.junit.jupiter.params.ParameterizedTest
  */
-@API(status = EXPERIMENTAL, since = "5.13")
+@API(status = MAINTAINED, since = "5.13.3")
 public interface ParameterDeclarations {
 
 	/**

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/support/ParameterInfo.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/support/ParameterInfo.java
@@ -10,7 +10,7 @@
 
 package org.junit.jupiter.params.support;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import org.apiguardian.api.API;
 import org.junit.jupiter.api.Nested;
@@ -49,7 +49,7 @@ import org.junit.jupiter.params.aggregator.ArgumentsAccessor;
  * @see ParameterizedClass
  * @see ParameterizedTest
  */
-@API(status = EXPERIMENTAL, since = "5.13")
+@API(status = MAINTAINED, since = "5.13.3")
 public interface ParameterInfo {
 
 	/**

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/AnnotationSupport.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/AnnotationSupport.java
@@ -11,7 +11,6 @@
 package org.junit.platform.commons.support;
 
 import static org.apiguardian.api.API.Status.DEPRECATED;
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import java.lang.annotation.Annotation;
@@ -213,7 +212,7 @@ public final class AnnotationSupport {
 	 * @since 1.12
 	 * @see #findAnnotation(AnnotatedElement, Class)
 	 */
-	@API(status = EXPERIMENTAL, since = "1.12")
+	@API(status = MAINTAINED, since = "1.13.3")
 	public static <A extends Annotation> Optional<A> findAnnotation(Class<?> clazz, Class<A> annotationType,
 			List<Class<?>> enclosingInstanceTypes) {
 

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/ModifierSupport.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/ModifierSupport.java
@@ -10,7 +10,6 @@
 
 package org.junit.platform.commons.support;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import java.lang.reflect.Member;
@@ -151,7 +150,7 @@ public final class ModifierSupport {
 	 * @since 1.13
 	 * @see java.lang.reflect.Modifier#isAbstract(int)
 	 */
-	@API(status = EXPERIMENTAL, since = "1.13")
+	@API(status = MAINTAINED, since = "1.13.3")
 	public static boolean isNotAbstract(Class<?> clazz) {
 		return ReflectionUtils.isNotAbstract(clazz);
 	}
@@ -164,7 +163,7 @@ public final class ModifierSupport {
 	 * @since 1.13
 	 * @see java.lang.reflect.Modifier#isAbstract(int)
 	 */
-	@API(status = EXPERIMENTAL, since = "1.13")
+	@API(status = MAINTAINED, since = "1.13.3")
 	public static boolean isNotAbstract(Member member) {
 		return ReflectionUtils.isNotAbstract(member);
 	}

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/ReflectionSupport.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/ReflectionSupport.java
@@ -11,7 +11,6 @@
 package org.junit.platform.commons.support;
 
 import static org.apiguardian.api.API.Status.DEPRECATED;
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import java.lang.reflect.Field;
@@ -110,7 +109,7 @@ public final class ReflectionSupport {
 	 * @since 1.10
 	 * @see #tryToLoadClass(String)
 	 */
-	@API(status = EXPERIMENTAL, since = "1.10")
+	@API(status = MAINTAINED, since = "1.13.3")
 	public static Try<Class<?>> tryToLoadClass(String name, ClassLoader classLoader) {
 		return ReflectionUtils.tryToLoadClass(name, classLoader);
 	}
@@ -133,7 +132,7 @@ public final class ReflectionSupport {
 	 * @since 1.12
 	 * @see #tryToGetResources(String, ClassLoader)
 	 */
-	@API(status = EXPERIMENTAL, since = "1.12")
+	@API(status = MAINTAINED, since = "1.13.3")
 	public static Try<Set<Resource>> tryToGetResources(String classpathResourceName) {
 		return ReflectionUtils.tryToGetResources(classpathResourceName);
 	}
@@ -157,7 +156,7 @@ public final class ReflectionSupport {
 	 * @since 1.12
 	 * @see #tryToGetResources(String)
 	 */
-	@API(status = EXPERIMENTAL, since = "1.12")
+	@API(status = MAINTAINED, since = "1.13.3")
 	public static Try<Set<Resource>> tryToGetResources(String classpathResourceName, ClassLoader classLoader) {
 		return ReflectionUtils.tryToGetResources(classpathResourceName, classLoader);
 	}
@@ -201,7 +200,7 @@ public final class ReflectionSupport {
 	 * @see #findAllResourcesInPackage(String, Predicate)
 	 * @see #findAllResourcesInModule(String, Predicate)
 	 */
-	@API(status = EXPERIMENTAL, since = "1.11")
+	@API(status = MAINTAINED, since = "1.13.3")
 	public static List<Resource> findAllResourcesInClasspathRoot(URI root, Predicate<Resource> resourceFilter) {
 		return ReflectionUtils.findAllResourcesInClasspathRoot(root, resourceFilter);
 	}
@@ -247,7 +246,7 @@ public final class ReflectionSupport {
 	 * @see #streamAllResourcesInPackage(String, Predicate)
 	 * @see #streamAllResourcesInModule(String, Predicate)
 	 */
-	@API(status = EXPERIMENTAL, since = "1.11")
+	@API(status = MAINTAINED, since = "1.13.3")
 	public static Stream<Resource> streamAllResourcesInClasspathRoot(URI root, Predicate<Resource> resourceFilter) {
 		return ReflectionUtils.streamAllResourcesInClasspathRoot(root, resourceFilter);
 	}
@@ -294,7 +293,7 @@ public final class ReflectionSupport {
 	 * @see #findAllResourcesInClasspathRoot(URI, Predicate)
 	 * @see #findAllResourcesInModule(String, Predicate)
 	 */
-	@API(status = EXPERIMENTAL, since = "1.11")
+	@API(status = MAINTAINED, since = "1.13.3")
 	public static List<Resource> findAllResourcesInPackage(String basePackageName, Predicate<Resource> resourceFilter) {
 		return ReflectionUtils.findAllResourcesInPackage(basePackageName, resourceFilter);
 	}
@@ -344,7 +343,7 @@ public final class ReflectionSupport {
 	 * @see #streamAllResourcesInClasspathRoot(URI, Predicate)
 	 * @see #streamAllResourcesInModule(String, Predicate)
 	 */
-	@API(status = EXPERIMENTAL, since = "1.11")
+	@API(status = MAINTAINED, since = "1.13.3")
 	public static Stream<Resource> streamAllResourcesInPackage(String basePackageName,
 			Predicate<Resource> resourceFilter) {
 
@@ -392,7 +391,7 @@ public final class ReflectionSupport {
 	 * @see #findAllResourcesInClasspathRoot(URI, Predicate)
 	 * @see #findAllResourcesInPackage(String, Predicate)
 	 */
-	@API(status = EXPERIMENTAL, since = "1.11")
+	@API(status = MAINTAINED, since = "1.13.3")
 	public static List<Resource> findAllResourcesInModule(String moduleName, Predicate<Resource> resourceFilter) {
 		return ReflectionUtils.findAllResourcesInModule(moduleName, resourceFilter);
 	}
@@ -438,7 +437,7 @@ public final class ReflectionSupport {
 	 * @see #streamAllResourcesInClasspathRoot(URI, Predicate)
 	 * @see #streamAllResourcesInPackage(String, Predicate)
 	 */
-	@API(status = EXPERIMENTAL, since = "1.11")
+	@API(status = MAINTAINED, since = "1.13.3")
 	public static Stream<Resource> streamAllResourcesInModule(String moduleName, Predicate<Resource> resourceFilter) {
 		return ReflectionUtils.streamAllResourcesInModule(moduleName, resourceFilter);
 	}
@@ -712,7 +711,7 @@ public final class ReflectionSupport {
 	 * @since 1.12
 	 * @see Field#setAccessible(boolean)
 	 */
-	@API(status = EXPERIMENTAL, since = "1.12")
+	@API(status = MAINTAINED, since = "1.13.3")
 	public static Field makeAccessible(Field field) {
 		return ReflectionUtils.makeAccessible(Preconditions.notNull(field, "field must not be null"));
 	}

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/Resource.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/Resource.java
@@ -10,7 +10,7 @@
 
 package org.junit.platform.commons.support;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -30,7 +30,7 @@ import org.apiguardian.api.API;
  * @see ReflectionSupport#streamAllResourcesInPackage(String, Predicate)
  * @see ReflectionSupport#streamAllResourcesInModule(String, Predicate)
  */
-@API(status = EXPERIMENTAL, since = "1.11")
+@API(status = MAINTAINED, since = "1.13.3")
 public interface Resource {
 
 	/**

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/conversion/ConversionException.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/conversion/ConversionException.java
@@ -10,7 +10,7 @@
 
 package org.junit.platform.commons.support.conversion;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import org.apiguardian.api.API;
 import org.junit.platform.commons.JUnitException;
@@ -21,7 +21,7 @@ import org.junit.platform.commons.JUnitException;
  *
  * @since 1.11
  */
-@API(status = EXPERIMENTAL, since = "1.11")
+@API(status = MAINTAINED, since = "1.13.3")
 public class ConversionException extends JUnitException {
 
 	private static final long serialVersionUID = 1L;

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/conversion/ConversionSupport.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/conversion/ConversionSupport.java
@@ -12,7 +12,7 @@ package org.junit.platform.commons.support.conversion;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.unmodifiableList;
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.junit.platform.commons.util.ReflectionUtils.getWrapperType;
 
 import java.util.List;
@@ -27,7 +27,7 @@ import org.junit.platform.commons.util.ClassLoaderUtils;
  *
  * @since 1.11
  */
-@API(status = EXPERIMENTAL, since = "1.11")
+@API(status = MAINTAINED, since = "1.13.3")
 public final class ConversionSupport {
 
 	private static final List<StringToObjectConverter> stringToObjectConverters = unmodifiableList(asList( //

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/scanning/ClassFilter.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/scanning/ClassFilter.java
@@ -10,7 +10,7 @@
 
 package org.junit.platform.commons.support.scanning;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import java.util.function.Predicate;
 
@@ -22,7 +22,7 @@ import org.junit.platform.commons.util.Preconditions;
  *
  * @since 1.1
  */
-@API(status = EXPERIMENTAL, since = "1.12")
+@API(status = MAINTAINED, since = "1.13.3")
 public class ClassFilter {
 
 	/**

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/scanning/ClasspathScanner.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/scanning/ClasspathScanner.java
@@ -28,7 +28,7 @@ import org.junit.platform.commons.support.Resource;
  *
  * @since 1.12
  */
-@API(status = Status.EXPERIMENTAL, since = "1.12")
+@API(status = Status.MAINTAINED, since = "1.13.3")
 public interface ClasspathScanner {
 
 	/**

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/DiscoveryIssue.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/DiscoveryIssue.java
@@ -10,7 +10,7 @@
 
 package org.junit.platform.engine;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import java.util.Optional;
 import java.util.function.UnaryOperator;
@@ -24,7 +24,7 @@ import org.junit.platform.commons.util.Preconditions;
  *
  * @since 1.13
  */
-@API(status = EXPERIMENTAL, since = "1.13")
+@API(status = MAINTAINED, since = "1.13.3")
 public interface DiscoveryIssue {
 
 	/**

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/DiscoverySelector.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/DiscoverySelector.java
@@ -10,7 +10,7 @@
 
 package org.junit.platform.engine;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.util.Optional;
@@ -45,7 +45,7 @@ public interface DiscoverySelector {
 	 * identifiers
 	 * @since 1.11
 	 */
-	@API(status = EXPERIMENTAL, since = "1.11")
+	@API(status = MAINTAINED, since = "1.13.3")
 	default Optional<DiscoverySelectorIdentifier> toIdentifier() {
 		return Optional.empty();
 	}

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/DiscoverySelectorIdentifier.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/DiscoverySelectorIdentifier.java
@@ -10,7 +10,7 @@
 
 package org.junit.platform.engine;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import java.util.Objects;
 
@@ -29,7 +29,7 @@ import org.junit.platform.commons.util.StringUtils;
  * @see org.junit.platform.engine.discovery.DiscoverySelectors#parse(String)
  * @see org.junit.platform.engine.discovery.DiscoverySelectorIdentifierParser
  */
-@API(status = EXPERIMENTAL, since = "1.11")
+@API(status = MAINTAINED, since = "1.13.3")
 public final class DiscoverySelectorIdentifier {
 
 	private final String prefix;

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/EngineDiscoveryListener.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/EngineDiscoveryListener.java
@@ -10,7 +10,7 @@
 
 package org.junit.platform.engine;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import org.apiguardian.api.API;
@@ -63,7 +63,7 @@ public interface EngineDiscoveryListener {
 	 * @since 1.13
 	 * @see DiscoveryIssue
 	 */
-	@API(status = EXPERIMENTAL, since = "1.13")
+	@API(status = MAINTAINED, since = "1.13.3")
 	default void issueEncountered(UniqueId engineId, DiscoveryIssue issue) {
 	}
 

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/EngineDiscoveryRequest.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/EngineDiscoveryRequest.java
@@ -10,7 +10,7 @@
 
 package org.junit.platform.engine;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.util.List;
@@ -89,7 +89,7 @@ public interface EngineDiscoveryRequest {
 	 * @return the output directory provider; never {@code null}
 	 * @since 1.12
 	 */
-	@API(status = EXPERIMENTAL, since = "1.12")
+	@API(status = MAINTAINED, since = "1.13.3")
 	default OutputDirectoryProvider getOutputDirectoryProvider() {
 		throw new JUnitException(
 			"OutputDirectoryProvider not available; probably due to unaligned versions of the junit-platform-engine and junit-platform-launcher jars on the classpath/module path.");

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/EngineExecutionListener.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/EngineExecutionListener.java
@@ -10,7 +10,7 @@
 
 package org.junit.platform.engine;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import org.apiguardian.api.API;
@@ -156,7 +156,7 @@ public interface EngineExecutionListener {
 	* the file entry belongs
 	 * @param file a {@code FileEntry} instance to be attached
 	 */
-	@API(status = EXPERIMENTAL, since = "1.12")
+	@API(status = MAINTAINED, since = "1.13.3")
 	default void fileEntryPublished(TestDescriptor testDescriptor, FileEntry file) {
 	}
 }

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/ExecutionRequest.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/ExecutionRequest.java
@@ -13,6 +13,7 @@ package org.junit.platform.engine;
 import static org.apiguardian.api.API.Status.DEPRECATED;
 import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.INTERNAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import org.apiguardian.api.API;
@@ -144,7 +145,7 @@ public class ExecutionRequest {
 	 * is not available
 	 * @since 1.12
 	 */
-	@API(status = EXPERIMENTAL, since = "1.12")
+	@API(status = MAINTAINED, since = "1.13.3")
 	public OutputDirectoryProvider getOutputDirectoryProvider() {
 		return Preconditions.notNull(this.outputDirectoryProvider,
 			"No OutputDirectoryProvider was configured for this request");

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/ExecutionRequest.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/ExecutionRequest.java
@@ -11,7 +11,6 @@
 package org.junit.platform.engine;
 
 import static org.apiguardian.api.API.Status.DEPRECATED;
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.INTERNAL;
 import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
@@ -162,7 +161,7 @@ public class ExecutionRequest {
 	 * @since 1.13
 	 * @see NamespacedHierarchicalStore
 	 */
-	@API(status = EXPERIMENTAL, since = "1.13")
+	@API(status = MAINTAINED, since = "1.13.3")
 	public NamespacedHierarchicalStore<Namespace> getStore() {
 		return Preconditions.notNull(this.requestLevelStore,
 			"No NamespacedHierarchicalStore was configured for this request");

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/TestDescriptor.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/TestDescriptor.java
@@ -10,7 +10,6 @@
 
 package org.junit.platform.engine;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
 
@@ -334,7 +333,7 @@ public interface TestDescriptor {
 		 * is empty
 		 * @since 1.13
 		 */
-		@API(status = EXPERIMENTAL, since = "1.13")
+		@API(status = MAINTAINED, since = "1.13.3")
 		static Visitor composite(Visitor... visitors) {
 			return CompositeTestDescriptorVisitor.from(visitors);
 		}

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/TestDescriptor.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/TestDescriptor.java
@@ -11,6 +11,7 @@
 package org.junit.platform.engine;
 
 import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.util.ArrayList;
@@ -188,7 +189,7 @@ public interface TestDescriptor {
 	 * @param orderer a unary operator to order the children of this test descriptor
 	 * @since 1.12
 	 */
-	@API(since = "1.12", status = EXPERIMENTAL)
+	@API(status = MAINTAINED, since = "1.13.3")
 	default void orderChildren(UnaryOperator<List<TestDescriptor>> orderer) {
 		Preconditions.notNull(orderer, "orderer must not be null");
 		Set<? extends TestDescriptor> originalChildren = getChildren();

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/ClassSelector.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/ClassSelector.java
@@ -10,8 +10,8 @@
 
 package org.junit.platform.engine.discovery;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.INTERNAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.util.Objects;
@@ -69,7 +69,7 @@ public class ClassSelector implements DiscoverySelector {
 	 * @return the {@code ClassLoader}; potentially {@code null}
 	 * @since 1.10
 	 */
-	@API(status = EXPERIMENTAL, since = "1.10")
+	@API(status = MAINTAINED, since = "1.13.3")
 	public ClassLoader getClassLoader() {
 		return this.classLoader;
 	}

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/ClasspathResourceSelector.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/ClasspathResourceSelector.java
@@ -11,8 +11,8 @@
 package org.junit.platform.engine.discovery;
 
 import static java.util.Collections.unmodifiableSet;
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.INTERNAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.util.LinkedHashSet;
@@ -93,7 +93,7 @@ public class ClasspathResourceSelector implements DiscoverySelector {
 	 *
 	 * @since 1.12
 	 */
-	@API(status = EXPERIMENTAL, since = "1.12")
+	@API(status = MAINTAINED, since = "1.13.3")
 	public Set<Resource> getClasspathResources() {
 		if (this.classpathResources == null) {
 			Try<Set<Resource>> tryToGetResource = ReflectionUtils.tryToGetResources(this.classpathResourceName);

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/DiscoverySelectorIdentifierParser.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/DiscoverySelectorIdentifierParser.java
@@ -10,7 +10,7 @@
 
 package org.junit.platform.engine.discovery;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import java.util.Optional;
 
@@ -28,7 +28,7 @@ import org.junit.platform.engine.DiscoverySelectorIdentifier;
  * @since 1.11
  * @see DiscoverySelectors#parse(String)
  */
-@API(status = EXPERIMENTAL, since = "1.11")
+@API(status = MAINTAINED, since = "1.13.3")
 public interface DiscoverySelectorIdentifierParser {
 
 	/**

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/DiscoverySelectors.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/DiscoverySelectors.java
@@ -11,7 +11,7 @@
 package org.junit.platform.engine.discovery;
 
 import static java.util.stream.Collectors.toList;
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
 import static org.junit.platform.commons.util.CollectionUtils.toUnmodifiableList;
 
@@ -349,7 +349,7 @@ public final class DiscoverySelectors {
 	 * @see ClasspathResourceSelector
 	 * @see ReflectionSupport#tryToGetResources(String)
 	 */
-	@API(status = EXPERIMENTAL, since = "1.12")
+	@API(status = MAINTAINED, since = "1.13.3")
 	public static ClasspathResourceSelector selectClasspathResource(Set<Resource> classpathResources) {
 		Preconditions.notEmpty(classpathResources, "classpath resources must not be null or empty");
 		Preconditions.containsNoNullElements(classpathResources, "individual classpath resources must not be null");
@@ -445,7 +445,7 @@ public final class DiscoverySelectors {
 	 * @since 1.10
 	 * @see ClassSelector
 	 */
-	@API(status = EXPERIMENTAL, since = "1.10")
+	@API(status = MAINTAINED, since = "1.13.3")
 	public static ClassSelector selectClass(ClassLoader classLoader, String className) {
 		Preconditions.notBlank(className, "Class name must not be null or blank");
 		return new ClassSelector(classLoader, className);
@@ -513,7 +513,7 @@ public final class DiscoverySelectors {
 	 * @see #selectMethod(String)
 	 * @see MethodSelector
 	 */
-	@API(status = EXPERIMENTAL, since = "1.10")
+	@API(status = MAINTAINED, since = "1.13.3")
 	public static MethodSelector selectMethod(ClassLoader classLoader, String fullyQualifiedMethodName)
 			throws PreconditionViolationException {
 		String[] methodParts = ReflectionUtils.parseFullyQualifiedMethodName(fullyQualifiedMethodName);
@@ -545,7 +545,7 @@ public final class DiscoverySelectors {
 	 * @since 1.10
 	 * @see MethodSelector
 	 */
-	@API(status = EXPERIMENTAL, since = "1.10")
+	@API(status = MAINTAINED, since = "1.13.3")
 	public static MethodSelector selectMethod(ClassLoader classLoader, String className, String methodName) {
 		return selectMethod(classLoader, className, methodName, "");
 	}
@@ -589,7 +589,7 @@ public final class DiscoverySelectors {
 	 * @since 1.10
 	 * @see MethodSelector
 	 */
-	@API(status = EXPERIMENTAL, since = "1.10")
+	@API(status = MAINTAINED, since = "1.13.3")
 	public static MethodSelector selectMethod(ClassLoader classLoader, String className, String methodName,
 			String parameterTypeNames) {
 		Preconditions.notBlank(className, "Class name must not be null or blank");
@@ -645,7 +645,7 @@ public final class DiscoverySelectors {
 	 * @since 1.10
 	 * @see MethodSelector
 	 */
-	@API(status = EXPERIMENTAL, since = "1.10")
+	@API(status = MAINTAINED, since = "1.13.3")
 	public static MethodSelector selectMethod(String className, String methodName, Class<?>... parameterTypes) {
 		Preconditions.notBlank(className, "Class name must not be null or blank");
 		Preconditions.notBlank(methodName, "Method name must not be null or blank");
@@ -666,7 +666,7 @@ public final class DiscoverySelectors {
 	 * @since 1.10
 	 * @see MethodSelector
 	 */
-	@API(status = EXPERIMENTAL, since = "1.10")
+	@API(status = MAINTAINED, since = "1.13.3")
 	public static MethodSelector selectMethod(Class<?> javaClass, String methodName, Class<?>... parameterTypes) {
 		Preconditions.notNull(javaClass, "Class must not be null");
 		Preconditions.notBlank(methodName, "Method name must not be null or blank");
@@ -730,7 +730,7 @@ public final class DiscoverySelectors {
 	 * @since 1.10
 	 * @see NestedClassSelector
 	 */
-	@API(status = EXPERIMENTAL, since = "1.10")
+	@API(status = MAINTAINED, since = "1.13.3")
 	public static NestedClassSelector selectNestedClass(ClassLoader classLoader, List<String> enclosingClassNames,
 			String nestedClassName) {
 		Preconditions.notEmpty(enclosingClassNames, "Enclosing class names must not be null or empty");
@@ -766,7 +766,7 @@ public final class DiscoverySelectors {
 	 * @since 1.10
 	 * @see NestedMethodSelector
 	 */
-	@API(status = EXPERIMENTAL, since = "1.10")
+	@API(status = MAINTAINED, since = "1.13.3")
 	public static NestedMethodSelector selectNestedMethod(ClassLoader classLoader, List<String> enclosingClassNames,
 			String nestedClassName, String methodName) throws PreconditionViolationException {
 		Preconditions.notEmpty(enclosingClassNames, "Enclosing class names must not be null or empty");
@@ -814,7 +814,7 @@ public final class DiscoverySelectors {
 	 * @since 1.10
 	 * @see #selectNestedMethod(List, String, String, String)
 	 */
-	@API(status = EXPERIMENTAL, since = "1.10")
+	@API(status = MAINTAINED, since = "1.13.3")
 	public static NestedMethodSelector selectNestedMethod(ClassLoader classLoader, List<String> enclosingClassNames,
 			String nestedClassName, String methodName, String parameterTypeNames) {
 
@@ -840,7 +840,7 @@ public final class DiscoverySelectors {
 	 * @since 1.10
 	 * @see NestedMethodSelector
 	 */
-	@API(status = EXPERIMENTAL, since = "1.10")
+	@API(status = MAINTAINED, since = "1.13.3")
 	public static NestedMethodSelector selectNestedMethod(List<String> enclosingClassNames, String nestedClassName,
 			String methodName, Class<?>... parameterTypes) {
 
@@ -909,7 +909,7 @@ public final class DiscoverySelectors {
 	 * @since 1.10
 	 * @see NestedMethodSelector
 	 */
-	@API(status = EXPERIMENTAL, since = "1.10")
+	@API(status = MAINTAINED, since = "1.13.3")
 	public static NestedMethodSelector selectNestedMethod(List<Class<?>> enclosingClasses, Class<?> nestedClass,
 			String methodName, Class<?>... parameterTypes) {
 
@@ -973,7 +973,7 @@ public final class DiscoverySelectors {
 	 * @since 1.9
 	 * @see IterationSelector
 	 */
-	@API(status = EXPERIMENTAL, since = "1.9")
+	@API(status = MAINTAINED, since = "1.13.3")
 	public static IterationSelector selectIteration(DiscoverySelector parentSelector, int... iterationIndices) {
 		Preconditions.notNull(parentSelector, "Parent selector must not be null");
 		Preconditions.notEmpty(iterationIndices, "iteration indices must not be empty");
@@ -990,7 +990,7 @@ public final class DiscoverySelectors {
 	 * @since 1.11
 	 * @see DiscoverySelectorIdentifierParser
 	 */
-	@API(status = EXPERIMENTAL, since = "1.11")
+	@API(status = MAINTAINED, since = "1.13.3")
 	public static Optional<? extends DiscoverySelector> parse(String identifier) {
 		return DiscoverySelectorIdentifierParsers.parse(identifier);
 	}
@@ -1005,7 +1005,7 @@ public final class DiscoverySelectors {
 	 * @since 1.11
 	 * @see DiscoverySelectorIdentifierParser
 	 */
-	@API(status = EXPERIMENTAL, since = "1.11")
+	@API(status = MAINTAINED, since = "1.13.3")
 	public static Optional<? extends DiscoverySelector> parse(DiscoverySelectorIdentifier identifier) {
 		return DiscoverySelectorIdentifierParsers.parse(identifier);
 	}
@@ -1021,7 +1021,7 @@ public final class DiscoverySelectors {
 	 * @since 1.11
 	 * @see DiscoverySelectorIdentifierParser
 	 */
-	@API(status = EXPERIMENTAL, since = "1.11")
+	@API(status = MAINTAINED, since = "1.13.3")
 	public static Stream<? extends DiscoverySelector> parseAll(String... identifiers) {
 		return DiscoverySelectorIdentifierParsers.parseAll(identifiers);
 	}
@@ -1037,7 +1037,7 @@ public final class DiscoverySelectors {
 	 * @since 1.11
 	 * @see DiscoverySelectorIdentifierParser
 	 */
-	@API(status = EXPERIMENTAL, since = "1.11")
+	@API(status = MAINTAINED, since = "1.13.3")
 	public static Stream<? extends DiscoverySelector> parseAll(Collection<DiscoverySelectorIdentifier> identifiers) {
 		return DiscoverySelectorIdentifierParsers.parseAll(identifiers);
 	}

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/IterationSelector.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/IterationSelector.java
@@ -13,8 +13,8 @@ package org.junit.platform.engine.discovery;
 import static java.util.stream.Collectors.collectingAndThen;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toCollection;
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.INTERNAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -44,7 +44,7 @@ import org.junit.platform.engine.DiscoverySelectorIdentifier;
  * @since 1.9
  * @see DiscoverySelectors#selectIteration(DiscoverySelector, int...)
  */
-@API(status = EXPERIMENTAL, since = "1.9")
+@API(status = MAINTAINED, since = "1.13.3")
 public class IterationSelector implements DiscoverySelector {
 
 	private final DiscoverySelector parentSelector;

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/MethodSelector.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/MethodSelector.java
@@ -11,8 +11,8 @@
 package org.junit.platform.engine.discovery;
 
 import static org.apiguardian.api.API.Status.DEPRECATED;
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.INTERNAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.lang.reflect.Method;
@@ -126,7 +126,7 @@ public class MethodSelector implements DiscoverySelector {
 	 * @return the {@code ClassLoader}; potentially {@code null}
 	 * @since 1.10
 	 */
-	@API(status = EXPERIMENTAL, since = "1.10")
+	@API(status = MAINTAINED, since = "1.13.3")
 	public ClassLoader getClassLoader() {
 		return this.classLoader;
 	}
@@ -227,7 +227,7 @@ public class MethodSelector implements DiscoverySelector {
 	 * @see #getParameterTypeNames()
 	 * @see Method#getParameterTypes()
 	 */
-	@API(status = EXPERIMENTAL, since = "1.10")
+	@API(status = MAINTAINED, since = "1.13.3")
 	public Class<?>[] getParameterTypes() {
 		lazyLoadParameterTypes();
 		return this.parameterTypes.clone();

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/NestedClassSelector.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/NestedClassSelector.java
@@ -12,8 +12,8 @@ package org.junit.platform.engine.discovery;
 
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.INTERNAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
 import static org.junit.platform.commons.util.CollectionUtils.toUnmodifiableList;
 
@@ -78,7 +78,7 @@ public class NestedClassSelector implements DiscoverySelector {
 	 * @return the {@code ClassLoader}; potentially {@code null}
 	 * @since 1.10
 	 */
-	@API(status = EXPERIMENTAL, since = "1.10")
+	@API(status = MAINTAINED, since = "1.13.3")
 	public ClassLoader getClassLoader() {
 		return this.classLoader;
 	}

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/NestedMethodSelector.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/NestedMethodSelector.java
@@ -11,8 +11,8 @@
 package org.junit.platform.engine.discovery;
 
 import static org.apiguardian.api.API.Status.DEPRECATED;
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.INTERNAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.lang.reflect.Method;
@@ -101,7 +101,7 @@ public class NestedMethodSelector implements DiscoverySelector {
 	 *
 	 * @since 1.10
 	 */
-	@API(status = EXPERIMENTAL, since = "1.10")
+	@API(status = MAINTAINED, since = "1.13.3")
 	public ClassLoader getClassLoader() {
 		return this.nestedClassSelector.getClassLoader();
 	}
@@ -209,7 +209,7 @@ public class NestedMethodSelector implements DiscoverySelector {
 	 * @see #getParameterTypeNames()
 	 * @see MethodSelector#getParameterTypes()
 	 */
-	@API(status = EXPERIMENTAL, since = "1.10")
+	@API(status = MAINTAINED, since = "1.13.3")
 	public Class<?>[] getParameterTypes() {
 		return this.methodSelector.getParameterTypes();
 	}

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/reporting/FileEntry.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/reporting/FileEntry.java
@@ -10,7 +10,7 @@
 
 package org.junit.platform.engine.reporting;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import java.nio.file.Path;
 import java.time.LocalDateTime;
@@ -27,7 +27,7 @@ import org.junit.platform.commons.util.ToStringBuilder;
  * @since 1.12
  * @see #from(Path, String)
  */
-@API(status = EXPERIMENTAL, since = "1.12")
+@API(status = MAINTAINED, since = "1.13.3")
 public final class FileEntry {
 
 	/**

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/reporting/OutputDirectoryProvider.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/reporting/OutputDirectoryProvider.java
@@ -10,7 +10,7 @@
 
 package org.junit.platform.engine.reporting;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -26,7 +26,7 @@ import org.junit.platform.engine.TestDescriptor;
  * @since 1.12
  * @see EngineDiscoveryRequest#getOutputDirectoryProvider()
  */
-@API(status = EXPERIMENTAL, since = "1.12")
+@API(status = MAINTAINED, since = "1.13.3")
 public interface OutputDirectoryProvider {
 
 	/**

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/discovery/DiscoveryIssueReporter.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/discovery/DiscoveryIssueReporter.java
@@ -10,7 +10,7 @@
 
 package org.junit.platform.engine.support.discovery;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -34,7 +34,7 @@ import org.junit.platform.engine.UniqueId;
  * @since 1.13
  * @see SelectorResolver.Context
  */
-@API(status = EXPERIMENTAL, since = "1.13")
+@API(status = MAINTAINED, since = "1.13.3")
 public interface DiscoveryIssueReporter {
 
 	/**

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/discovery/EngineDiscoveryRequestResolver.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/discovery/EngineDiscoveryRequestResolver.java
@@ -12,6 +12,7 @@ package org.junit.platform.engine.support.discovery;
 
 import static java.util.stream.Collectors.toCollection;
 import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.util.ArrayList;
@@ -227,7 +228,7 @@ public class EngineDiscoveryRequestResolver<T extends TestDescriptor> {
 		 * @return this builder for method chaining
 		 * @since 1.12
 		 */
-		@API(status = EXPERIMENTAL, since = "1.12")
+		@API(status = MAINTAINED, since = "1.13.3")
 		public Builder<T> addResourceContainerSelectorResolver(Predicate<Resource> resourceFilter) {
 			Preconditions.notNull(resourceFilter, "resourceFilter must not be null");
 			return addSelectorResolver(
@@ -336,7 +337,7 @@ public class EngineDiscoveryRequestResolver<T extends TestDescriptor> {
 		 * {@code null}
 		 * @since 1.12
 		 */
-		@API(status = EXPERIMENTAL, since = "1.12")
+		@API(status = MAINTAINED, since = "1.13.3")
 		Predicate<String> getPackageFilter();
 
 		/**

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/discovery/EngineDiscoveryRequestResolver.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/discovery/EngineDiscoveryRequestResolver.java
@@ -11,7 +11,6 @@
 package org.junit.platform.engine.support.discovery;
 
 import static java.util.stream.Collectors.toCollection;
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
 
@@ -137,7 +136,7 @@ public class EngineDiscoveryRequestResolver<T extends TestDescriptor> {
 	 * @see SelectorResolver
 	 * @see TestDescriptor.Visitor
 	 */
-	@API(status = EXPERIMENTAL, since = "1.13")
+	@API(status = MAINTAINED, since = "1.13.3")
 	public void resolve(EngineDiscoveryRequest request, T engineDescriptor, DiscoveryIssueReporter issueReporter) {
 		Preconditions.notNull(request, "request must not be null");
 		Preconditions.notNull(engineDescriptor, "engineDescriptor must not be null");
@@ -208,7 +207,7 @@ public class EngineDiscoveryRequestResolver<T extends TestDescriptor> {
 		 * {@code null}
 		 * @return this builder for method chaining
 		 */
-		@API(status = EXPERIMENTAL, since = "1.13")
+		@API(status = MAINTAINED, since = "1.13.3")
 		public Builder<T> addClassContainerSelectorResolverWithContext(
 				Function<InitializationContext<T>, Predicate<Class<?>>> classFilterCreator) {
 			Preconditions.notNull(classFilterCreator, "classFilterCreator must not be null");
@@ -346,7 +345,7 @@ public class EngineDiscoveryRequestResolver<T extends TestDescriptor> {
 		 *
 		 * @since 1.13
 		 */
-		@API(status = EXPERIMENTAL, since = "1.13")
+		@API(status = MAINTAINED, since = "1.13.3")
 		DiscoveryIssueReporter getIssueReporter();
 	}
 

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/discovery/SelectorResolver.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/discovery/SelectorResolver.java
@@ -12,7 +12,7 @@ package org.junit.platform.engine.support.discovery;
 
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.util.Collections;
@@ -315,7 +315,7 @@ public interface SelectorResolver {
 	 * Resolution#matches(Set) matches()}; never {@code null}
 	 * @see #resolve(DiscoverySelector, Context)
 	 */
-	@API(status = EXPERIMENTAL, since = "1.9")
+	@API(status = MAINTAINED, since = "1.13.3")
 	default Resolution resolve(IterationSelector selector, Context context) {
 		return resolve((DiscoverySelector) selector, context);
 	}

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/DefaultParallelExecutionConfigurationStrategy.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/DefaultParallelExecutionConfigurationStrategy.java
@@ -10,7 +10,7 @@
 
 package org.junit.platform.engine.support.hierarchical;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.math.BigDecimal;
@@ -144,7 +144,7 @@ public enum DefaultParallelExecutionConfigurationStrategy implements ParallelExe
 	 * @since 1.10
 	 * @see #FIXED
 	 */
-	@API(status = EXPERIMENTAL, since = "1.10")
+	@API(status = MAINTAINED, since = "1.13.3")
 	public static final String CONFIG_FIXED_MAX_POOL_SIZE_PROPERTY_NAME = "fixed.max-pool-size";
 
 	/**
@@ -160,7 +160,7 @@ public enum DefaultParallelExecutionConfigurationStrategy implements ParallelExe
 	 * @see #FIXED
 	 * @see #CONFIG_FIXED_MAX_POOL_SIZE_PROPERTY_NAME
 	 */
-	@API(status = EXPERIMENTAL, since = "1.10")
+	@API(status = MAINTAINED, since = "1.13.3")
 	public static final String CONFIG_FIXED_SATURATE_PROPERTY_NAME = "fixed.saturate";
 
 	/**
@@ -188,7 +188,7 @@ public enum DefaultParallelExecutionConfigurationStrategy implements ParallelExe
 	 * @since 1.10
 	 * @see #DYNAMIC
 	 */
-	@API(status = EXPERIMENTAL, since = "1.10")
+	@API(status = MAINTAINED, since = "1.13.3")
 	public static final String CONFIG_DYNAMIC_MAX_POOL_SIZE_FACTOR_PROPERTY_NAME = "dynamic.max-pool-size-factor";
 
 	/**
@@ -204,7 +204,7 @@ public enum DefaultParallelExecutionConfigurationStrategy implements ParallelExe
 	 * @see #DYNAMIC
 	 * @see #CONFIG_DYNAMIC_FACTOR_PROPERTY_NAME
 	 */
-	@API(status = EXPERIMENTAL, since = "1.10")
+	@API(status = MAINTAINED, since = "1.13.3")
 	public static final String CONFIG_DYNAMIC_SATURATE_PROPERTY_NAME = "dynamic.saturate";
 
 	/**

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/store/Namespace.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/store/Namespace.java
@@ -10,7 +10,7 @@
 
 package org.junit.platform.engine.support.store;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -28,7 +28,7 @@ import org.junit.platform.commons.util.Preconditions;
  * mixing data between extensions or across different invocations within the
  * lifecycle of a single extension.
  */
-@API(status = EXPERIMENTAL, since = "1.13")
+@API(status = MAINTAINED, since = "1.13.3")
 public class Namespace {
 
 	/**

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/store/NamespacedHierarchicalStore.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/store/NamespacedHierarchicalStore.java
@@ -12,6 +12,7 @@ package org.junit.platform.engine.support.store;
 
 import static java.util.Comparator.comparing;
 import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.junit.platform.commons.util.ReflectionUtils.getWrapperType;
 import static org.junit.platform.commons.util.ReflectionUtils.isAssignableTo;
 
@@ -44,7 +45,7 @@ import org.junit.platform.engine.support.hierarchical.ThrowableCollector;
  * @param <N> Namespace type
  * @since 1.10
  */
-@API(status = EXPERIMENTAL, since = "1.10")
+@API(status = MAINTAINED, since = "1.13.3")
 public final class NamespacedHierarchicalStore<N> implements AutoCloseable {
 
 	private final AtomicInteger insertOrderSequence = new AtomicInteger();
@@ -106,7 +107,7 @@ public final class NamespacedHierarchicalStore<N> implements AutoCloseable {
 	 * @since 1.11
 	 * @see #close()
 	 */
-	@API(status = EXPERIMENTAL, since = "1.11")
+	@API(status = MAINTAINED, since = "1.13.3")
 	public boolean isClosed() {
 		return this.closed;
 	}

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/store/NamespacedHierarchicalStore.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/store/NamespacedHierarchicalStore.java
@@ -11,7 +11,6 @@
 package org.junit.platform.engine.support.store;
 
 import static java.util.Comparator.comparing;
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.junit.platform.commons.util.ReflectionUtils.getWrapperType;
 import static org.junit.platform.commons.util.ReflectionUtils.isAssignableTo;
@@ -95,7 +94,7 @@ public final class NamespacedHierarchicalStore<N> implements AutoCloseable {
 	 * @return an {@code Optional} containing the parent store, or an empty {@code Optional} if there is no parent
 	 * @since 5.13
 	 */
-	@API(status = EXPERIMENTAL, since = "5.13")
+	@API(status = MAINTAINED, since = "5.13.3")
 	public Optional<NamespacedHierarchicalStore<N>> getParent() {
 		return Optional.ofNullable(this.parentStore);
 	}
@@ -462,7 +461,7 @@ public final class NamespacedHierarchicalStore<N> implements AutoCloseable {
 	@FunctionalInterface
 	public interface CloseAction<N> {
 
-		@API(status = EXPERIMENTAL, since = "1.13")
+		@API(status = MAINTAINED, since = "1.13.3")
 		static <N> CloseAction<N> closeAutoCloseables() {
 			return (__, ___, value) -> {
 				if (value instanceof AutoCloseable) {

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/store/NamespacedHierarchicalStoreException.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/store/NamespacedHierarchicalStoreException.java
@@ -10,7 +10,7 @@
 
 package org.junit.platform.engine.support.store;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import org.apiguardian.api.API;
 import org.junit.platform.commons.JUnitException;
@@ -20,7 +20,7 @@ import org.junit.platform.commons.JUnitException;
  *
  * @since 1.10
  */
-@API(status = EXPERIMENTAL, since = "1.10")
+@API(status = MAINTAINED, since = "1.13.3")
 public class NamespacedHierarchicalStoreException extends JUnitException {
 
 	private static final long serialVersionUID = 1L;

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/LauncherConstants.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/LauncherConstants.java
@@ -11,6 +11,7 @@
 package org.junit.platform.launcher;
 
 import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import org.apiguardian.api.API;
@@ -162,7 +163,7 @@ public class LauncherConstants {
 	 *
 	 * @see LauncherInterceptor
 	 */
-	@API(status = EXPERIMENTAL, since = "1.10")
+	@API(status = MAINTAINED, since = "1.13.3")
 	public static final String ENABLE_LAUNCHER_INTERCEPTORS = "junit.platform.launcher.interceptors.enabled";
 
 	/**
@@ -178,7 +179,7 @@ public class LauncherConstants {
 	 *
 	 * <p>Value must be either {@code true} or {@code false}; defaults to {@code false}.
 	 */
-	@API(status = EXPERIMENTAL, since = "1.10")
+	@API(status = MAINTAINED, since = "1.13.3")
 	public static final String DRY_RUN_PROPERTY_NAME = "junit.platform.execution.dryRun.enabled";
 
 	/**
@@ -188,7 +189,7 @@ public class LauncherConstants {
 	 *
 	 * @see org.junit.platform.launcher.core.EngineExecutionOrchestrator
 	 */
-	@API(status = EXPERIMENTAL, since = "1.10")
+	@API(status = MAINTAINED, since = "1.13.3")
 	public static final String STACKTRACE_PRUNING_ENABLED_PROPERTY_NAME = "junit.platform.stacktrace.pruning.enabled";
 
 	/**
@@ -202,7 +203,7 @@ public class LauncherConstants {
 	 * @see #OUTPUT_DIR_UNIQUE_NUMBER_PLACEHOLDER
 	 * @see org.junit.platform.engine.reporting.OutputDirectoryProvider
 	 */
-	@API(status = EXPERIMENTAL, since = "1.12")
+	@API(status = MAINTAINED, since = "1.13.3")
 	public static final String OUTPUT_DIR_PROPERTY_NAME = "junit.platform.reporting.output.dir";
 
 	/**
@@ -216,7 +217,7 @@ public class LauncherConstants {
 	 * @since 1.12
 	 * @see #OUTPUT_DIR_PROPERTY_NAME
 	 */
-	@API(status = EXPERIMENTAL, since = "1.12")
+	@API(status = MAINTAINED, since = "1.13.3")
 	public static final String OUTPUT_DIR_UNIQUE_NUMBER_PLACEHOLDER = "{uniqueNumber}";
 
 	/**

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/LauncherConstants.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/LauncherConstants.java
@@ -10,7 +10,6 @@
 
 package org.junit.platform.launcher;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
 
@@ -243,7 +242,7 @@ public class LauncherConstants {
 	 * @since 1.13
 	 * @see org.junit.platform.engine.DiscoveryIssue.Severity
 	 */
-	@API(status = EXPERIMENTAL, since = "1.13")
+	@API(status = MAINTAINED, since = "1.13.3")
 	public static final String CRITICAL_DISCOVERY_ISSUE_SEVERITY_PROPERTY_NAME = "junit.platform.discovery.issue.severity.critical";
 
 	/**
@@ -264,7 +263,7 @@ public class LauncherConstants {
 	 * @since 1.13
 	 * @see #CRITICAL_DISCOVERY_ISSUE_SEVERITY_PROPERTY_NAME
 	 */
-	@API(status = EXPERIMENTAL, since = "1.13")
+	@API(status = MAINTAINED, since = "1.13.3")
 	public static final String DISCOVERY_ISSUE_FAILURE_PHASE_PROPERTY_NAME = "junit.platform.discovery.issue.failure.phase";
 
 	private LauncherConstants() {

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/LauncherInterceptor.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/LauncherInterceptor.java
@@ -10,7 +10,7 @@
 
 package org.junit.platform.launcher;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import org.apiguardian.api.API;
 
@@ -52,7 +52,7 @@ import org.apiguardian.api.API;
  * @see LauncherSession
  * @see LauncherConstants#ENABLE_LAUNCHER_INTERCEPTORS
  */
-@API(status = EXPERIMENTAL, since = "1.10")
+@API(status = MAINTAINED, since = "1.13.3")
 public interface LauncherInterceptor {
 
 	/**

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/LauncherSession.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/LauncherSession.java
@@ -10,7 +10,7 @@
 
 package org.junit.platform.launcher;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import org.apiguardian.api.API;
@@ -62,7 +62,7 @@ public interface LauncherSession extends AutoCloseable {
 	 * @since 1.13
 	 * @see NamespacedHierarchicalStore
 	 */
-	@API(status = EXPERIMENTAL, since = "1.13")
+	@API(status = MAINTAINED, since = "1.13.3")
 	NamespacedHierarchicalStore<Namespace> getStore();
 
 }

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/MethodFilter.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/MethodFilter.java
@@ -10,7 +10,7 @@
 
 package org.junit.platform.launcher;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import java.lang.reflect.Method;
 import java.util.List;
@@ -25,7 +25,7 @@ import org.apiguardian.api.API;
  * @see #includeMethodNamePatterns(String...)
  * @see #excludeMethodNamePatterns(String...)
  */
-@API(status = EXPERIMENTAL, since = "1.12")
+@API(status = MAINTAINED, since = "1.13.3")
 public interface MethodFilter extends PostDiscoveryFilter {
 
 	/**

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestExecutionListener.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestExecutionListener.java
@@ -10,7 +10,7 @@
 
 package org.junit.platform.launcher;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import org.apiguardian.api.API;
@@ -195,7 +195,7 @@ public interface TestExecutionListener {
 	 * @param testIdentifier describes the test or container to which the entry pertains
 	 * @param file the published {@code FileEntry}
 	 */
-	@API(status = EXPERIMENTAL, since = "1.12")
+	@API(status = MAINTAINED, since = "1.13.3")
 	default void fileEntryPublished(TestIdentifier testIdentifier, FileEntry file) {
 	}
 }

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestPlan.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestPlan.java
@@ -14,7 +14,6 @@ import static java.util.Collections.emptySet;
 import static java.util.Collections.synchronizedSet;
 import static java.util.Collections.unmodifiableSet;
 import static org.apiguardian.api.API.Status.DEPRECATED;
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.INTERNAL;
 import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
@@ -300,7 +299,7 @@ public class TestPlan {
 	 * @return the output directory provider; never {@code null}
 	 * @since 1.12
 	 */
-	@API(status = EXPERIMENTAL, since = "1.12")
+	@API(status = MAINTAINED, since = "1.13.3")
 	public OutputDirectoryProvider getOutputDirectoryProvider() {
 		return this.outputDirectoryProvider;
 	}
@@ -312,7 +311,7 @@ public class TestPlan {
 	 * @param visitor the visitor to accept; never {@code null}
 	 * @since 1.10
 	 */
-	@API(status = EXPERIMENTAL, since = "1.10")
+	@API(status = MAINTAINED, since = "1.13.3")
 	public void accept(Visitor visitor) {
 		getRoots().forEach(it -> accept(visitor, it));
 	}
@@ -333,7 +332,7 @@ public class TestPlan {
 	 *
 	 * @since 1.10
 	 */
-	@API(status = EXPERIMENTAL, since = "1.10")
+	@API(status = MAINTAINED, since = "1.13.3")
 	public interface Visitor {
 
 		/**

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DiscoveryIssueException.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DiscoveryIssueException.java
@@ -10,7 +10,7 @@
 
 package org.junit.platform.launcher.core;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import org.apiguardian.api.API;
 import org.junit.platform.commons.JUnitException;
@@ -21,7 +21,7 @@ import org.junit.platform.commons.JUnitException;
  *
  * @since 1.13
  */
-@API(status = EXPERIMENTAL, since = "1.13")
+@API(status = MAINTAINED, since = "1.13.3")
 public class DiscoveryIssueException extends JUnitException {
 
 	private static final long serialVersionUID = 1L;

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherDiscoveryRequestBuilder.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherDiscoveryRequestBuilder.java
@@ -11,7 +11,7 @@
 package org.junit.platform.launcher.core;
 
 import static org.apiguardian.api.API.Status.DEPRECATED;
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
 import static org.junit.platform.launcher.LauncherConstants.OUTPUT_DIR_PROPERTY_NAME;
 
@@ -302,7 +302,7 @@ public final class LauncherDiscoveryRequestBuilder {
 	 * @see OutputDirectoryProvider
 	 * @see LauncherConstants#OUTPUT_DIR_PROPERTY_NAME
 	 */
-	@API(status = EXPERIMENTAL, since = "1.12")
+	@API(status = MAINTAINED, since = "1.13.3")
 	public LauncherDiscoveryRequestBuilder outputDirectoryProvider(OutputDirectoryProvider outputDirectoryProvider) {
 		this.outputDirectoryProvider = Preconditions.notNull(outputDirectoryProvider,
 			"outputDirectoryProvider must not be null");

--- a/junit-platform-reporting/src/main/java/org/junit/platform/reporting/open/xml/OpenTestReportGeneratingListener.java
+++ b/junit-platform-reporting/src/main/java/org/junit/platform/reporting/open/xml/OpenTestReportGeneratingListener.java
@@ -10,7 +10,7 @@
 
 package org.junit.platform.reporting.open.xml;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.junit.platform.commons.util.StringUtils.isNotBlank;
 import static org.junit.platform.launcher.LauncherConstants.STDERR_REPORT_ENTRY_KEY;
 import static org.junit.platform.launcher.LauncherConstants.STDOUT_REPORT_ENTRY_KEY;
@@ -96,7 +96,7 @@ import org.opentest4j.reporting.schema.Namespace;
  *
  * @since 1.9
  */
-@API(status = EXPERIMENTAL, since = "1.9")
+@API(status = MAINTAINED, since = "1.13.3")
 public class OpenTestReportGeneratingListener implements TestExecutionListener {
 
 	static final String ENABLED_PROPERTY_NAME = "junit.platform.reporting.open.xml.enabled";

--- a/junit-platform-suite-api/src/main/java/org/junit/platform/suite/api/AfterSuite.java
+++ b/junit-platform-suite-api/src/main/java/org/junit/platform/suite/api/AfterSuite.java
@@ -10,7 +10,7 @@
 
 package org.junit.platform.suite.api;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
@@ -70,6 +70,6 @@ import org.apiguardian.api.API;
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-@API(status = EXPERIMENTAL, since = "1.11")
+@API(status = MAINTAINED, since = "1.13.3")
 public @interface AfterSuite {
 }

--- a/junit-platform-suite-api/src/main/java/org/junit/platform/suite/api/BeforeSuite.java
+++ b/junit-platform-suite-api/src/main/java/org/junit/platform/suite/api/BeforeSuite.java
@@ -10,7 +10,7 @@
 
 package org.junit.platform.suite.api;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
@@ -70,6 +70,6 @@ import org.apiguardian.api.API;
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-@API(status = EXPERIMENTAL, since = "1.11")
+@API(status = MAINTAINED, since = "1.13.3")
 public @interface BeforeSuite {
 }

--- a/junit-platform-suite-api/src/main/java/org/junit/platform/suite/api/ConfigurationParametersResource.java
+++ b/junit-platform-suite-api/src/main/java/org/junit/platform/suite/api/ConfigurationParametersResource.java
@@ -10,7 +10,7 @@
 
 package org.junit.platform.suite.api;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
@@ -39,7 +39,7 @@ import org.apiguardian.api.API;
 @Target(ElementType.TYPE)
 @Inherited
 @Documented
-@API(status = EXPERIMENTAL, since = "1.11")
+@API(status = MAINTAINED, since = "1.13.3")
 @Repeatable(ConfigurationParametersResources.class)
 public @interface ConfigurationParametersResource {
 

--- a/junit-platform-suite-api/src/main/java/org/junit/platform/suite/api/ConfigurationParametersResources.java
+++ b/junit-platform-suite-api/src/main/java/org/junit/platform/suite/api/ConfigurationParametersResources.java
@@ -10,7 +10,7 @@
 
 package org.junit.platform.suite.api;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
@@ -36,7 +36,7 @@ import org.apiguardian.api.API;
 @Target(ElementType.TYPE)
 @Inherited
 @Documented
-@API(status = EXPERIMENTAL, since = "1.11")
+@API(status = MAINTAINED, since = "1.13.3")
 public @interface ConfigurationParametersResources {
 
 	/**

--- a/junit-platform-suite-api/src/main/java/org/junit/platform/suite/api/Select.java
+++ b/junit-platform-suite-api/src/main/java/org/junit/platform/suite/api/Select.java
@@ -10,7 +10,7 @@
 
 package org.junit.platform.suite.api;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
@@ -35,7 +35,7 @@ import org.apiguardian.api.API;
 @Target(ElementType.TYPE)
 @Inherited
 @Documented
-@API(status = EXPERIMENTAL, since = "1.11")
+@API(status = MAINTAINED, since = "1.13.3")
 @Repeatable(Selects.class)
 public @interface Select {
 

--- a/junit-platform-suite-api/src/main/java/org/junit/platform/suite/api/SelectClasses.java
+++ b/junit-platform-suite-api/src/main/java/org/junit/platform/suite/api/SelectClasses.java
@@ -10,7 +10,6 @@
 
 package org.junit.platform.suite.api;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import java.lang.annotation.Documented;
@@ -57,7 +56,7 @@ public @interface SelectClasses {
 	 *
 	 * @since 1.10
 	 */
-	@API(status = EXPERIMENTAL, since = "1.10")
+	@API(status = MAINTAINED, since = "1.13.3")
 	String[] names() default {};
 
 }

--- a/junit-platform-suite-api/src/main/java/org/junit/platform/suite/api/SelectMethod.java
+++ b/junit-platform-suite-api/src/main/java/org/junit/platform/suite/api/SelectMethod.java
@@ -10,7 +10,7 @@
 
 package org.junit.platform.suite.api;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
@@ -40,7 +40,7 @@ import org.apiguardian.api.API;
 @Target(ElementType.TYPE)
 @Inherited
 @Documented
-@API(status = EXPERIMENTAL, since = "1.10")
+@API(status = MAINTAINED, since = "1.13.3")
 @Repeatable(SelectMethods.class)
 public @interface SelectMethod {
 

--- a/junit-platform-suite-api/src/main/java/org/junit/platform/suite/api/SelectMethods.java
+++ b/junit-platform-suite-api/src/main/java/org/junit/platform/suite/api/SelectMethods.java
@@ -10,7 +10,7 @@
 
 package org.junit.platform.suite.api;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
@@ -36,7 +36,7 @@ import org.apiguardian.api.API;
 @Target(ElementType.TYPE)
 @Inherited
 @Documented
-@API(status = EXPERIMENTAL, since = "1.10")
+@API(status = MAINTAINED, since = "1.13.3")
 public @interface SelectMethods {
 
 	/**

--- a/junit-platform-suite-api/src/main/java/org/junit/platform/suite/api/Selects.java
+++ b/junit-platform-suite-api/src/main/java/org/junit/platform/suite/api/Selects.java
@@ -10,7 +10,7 @@
 
 package org.junit.platform.suite.api;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
@@ -36,7 +36,7 @@ import org.apiguardian.api.API;
 @Target(ElementType.TYPE)
 @Inherited
 @Documented
-@API(status = EXPERIMENTAL, since = "1.11")
+@API(status = MAINTAINED, since = "1.13.3")
 public @interface Selects {
 
 	/**

--- a/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/EngineDiscoveryResults.java
+++ b/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/EngineDiscoveryResults.java
@@ -11,7 +11,7 @@
 package org.junit.platform.testkit.engine;
 
 import static java.util.Collections.unmodifiableList;
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import java.util.List;
 
@@ -28,7 +28,7 @@ import org.junit.platform.engine.TestDescriptor;
  *
  * @since 1.13
  */
-@API(status = EXPERIMENTAL, since = "1.13")
+@API(status = MAINTAINED, since = "1.13.3")
 public class EngineDiscoveryResults {
 
 	private final TestDescriptor engineDescriptor;

--- a/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/EngineTestKit.java
+++ b/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/EngineTestKit.java
@@ -531,7 +531,7 @@ public final class EngineTestKit {
 		 * @since 1.12
 		 * @see OutputDirectoryProvider
 		 */
-		@API(status = EXPERIMENTAL, since = "1.12")
+		@API(status = MAINTAINED, since = "1.13.3")
 		public Builder outputDirectoryProvider(OutputDirectoryProvider outputDirectoryProvider) {
 			this.requestBuilder.outputDirectoryProvider(outputDirectoryProvider);
 			return this;

--- a/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/EngineTestKit.java
+++ b/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/EngineTestKit.java
@@ -13,7 +13,6 @@ package org.junit.platform.testkit.engine;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
 import static org.apiguardian.api.API.Status.DEPRECATED;
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
 import static org.junit.platform.engine.support.store.NamespacedHierarchicalStore.CloseAction.closeAutoCloseables;
@@ -159,7 +158,7 @@ public final class EngineTestKit {
 	 * @see #engine(String)
 	 * @see #engine(TestEngine)
 	 */
-	@API(status = EXPERIMENTAL, since = "1.13")
+	@API(status = MAINTAINED, since = "1.13.3")
 	public static EngineDiscoveryResults discover(String engineId, LauncherDiscoveryRequest discoveryRequest) {
 		Preconditions.notBlank(engineId, "TestEngine ID must not be null or blank");
 		return discover(loadTestEngine(engineId.trim()), discoveryRequest);
@@ -184,7 +183,7 @@ public final class EngineTestKit {
 	 * @see #engine(String)
 	 * @see #engine(TestEngine)
 	 */
-	@API(status = EXPERIMENTAL, since = "1.13")
+	@API(status = MAINTAINED, since = "1.13.3")
 	public static EngineDiscoveryResults discover(TestEngine testEngine, LauncherDiscoveryRequest discoveryRequest) {
 		Preconditions.notNull(testEngine, "TestEngine must not be null");
 		Preconditions.notNull(discoveryRequest, "EngineDiscoveryRequest must not be null");
@@ -550,7 +549,7 @@ public final class EngineTestKit {
 		 * @see #configurationParameter(String, String)
 		 * @see #configurationParameters(Map)
 		 */
-		@API(status = EXPERIMENTAL, since = "1.13")
+		@API(status = MAINTAINED, since = "1.13.3")
 		public EngineDiscoveryResults discover() {
 			LauncherDiscoveryRequest request = this.requestBuilder.build();
 			return EngineTestKit.discover(this.testEngine, request);

--- a/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/Event.java
+++ b/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/Event.java
@@ -10,7 +10,6 @@
 
 package org.junit.platform.testkit.engine;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.junit.platform.commons.util.FunctionUtils.where;
 
@@ -64,7 +63,7 @@ public class Event {
 	 * @since 1.12
 	 * @see EventType#FILE_ENTRY_PUBLISHED
 	 */
-	@API(status = EXPERIMENTAL, since = "1.12")
+	@API(status = MAINTAINED, since = "1.13.3")
 	public static Event fileEntryPublished(TestDescriptor testDescriptor, FileEntry file) {
 		Preconditions.notNull(file, "FileEntry must not be null");
 		return new Event(EventType.FILE_ENTRY_PUBLISHED, testDescriptor, file);

--- a/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/EventConditions.java
+++ b/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/EventConditions.java
@@ -12,7 +12,6 @@ package org.junit.platform.testkit.engine;
 
 import static java.util.function.Predicate.isEqual;
 import static java.util.stream.Collectors.toList;
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
 import static org.assertj.core.api.Assertions.allOf;
@@ -257,7 +256,7 @@ public final class EventConditions {
 	 *
 	 * @since 1.13
 	 */
-	@API(status = EXPERIMENTAL, since = "1.13")
+	@API(status = MAINTAINED, since = "1.13.3")
 	public static Condition<Event> uniqueId(String uniqueId) {
 		return uniqueId(UniqueId.parse(uniqueId));
 	}
@@ -270,7 +269,7 @@ public final class EventConditions {
 	 *
 	 * @since 1.13
 	 */
-	@API(status = EXPERIMENTAL, since = "1.13")
+	@API(status = MAINTAINED, since = "1.13.3")
 	public static Condition<Event> uniqueId(UniqueId uniqueId) {
 		return uniqueId(new Condition<>(isEqual(uniqueId), "equal to '%s'", uniqueId));
 	}
@@ -298,7 +297,7 @@ public final class EventConditions {
 	 *
 	 * @since 1.13
 	 */
-	@API(status = EXPERIMENTAL, since = "1.13")
+	@API(status = MAINTAINED, since = "1.13.3")
 	public static Condition<Event> uniqueId(Condition<? super UniqueId> condition) {
 		return new Condition<>(byTestDescriptor(where(TestDescriptor::getUniqueId, condition::matches)),
 			"descriptor with uniqueId %s", condition.description().value());
@@ -360,7 +359,7 @@ public final class EventConditions {
 	 *
 	 * @since 1.13
 	 */
-	@API(status = EXPERIMENTAL, since = "1.13")
+	@API(status = MAINTAINED, since = "1.13.3")
 	public static Condition<Event> legacyReportingName(String legacyReportingName) {
 		return new Condition<>(
 			byTestDescriptor(where(TestDescriptor::getLegacyReportingName, isEqual(legacyReportingName))),

--- a/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/EventConditions.java
+++ b/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/EventConditions.java
@@ -532,7 +532,7 @@ public final class EventConditions {
 	 *
 	 * @since 1.12
 	 */
-	@API(status = EXPERIMENTAL, since = "1.12")
+	@API(status = MAINTAINED, since = "1.13.3")
 	public static Condition<Event> fileEntry(Predicate<FileEntry> predicate) {
 		return new Condition<>(byPayload(FileEntry.class, predicate), "event for file entry with custom predicate");
 	}

--- a/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/EventStatistics.java
+++ b/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/EventStatistics.java
@@ -10,7 +10,6 @@
 
 package org.junit.platform.testkit.engine;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.junit.platform.testkit.engine.Assertions.assertEquals;
 
@@ -135,7 +134,7 @@ public class EventStatistics {
 	 * @return this {@code EventStatistics} for method chaining
 	 * @since 1.12
 	 */
-	@API(status = EXPERIMENTAL, since = "1.12")
+	@API(status = MAINTAINED, since = "1.13.3")
 	public EventStatistics fileEntryPublished(long expected) {
 		this.executables.add(
 			() -> assertEquals(expected, this.events.fileEntryPublished().count(), "file entry published"));

--- a/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/EventType.java
+++ b/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/EventType.java
@@ -10,7 +10,6 @@
 
 package org.junit.platform.testkit.engine;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import org.apiguardian.api.API;
@@ -70,7 +69,7 @@ public enum EventType {
 	 * @since 1.12
 	 * @see org.junit.platform.engine.EngineExecutionListener#fileEntryPublished(TestDescriptor, FileEntry)
 	 */
-	@API(status = EXPERIMENTAL, since = "1.12")
+	@API(status = MAINTAINED, since = "1.13.3")
 	FILE_ENTRY_PUBLISHED
 
 }

--- a/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/Events.java
+++ b/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/Events.java
@@ -13,7 +13,6 @@ package org.junit.platform.testkit.engine;
 import static java.util.Collections.sort;
 import static java.util.function.Predicate.isEqual;
 import static java.util.stream.Collectors.toList;
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.junit.platform.commons.util.FunctionUtils.where;
 import static org.junit.platform.testkit.engine.Event.byPayload;
@@ -215,7 +214,7 @@ public final class Events {
 	 * @return the filtered {@code Events}; never {@code null}
 	 * @since 1.12
 	 */
-	@API(status = EXPERIMENTAL, since = "1.12")
+	@API(status = MAINTAINED, since = "1.13.3")
 	public Events fileEntryPublished() {
 		return new Events(eventsByType(EventType.FILE_ENTRY_PUBLISHED), this.category + " File Entry Published");
 	}

--- a/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/ExecutionRecorder.java
+++ b/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/ExecutionRecorder.java
@@ -10,7 +10,6 @@
 
 package org.junit.platform.testkit.engine;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import java.util.List;
@@ -89,7 +88,7 @@ public class ExecutionRecorder implements EngineExecutionListener {
 	 *
 	 * @since 1.12
 	 */
-	@API(status = EXPERIMENTAL, since = "1.12")
+	@API(status = MAINTAINED, since = "1.13.3")
 	@Override
 	public void fileEntryPublished(TestDescriptor testDescriptor, FileEntry file) {
 		this.events.add(Event.fileEntryPublished(testDescriptor, file));

--- a/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/TestExecutionResultConditions.java
+++ b/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/TestExecutionResultConditions.java
@@ -12,7 +12,6 @@ package org.junit.platform.testkit.engine;
 
 import static java.util.function.Predicate.isEqual;
 import static java.util.stream.Collectors.toList;
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.junit.platform.commons.util.FunctionUtils.where;
 
@@ -95,7 +94,7 @@ public final class TestExecutionResultConditions {
 	 * @see #cause(Condition...)
 	 * @see #suppressed(int, Condition...)
 	 */
-	@API(status = EXPERIMENTAL, since = "1.11")
+	@API(status = MAINTAINED, since = "1.13.3")
 	@SafeVarargs
 	@SuppressWarnings("varargs")
 	public static Condition<Throwable> rootCause(Condition<Throwable>... conditions) {

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/Constants.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/Constants.java
@@ -10,7 +10,7 @@
 
 package org.junit.vintage.engine;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import org.apiguardian.api.API;
@@ -31,7 +31,7 @@ public final class Constants {
 	 *
 	 * @since 5.12
 	 */
-	@API(status = EXPERIMENTAL, since = "5.12")
+	@API(status = MAINTAINED, since = "5.13.3")
 	public static final String PARALLEL_EXECUTION_ENABLED = "junit.vintage.execution.parallel.enabled";
 
 	/**
@@ -43,7 +43,7 @@ public final class Constants {
 	 *
 	 * @since 5.12
 	 */
-	@API(status = EXPERIMENTAL, since = "5.12")
+	@API(status = MAINTAINED, since = "5.13.3")
 	public static final String PARALLEL_POOL_SIZE = "junit.vintage.execution.parallel.pool-size";
 
 	/**
@@ -55,7 +55,7 @@ public final class Constants {
 	 *
 	 * @since 5.12
 	 */
-	@API(status = EXPERIMENTAL, since = "5.12")
+	@API(status = MAINTAINED, since = "5.13.3")
 	public static final String PARALLEL_CLASS_EXECUTION = "junit.vintage.execution.parallel.classes";
 
 	/**
@@ -67,7 +67,7 @@ public final class Constants {
 	 *
 	 * @since 5.12
 	 */
-	@API(status = EXPERIMENTAL, since = "5.12")
+	@API(status = MAINTAINED, since = "5.13.3")
 	public static final String PARALLEL_METHOD_EXECUTION = "junit.vintage.execution.parallel.methods";
 
 	private Constants() {


### PR DESCRIPTION
## Overview

- **Promote experimental APIs introduced in 5.12 and earlier to "maintained"**
- **Promote experimental APIs introduced in 5.13 to "maintained"**
- **Add note about absence of annotated APIs in case there are none**

Resolves #4685.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://docs.junit.org/snapshot/user-guide/) and [Release Notes](https://docs.junit.org/snapshot/user-guide/#release-notes)
