### PR TITLE
Support `@Nullable` reasons in `ConditionEvaluationResult` APIs

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-6.0.0-M2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-6.0.0-M2.adoc
@@ -22,7 +22,7 @@ repository on GitHub.
 ==== Deprecations and Breaking Changes
 
 * Discontinue `junit-platform-suite-commons` which is now integrated into
-  `junit-platform-suite`
+  `junit-platform-suite`.
 
 [[release-notes-6.0.0-M2-junit-platform-new-features-and-improvements]]
 ==== New Features and Improvements
@@ -47,7 +47,8 @@ repository on GitHub.
 [[release-notes-6.0.0-M2-junit-jupiter-new-features-and-improvements]]
 ==== New Features and Improvements
 
-* ❓
+* Reason strings supplied to `ConditionEvaluationResult` APIs are now officially declared
+  as `@Nullable`.
 
 
 [[release-notes-6.0.0-M2-junit-vintage]]

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ConditionEvaluationResult.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ConditionEvaluationResult.java
@@ -15,6 +15,7 @@ import static org.apiguardian.api.API.Status.STABLE;
 import java.util.Optional;
 
 import org.apiguardian.api.API;
+import org.jspecify.annotations.Nullable;
 import org.junit.platform.commons.util.StringUtils;
 import org.junit.platform.commons.util.ToStringBuilder;
 
@@ -35,7 +36,7 @@ public class ConditionEvaluationResult {
 	 * or an <em>empty</em> reason if the reason is unknown
 	 * @see StringUtils#isBlank(String)
 	 */
-	public static ConditionEvaluationResult enabled(String reason) {
+	public static ConditionEvaluationResult enabled(@Nullable String reason) {
 		return new ConditionEvaluationResult(true, reason);
 	}
 
@@ -48,7 +49,7 @@ public class ConditionEvaluationResult {
 	 * or an <em>empty</em> reason if the reason is unknown
 	 * @see StringUtils#isBlank(String)
 	 */
-	public static ConditionEvaluationResult disabled(String reason) {
+	public static ConditionEvaluationResult disabled(@Nullable String reason) {
 		return new ConditionEvaluationResult(false, reason);
 	}
 
@@ -69,7 +70,8 @@ public class ConditionEvaluationResult {
 	 * @see StringUtils#isBlank(String)
 	 */
 	@API(status = STABLE, since = "5.7")
-	public static ConditionEvaluationResult disabled(String reason, String customReason) {
+	@SuppressWarnings("NullAway") // StringUtils.isBlank() does not yet have a nullability @Contract
+	public static ConditionEvaluationResult disabled(@Nullable String reason, @Nullable String customReason) {
 		if (StringUtils.isBlank(reason)) {
 			return disabled(customReason);
 		}
@@ -84,7 +86,7 @@ public class ConditionEvaluationResult {
 	private final Optional<String> reason;
 
 	@SuppressWarnings("NullAway") // StringUtils.isNotBlank() does not yet have a nullability @Contract
-	private ConditionEvaluationResult(boolean enabled, String reason) {
+	private ConditionEvaluationResult(boolean enabled, @Nullable String reason) {
 		this.enabled = enabled;
 		this.reason = StringUtils.isNotBlank(reason) ? Optional.of(reason.strip()) : Optional.empty();
 	}

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/condition/ConditionEvaluationResultTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/condition/ConditionEvaluationResultTests.java
@@ -41,7 +41,6 @@ class ConditionEvaluationResultTests {
 
 	@BlankReasonsTest
 	void enabledWithBlankReason(@Nullable String reason) {
-		@SuppressWarnings("NullAway")
 		var result = ConditionEvaluationResult.enabled(reason);
 
 		assertThat(result.isDisabled()).isFalse();
@@ -62,7 +61,6 @@ class ConditionEvaluationResultTests {
 
 	@BlankReasonsTest
 	void disabledWithBlankDefaultReason(@Nullable String reason) {
-		@SuppressWarnings("NullAway")
 		var result = ConditionEvaluationResult.disabled(reason);
 
 		assertThat(result.isDisabled()).isTrue();
@@ -73,7 +71,6 @@ class ConditionEvaluationResultTests {
 
 	@BlankReasonsTest
 	void disabledWithDefaultReasonAndBlankCustomReason(@Nullable String customReason) {
-		@SuppressWarnings("NullAway")
 		var result = ConditionEvaluationResult.disabled("default", customReason);
 
 		assertThat(result.isDisabled()).isTrue();
@@ -84,7 +81,6 @@ class ConditionEvaluationResultTests {
 
 	@BlankReasonsTest
 	void disabledWithBlankDefaultReasonAndCustomReason(@Nullable String reason) {
-		@SuppressWarnings("NullAway")
 		var result = ConditionEvaluationResult.disabled(reason, "custom");
 
 		assertThat(result.isDisabled()).isTrue();
@@ -95,7 +91,6 @@ class ConditionEvaluationResultTests {
 	@BlankReasonsTest
 	void disabledWithBlankDefaultReasonAndBlankCustomReason(@Nullable String reason) {
 		// We intentionally use the reason as both the default and custom reason.
-		@SuppressWarnings("NullAway")
 		var result = ConditionEvaluationResult.disabled(reason, reason);
 
 		assertThat(result.isDisabled()).isTrue();


### PR DESCRIPTION
## Overview

This PR addresses the issues raised in #4698 by annotating all "reason" parameters with `@Nullable`.

## Related Issues

- #4698
- #4715 
