### PR TITLE
Create .jitpack.yml

### DIFF
--- a/.jitpack.yml
+++ b/.jitpack.yml
@@ -1,0 +1,6 @@
+before_install:
+  - sdk install java 24-open
+  - sdk use java 24-open
+install:
+  - ./gradlew --version
+  - ./gradlew publishToMavenLocal -x test


### PR DESCRIPTION
## Overview

Add support for building the JUnit Framwork via [JitPack](https://jitpack.io/). With JitPack now support SDKMAN to install a newer JDK before running a build, we should basically revert:
- #2815 

It seems that artifact signing is being skipped automatically, see `> Task :junit-platform-console-standalone:signMavenPublication SKIPPED` for example.


Find the associated and successful build for this PR branch at: https://jitpack.io/com/github/junit-team/junit-framework/sormuras~jitpack-643cb5102f-1/build.log

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://docs.junit.org/snapshot/user-guide/) and [Release Notes](https://docs.junit.org/snapshot/user-guide/#release-notes)
