### PR TITLE
apply `spotlessApply` on dev environment

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,18 +76,23 @@ Whenever an acronym is included as part of a field name or parameter name:
 
 #### Code
 
-Code formatting is enforced using the [Spotless](https://github.com/diffplug/spotless)
-Gradle plugin. You can use `gradle spotlessApply` to format new code and add missing
-license headers to source files. Formatter and import order settings for Eclipse are
-available in the repository under
-[junit-eclipse-formatter-settings.xml](gradle/config/eclipse/junit-eclipse-formatter-settings.xml)
-and [junit-eclipse.importorder](gradle/config/eclipse/junit-eclipse.importorder),
-respectively. For IntelliJ IDEA there's a
-[plugin](https://plugins.jetbrains.com/plugin/6546) you can use in conjunction with the
-Eclipse settings.
+Code formatting is automatically enforced using the [Spotless](https://github.com/diffplug/spotless) Gradle plugin during the build process. The build will:
 
-It is forbidden to use _wildcard imports_ (e.g., `import static org.junit.jupiter.api.Assertions.*;`)
-in Java code.
+- Automatically format all code
+- Add missing license headers
+- Correct import order
+- Fix other style issues
+
+You can run the plugin goal `gradle spotlessApply` to apply formation.
+Nevertheless, that´s not required, as the build handles everything automatically.
+
+IDE configuration is available for consistency:
+- **Eclipse**: Use our predefined settings:
+  - [Formatter config](gradle/config/eclipse/junit-eclipse-formatter-settings.xml)
+  - [Import order](gradle/config/eclipse/junit-eclipse.importorder)
+- **IntelliJ**: Install the [Eclipse Code Formatter plugin](https://plugins.jetbrains.com/plugin/6546) with our settings
+
+**Important**: Wildcard imports (e.g., `import static org.junit.jupiter.api.Assertions.*;`) remain strictly forbidden.
 
 #### Documentation
 

--- a/gradle/plugins/common/src/main/kotlin/junitbuild.spotless-conventions.gradle.kts
+++ b/gradle/plugins/common/src/main/kotlin/junitbuild.spotless-conventions.gradle.kts
@@ -86,4 +86,10 @@ tasks {
 	named("spotlessMisc") {
 		outputs.doNotCacheIf("negative avoidance savings") { true }
 	}
+	if (System.getenv("CI") == null) {
+		named("spotlessCheck") {
+			dependsOn("spotlessApply")
+			mustRunAfter("spotlessApply")
+		}
+	}
 }


### PR DESCRIPTION
## Overview


if there is the glance of autofix why not automatically apply it. Might be worth to save time, just as quarkus, maven and PMD have done their setup that way. 

Currently its breaking the build for whitespaces having to run some random command (`spotlessApply`) to fix.

have (break build):

<img width="1466" alt="image" src="https://github.com/user-attachments/assets/6f3ec9c8-5d78-4feb-b02a-6f6326737f51" />






want (fix build):


<img width="1314" alt="image" src="https://github.com/user-attachments/assets/6ac06853-ae3c-43f3-918e-84636ccc5752" />

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://docs.junit.org/snapshot/user-guide/) and [Release Notes](https://docs.junit.org/snapshot/user-guide/#release-notes)
