### PR TITLE
`@Csv\{File}Source`: document that extra chars after closing quote are no longer allowed

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-6.0.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-6.0.0-M1.adoc
@@ -120,6 +120,10 @@ repository on GitHub.
 * Attributes such as `ignoreLeadingAndTrailingWhitespace`, `nullValues`, and others in
   `@CsvSource` and `@CsvFileSource` now apply to header fields as well as to regular
   fields.
+* Extra characters after a closing quote are no longer allowed in `@CsvSource` and
+  `@CsvFileSource`. For example, if a single quote is used as the quote character,
+  the following CSV value `'foo'INVALID,'bar'` will now cause an exception to be thrown.
+  This helps ensure that malformed input is not silently accepted or misinterpreted.
 * The `junit-jupiter-migrationsupport` artifact and its contained classes are now
   deprecated and will be removed in the next major version.
 * The type bounds of the following methods have been changed to be more flexible and allow


### PR DESCRIPTION
## Overview

https://github.com/junit-team/junit-framework/issues/4693

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://docs.junit.org/snapshot/user-guide/) and [Release Notes](https://docs.junit.org/snapshot/user-guide/#release-notes)
