### PR TITLE
Draft support for cancelling test execution

### DIFF
--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/CancellationToken.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/CancellationToken.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2015-2025 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.engine;
+
+import org.apiguardian.api.API;
+
+/**
+ * Token that should be checked to determine whether an operation was requested
+ * to be cancelled.
+ *
+ * <p>For example, this is used by {@link org.junit.platform.engine.TestEngine}
+ * implementations to determine whether
+ *
+ * <p>This interface is not intended to be implemented by clients.
+ *
+ * @since 6.0
+ * @see ExecutionRequest#getCancellationToken()
+ */
+@API(status = API.Status.EXPERIMENTAL, since = "6.0")
+public interface CancellationToken {
+
+	static CancellationToken create() {
+		return new DefaultCancellationToken();
+	}
+
+	boolean isCancellationRequested();
+
+	void cancel();
+
+}

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/DefaultCancellationToken.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/DefaultCancellationToken.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2015-2025 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.engine;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+class DefaultCancellationToken implements CancellationToken {
+
+	private final AtomicBoolean cancelled = new AtomicBoolean();
+
+	@Override
+	public boolean isCancellationRequested() {
+		return cancelled.get();
+	}
+
+	@Override
+	public void cancel() {
+		cancelled.set(true);
+	}
+}

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/ExecutionRequest.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/ExecutionRequest.java
@@ -43,21 +43,21 @@ public class ExecutionRequest {
 	private final TestDescriptor rootTestDescriptor;
 	private final EngineExecutionListener engineExecutionListener;
 	private final ConfigurationParameters configurationParameters;
-
 	private final @Nullable OutputDirectoryProvider outputDirectoryProvider;
-
 	private final @Nullable NamespacedHierarchicalStore<Namespace> requestLevelStore;
+	private final @Nullable CancellationToken cancellationToken;
 
 	@Deprecated
 	@API(status = DEPRECATED, since = "1.11")
 	public ExecutionRequest(TestDescriptor rootTestDescriptor, EngineExecutionListener engineExecutionListener,
 			ConfigurationParameters configurationParameters) {
-		this(rootTestDescriptor, engineExecutionListener, configurationParameters, null, null);
+		this(rootTestDescriptor, engineExecutionListener, configurationParameters, null, null, null);
 	}
 
 	private ExecutionRequest(TestDescriptor rootTestDescriptor, EngineExecutionListener engineExecutionListener,
 			ConfigurationParameters configurationParameters, @Nullable OutputDirectoryProvider outputDirectoryProvider,
-			@Nullable NamespacedHierarchicalStore<Namespace> requestLevelStore) {
+			@Nullable NamespacedHierarchicalStore<Namespace> requestLevelStore,
+			@Nullable CancellationToken cancellationToken) {
 		this.rootTestDescriptor = Preconditions.notNull(rootTestDescriptor, "rootTestDescriptor must not be null");
 		this.engineExecutionListener = Preconditions.notNull(engineExecutionListener,
 			"engineExecutionListener must not be null");
@@ -65,6 +65,7 @@ public class ExecutionRequest {
 			"configurationParameters must not be null");
 		this.outputDirectoryProvider = outputDirectoryProvider;
 		this.requestLevelStore = requestLevelStore;
+		this.cancellationToken = cancellationToken;
 	}
 
 	/**
@@ -105,11 +106,13 @@ public class ExecutionRequest {
 	@API(status = INTERNAL, since = "1.13")
 	public static ExecutionRequest create(TestDescriptor rootTestDescriptor,
 			EngineExecutionListener engineExecutionListener, ConfigurationParameters configurationParameters,
-			OutputDirectoryProvider outputDirectoryProvider, NamespacedHierarchicalStore<Namespace> requestLevelStore) {
+			OutputDirectoryProvider outputDirectoryProvider, NamespacedHierarchicalStore<Namespace> requestLevelStore,
+			CancellationToken cancellationToken) {
 
 		return new ExecutionRequest(rootTestDescriptor, engineExecutionListener, configurationParameters,
 			Preconditions.notNull(outputDirectoryProvider, "outputDirectoryProvider must not be null"),
-			Preconditions.notNull(requestLevelStore, "requestLevelStore must not be null"));
+			Preconditions.notNull(requestLevelStore, "requestLevelStore must not be null"),
+			Preconditions.notNull(cancellationToken, "cancellationToken must not be null"));
 	}
 
 	/**
@@ -169,6 +172,10 @@ public class ExecutionRequest {
 	public NamespacedHierarchicalStore<Namespace> getStore() {
 		return Preconditions.notNull(this.requestLevelStore,
 			"No NamespacedHierarchicalStore was configured for this request");
+	}
+
+	public CancellationToken getCancellationToken() {
+		return Preconditions.notNull(this.cancellationToken, "No CancellationToken was configured for this request");
 	}
 
 }

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/HierarchicalTestExecutor.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/HierarchicalTestExecutor.java
@@ -13,6 +13,7 @@ package org.junit.platform.engine.support.hierarchical;
 import java.util.concurrent.Future;
 
 import org.jspecify.annotations.Nullable;
+import org.junit.platform.engine.CancellationToken;
 import org.junit.platform.engine.EngineExecutionListener;
 import org.junit.platform.engine.ExecutionRequest;
 import org.junit.platform.engine.TestDescriptor;
@@ -51,8 +52,9 @@ class HierarchicalTestExecutor<C extends EngineExecutionContext> {
 		TestDescriptor rootTestDescriptor = this.request.getRootTestDescriptor();
 		EngineExecutionListener executionListener = this.request.getEngineExecutionListener();
 		NodeExecutionAdvisor executionAdvisor = new NodeTreeWalker().walk(rootTestDescriptor);
+		CancellationToken cancellationToken = this.request.getCancellationToken();
 		NodeTestTaskContext taskContext = new NodeTestTaskContext(executionListener, this.executorService,
-			this.throwableCollectorFactory, executionAdvisor);
+			this.throwableCollectorFactory, executionAdvisor, cancellationToken);
 		NodeTestTask<C> rootTestTask = new NodeTestTask<>(taskContext, rootTestDescriptor);
 		rootTestTask.setParentContext(this.rootContext);
 		return this.executorService.submit(rootTestTask);

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/NodeTestTaskContext.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/NodeTestTaskContext.java
@@ -10,19 +10,22 @@
 
 package org.junit.platform.engine.support.hierarchical;
 
+import org.junit.platform.engine.CancellationToken;
 import org.junit.platform.engine.EngineExecutionListener;
 
 /**
  * @since 1.3.1
  */
 record NodeTestTaskContext(EngineExecutionListener listener, HierarchicalTestExecutorService executorService,
-		ThrowableCollector.Factory throwableCollectorFactory, NodeExecutionAdvisor executionAdvisor) {
+		ThrowableCollector.Factory throwableCollectorFactory, NodeExecutionAdvisor executionAdvisor,
+		CancellationToken cancellationToken) {
 
 	NodeTestTaskContext withListener(EngineExecutionListener listener) {
 		if (this.listener == listener) {
 			return this;
 		}
-		return new NodeTestTaskContext(listener, executorService, throwableCollectorFactory, executionAdvisor);
+		return new NodeTestTaskContext(listener, executorService, throwableCollectorFactory, executionAdvisor,
+			cancellationToken);
 	}
 
 }

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/Launcher.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/Launcher.java
@@ -111,6 +111,37 @@ public interface Launcher {
 	void execute(LauncherDiscoveryRequest launcherDiscoveryRequest, TestExecutionListener... listeners);
 
 	/**
+	 * Execute a {@link TestPlan} which is built according to the supplied
+	 * {@link LauncherDiscoveryRequest} by querying all registered engines and
+	 * collecting their results, and notify
+	 * {@linkplain #registerTestExecutionListeners registered listeners} about
+	 * the progress and results of the execution.
+	 *
+	 * <p>Supplied test execution listeners are registered in addition to already
+	 * registered listeners but only for the supplied launcher discovery request.
+	 *
+	 * <p>Additionally, it's possible to request cancellation of the started
+	 * execution via the supplied {@link CancellationToken}.
+	 *
+	 * @apiNote Calling this method will cause test discovery to be executed for
+	 * all registered engines. If the same {@link LauncherDiscoveryRequest} was
+	 * previously passed to {@link #discover(LauncherDiscoveryRequest)}, you
+	 * should instead call {@link #execute(TestPlan, TestExecutionListener...)}
+	 * and pass the already acquired {@link TestPlan} to avoid the potential
+	 * performance degradation (e.g., classpath scanning) of running test
+	 * discovery twice.
+	 *
+	 * @param launcherDiscoveryRequest the launcher discovery request; never {@code null}
+	 * @param cancellationToken the token used to request cancellation of the
+	 * started execution; never {@code null}
+	 * @param listeners additional test execution listeners; never {@code null}
+	 * @since 6.0
+	 */
+	@API(status = EXPERIMENTAL, since = "6.0")
+	void execute(LauncherDiscoveryRequest launcherDiscoveryRequest, CancellationToken cancellationToken,
+			TestExecutionListener... listeners);
+
+	/**
 	 * Execute the supplied {@link TestPlan} and notify
 	 * {@linkplain #registerTestExecutionListeners registered listeners} about
 	 * the progress and results of the execution.
@@ -138,12 +169,15 @@ public interface Launcher {
 	 * already registered listeners but only for the execution of the supplied
 	 * test plan.
 	 *
-	 * <p>Additionally, it's possible to request cancellation
+	 * <p>Additionally, it's possible to request cancellation of the started
+	 * execution via the supplied {@link CancellationToken}.
 	 *
 	 * @apiNote The supplied {@link TestPlan} must not have been executed
 	 * previously.
 	 *
 	 * @param testPlan the test plan to execute; never {@code null}
+	 * @param cancellationToken the token used to request cancellation of the
+	 * started execution; never {@code null}
 	 * @param listeners additional test execution listeners; never {@code null}
 	 * @since 6.0
 	 */

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/Launcher.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/Launcher.java
@@ -10,9 +10,11 @@
 
 package org.junit.platform.launcher;
 
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import org.apiguardian.api.API;
+import org.junit.platform.engine.CancellationToken;
 
 /**
  * The {@code Launcher} API is the main entry point for client code that
@@ -126,5 +128,26 @@ public interface Launcher {
 	 */
 	@API(status = STABLE, since = "1.4")
 	void execute(TestPlan testPlan, TestExecutionListener... listeners);
+
+	/**
+	 * Execute the supplied {@link TestPlan} and notify
+	 * {@linkplain #registerTestExecutionListeners registered listeners} about
+	 * the progress and results of the execution.
+	 *
+	 * <p>Supplied test execution listeners are registered in addition to
+	 * already registered listeners but only for the execution of the supplied
+	 * test plan.
+	 *
+	 * <p>Additionally, it's possible to request cancellation
+	 *
+	 * @apiNote The supplied {@link TestPlan} must not have been executed
+	 * previously.
+	 *
+	 * @param testPlan the test plan to execute; never {@code null}
+	 * @param listeners additional test execution listeners; never {@code null}
+	 * @since 6.0
+	 */
+	@API(status = EXPERIMENTAL, since = "6.0")
+	void execute(TestPlan testPlan, CancellationToken cancellationToken, TestExecutionListener... listeners);
 
 }

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DefaultLauncher.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DefaultLauncher.java
@@ -18,6 +18,7 @@ import static org.junit.platform.launcher.core.LauncherPhase.EXECUTION;
 import java.util.Collection;
 
 import org.junit.platform.commons.util.Preconditions;
+import org.junit.platform.engine.CancellationToken;
 import org.junit.platform.engine.TestEngine;
 import org.junit.platform.engine.support.store.Namespace;
 import org.junit.platform.engine.support.store.NamespacedHierarchicalStore;
@@ -93,20 +94,27 @@ class DefaultLauncher implements Launcher {
 
 	@Override
 	public void execute(TestPlan testPlan, TestExecutionListener... listeners) {
+		execute(testPlan, CancellationToken.create(), listeners);
+	}
+
+	@Override
+	public void execute(TestPlan testPlan, CancellationToken cancellationToken, TestExecutionListener... listeners) {
 		Preconditions.notNull(testPlan, "TestPlan must not be null");
 		Preconditions.condition(testPlan instanceof InternalTestPlan, "TestPlan was not returned by this Launcher");
+		Preconditions.notNull(cancellationToken, "CancellationToken must not be null");
 		Preconditions.notNull(listeners, "TestExecutionListener array must not be null");
 		Preconditions.containsNoNullElements(listeners, "individual listeners must not be null");
-		execute((InternalTestPlan) testPlan, listeners);
+		execute((InternalTestPlan) testPlan, cancellationToken, listeners);
 	}
 
 	private LauncherDiscoveryResult discover(LauncherDiscoveryRequest discoveryRequest, LauncherPhase phase) {
 		return discoveryOrchestrator.discover(discoveryRequest, phase);
 	}
 
-	private void execute(InternalTestPlan internalTestPlan, TestExecutionListener[] listeners) {
+	private void execute(InternalTestPlan internalTestPlan, CancellationToken cancellationToken,
+			TestExecutionListener[] listeners) {
 		try (NamespacedHierarchicalStore<Namespace> requestLevelStore = createRequestLevelStore()) {
-			executionOrchestrator.execute(internalTestPlan, requestLevelStore, listeners);
+			executionOrchestrator.execute(internalTestPlan, requestLevelStore, cancellationToken, listeners);
 		}
 	}
 

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DefaultLauncher.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DefaultLauncher.java
@@ -86,10 +86,17 @@ class DefaultLauncher implements Launcher {
 
 	@Override
 	public void execute(LauncherDiscoveryRequest discoveryRequest, TestExecutionListener... listeners) {
+		execute(discoveryRequest, CancellationToken.create(), listeners);
+	}
+
+	@Override
+	public void execute(LauncherDiscoveryRequest discoveryRequest, CancellationToken cancellationToken,
+			TestExecutionListener... listeners) {
+
 		Preconditions.notNull(discoveryRequest, "LauncherDiscoveryRequest must not be null");
 		Preconditions.notNull(listeners, "TestExecutionListener array must not be null");
 		Preconditions.containsNoNullElements(listeners, "individual listeners must not be null");
-		execute(InternalTestPlan.from(discover(discoveryRequest, EXECUTION)), listeners);
+		execute(InternalTestPlan.from(discover(discoveryRequest, EXECUTION)), cancellationToken, listeners);
 	}
 
 	@Override

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DefaultLauncherSession.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DefaultLauncherSession.java
@@ -17,6 +17,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import org.junit.platform.commons.PreconditionViolationException;
+import org.junit.platform.engine.CancellationToken;
 import org.junit.platform.engine.support.store.Namespace;
 import org.junit.platform.engine.support.store.NamespacedHierarchicalStore;
 import org.junit.platform.launcher.Launcher;
@@ -123,6 +124,12 @@ class DefaultLauncherSession implements LauncherSession {
 
 		@Override
 		public void execute(TestPlan testPlan, TestExecutionListener... listeners) {
+			throw new PreconditionViolationException("Launcher session has already been closed");
+		}
+
+		@Override
+		public void execute(TestPlan testPlan, CancellationToken cancellationToken,
+				TestExecutionListener... listeners) {
 			throw new PreconditionViolationException("Launcher session has already been closed");
 		}
 	}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DefaultLauncherSession.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DefaultLauncherSession.java
@@ -123,6 +123,12 @@ class DefaultLauncherSession implements LauncherSession {
 		}
 
 		@Override
+		public void execute(LauncherDiscoveryRequest launcherDiscoveryRequest, CancellationToken cancellationToken,
+				TestExecutionListener... listeners) {
+			throw new PreconditionViolationException("Launcher session has already been closed");
+		}
+
+		@Override
 		public void execute(TestPlan testPlan, TestExecutionListener... listeners) {
 			throw new PreconditionViolationException("Launcher session has already been closed");
 		}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DelegatingLauncher.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DelegatingLauncher.java
@@ -49,6 +49,12 @@ class DelegatingLauncher implements Launcher {
 	}
 
 	@Override
+	public void execute(LauncherDiscoveryRequest launcherDiscoveryRequest, CancellationToken cancellationToken,
+			TestExecutionListener... listeners) {
+		delegate.execute(launcherDiscoveryRequest, cancellationToken, listeners);
+	}
+
+	@Override
 	public void execute(TestPlan testPlan, TestExecutionListener... listeners) {
 		delegate.execute(testPlan, listeners);
 	}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DelegatingLauncher.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DelegatingLauncher.java
@@ -10,6 +10,7 @@
 
 package org.junit.platform.launcher.core;
 
+import org.junit.platform.engine.CancellationToken;
 import org.junit.platform.launcher.Launcher;
 import org.junit.platform.launcher.LauncherDiscoveryListener;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
@@ -52,4 +53,8 @@ class DelegatingLauncher implements Launcher {
 		delegate.execute(testPlan, listeners);
 	}
 
+	@Override
+	public void execute(TestPlan testPlan, CancellationToken cancellationToken, TestExecutionListener... listeners) {
+		delegate.execute(testPlan, cancellationToken, listeners);
+	}
 }

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/EngineExecutionOrchestrator.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/EngineExecutionOrchestrator.java
@@ -231,7 +231,10 @@ public class EngineExecutionOrchestrator {
 			NamespacedHierarchicalStore<Namespace> requestLevelStore, CancellationToken cancellationToken) {
 
 		if (cancellationToken.isCancellationRequested()) {
-			listener.executionSkipped(engineDescriptor, "Cancellation of execution requested");
+			listener.executionStarted(engineDescriptor);
+			engineDescriptor.getChildren().forEach(
+				child -> listener.executionSkipped(child, "Cancellation of execution requested"));
+			listener.executionFinished(engineDescriptor, TestExecutionResult.aborted(null));
 			return;
 		}
 

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/SessionPerRequestLauncher.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/SessionPerRequestLauncher.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import org.junit.platform.engine.CancellationToken;
 import org.junit.platform.engine.support.store.Namespace;
 import org.junit.platform.engine.support.store.NamespacedHierarchicalStore;
 import org.junit.platform.launcher.Launcher;
@@ -71,6 +72,13 @@ class SessionPerRequestLauncher implements Launcher {
 	public void execute(TestPlan testPlan, TestExecutionListener... listeners) {
 		try (LauncherSession session = createSession()) {
 			session.getLauncher().execute(testPlan, listeners);
+		}
+	}
+
+	@Override
+	public void execute(TestPlan testPlan, CancellationToken cancellationToken, TestExecutionListener... listeners) {
+		try (LauncherSession session = createSession()) {
+			session.getLauncher().execute(testPlan, cancellationToken, listeners);
 		}
 	}
 

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/SessionPerRequestLauncher.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/SessionPerRequestLauncher.java
@@ -69,6 +69,14 @@ class SessionPerRequestLauncher implements Launcher {
 	}
 
 	@Override
+	public void execute(LauncherDiscoveryRequest launcherDiscoveryRequest, CancellationToken cancellationToken,
+			TestExecutionListener... listeners) {
+		try (LauncherSession session = createSession()) {
+			session.getLauncher().execute(launcherDiscoveryRequest, cancellationToken, listeners);
+		}
+	}
+
+	@Override
 	public void execute(TestPlan testPlan, TestExecutionListener... listeners) {
 		try (LauncherSession session = createSession()) {
 			session.getLauncher().execute(testPlan, listeners);

--- a/junit-platform-suite-engine/src/main/java/org/junit/platform/suite/engine/SuiteLauncher.java
+++ b/junit-platform-suite-engine/src/main/java/org/junit/platform/suite/engine/SuiteLauncher.java
@@ -16,6 +16,7 @@ import java.util.LinkedHashSet;
 import java.util.Set;
 
 import org.junit.platform.commons.util.Preconditions;
+import org.junit.platform.engine.CancellationToken;
 import org.junit.platform.engine.EngineExecutionListener;
 import org.junit.platform.engine.TestEngine;
 import org.junit.platform.engine.UniqueId;
@@ -60,9 +61,10 @@ class SuiteLauncher {
 
 	TestExecutionSummary execute(LauncherDiscoveryResult discoveryResult,
 			EngineExecutionListener parentEngineExecutionListener,
-			NamespacedHierarchicalStore<Namespace> requestLevelStore) {
+			NamespacedHierarchicalStore<Namespace> requestLevelStore, CancellationToken cancellationToken) {
 		SummaryGeneratingListener listener = new SummaryGeneratingListener();
-		executionOrchestrator.execute(discoveryResult, parentEngineExecutionListener, listener, requestLevelStore);
+		executionOrchestrator.execute(discoveryResult, parentEngineExecutionListener, listener, requestLevelStore,
+			cancellationToken);
 		return listener.getSummary();
 	}
 

--- a/junit-platform-suite-engine/src/main/java/org/junit/platform/suite/engine/SuiteTestDescriptor.java
+++ b/junit-platform-suite-engine/src/main/java/org/junit/platform/suite/engine/SuiteTestDescriptor.java
@@ -27,6 +27,7 @@ import org.junit.platform.commons.JUnitException;
 import org.junit.platform.commons.support.ReflectionSupport;
 import org.junit.platform.commons.util.Preconditions;
 import org.junit.platform.commons.util.StringUtils;
+import org.junit.platform.engine.CancellationToken;
 import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.engine.DiscoveryIssue;
 import org.junit.platform.engine.EngineDiscoveryListener;
@@ -149,13 +150,13 @@ final class SuiteTestDescriptor extends AbstractTestDescriptor {
 	}
 
 	void execute(EngineExecutionListener parentEngineExecutionListener,
-			NamespacedHierarchicalStore<Namespace> requestLevelStore) {
+			NamespacedHierarchicalStore<Namespace> requestLevelStore, CancellationToken cancellationToken) {
 		parentEngineExecutionListener.executionStarted(this);
 		ThrowableCollector throwableCollector = new OpenTest4JAwareThrowableCollector();
 
 		executeBeforeSuiteMethods(throwableCollector);
 
-		TestExecutionSummary summary = executeTests(parentEngineExecutionListener, requestLevelStore,
+		TestExecutionSummary summary = executeTests(parentEngineExecutionListener, requestLevelStore, cancellationToken,
 			throwableCollector);
 
 		executeAfterSuiteMethods(throwableCollector);
@@ -177,7 +178,8 @@ final class SuiteTestDescriptor extends AbstractTestDescriptor {
 	}
 
 	private @Nullable TestExecutionSummary executeTests(EngineExecutionListener parentEngineExecutionListener,
-			NamespacedHierarchicalStore<Namespace> requestLevelStore, ThrowableCollector throwableCollector) {
+			NamespacedHierarchicalStore<Namespace> requestLevelStore, CancellationToken cancellationToken,
+			ThrowableCollector throwableCollector) {
 		if (throwableCollector.isNotEmpty()) {
 			return null;
 		}
@@ -187,7 +189,8 @@ final class SuiteTestDescriptor extends AbstractTestDescriptor {
 		// be pruned accordingly.
 		LauncherDiscoveryResult discoveryResult = requireNonNull(this.launcherDiscoveryResult).withRetainedEngines(
 			getChildren()::contains);
-		return requireNonNull(launcher).execute(discoveryResult, parentEngineExecutionListener, requestLevelStore);
+		return requireNonNull(launcher).execute(discoveryResult, parentEngineExecutionListener, requestLevelStore,
+			cancellationToken);
 	}
 
 	private void executeAfterSuiteMethods(ThrowableCollector throwableCollector) {

--- a/junit-platform-suite-engine/src/main/java/org/junit/platform/suite/engine/SuiteTestEngine.java
+++ b/junit-platform-suite-engine/src/main/java/org/junit/platform/suite/engine/SuiteTestEngine.java
@@ -73,7 +73,7 @@ public final class SuiteTestEngine implements TestEngine {
 		suiteEngineDescriptor.getChildren()
 				.stream()
 				.map(SuiteTestDescriptor.class::cast)
-				.forEach(suiteTestDescriptor -> suiteTestDescriptor.execute(engineExecutionListener, requestLevelStore));
+				.forEach(suiteTestDescriptor -> suiteTestDescriptor.execute(engineExecutionListener, requestLevelStore, request.getCancellationToken()));
 		// @formatter:on
 		engineExecutionListener.executionFinished(suiteEngineDescriptor, TestExecutionResult.successful());
 	}

--- a/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/EngineTestKit.java
+++ b/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/EngineTestKit.java
@@ -12,6 +12,7 @@ package org.junit.platform.testkit.engine;
 
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
+import static java.util.Objects.requireNonNullElseGet;
 import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
@@ -30,6 +31,7 @@ import org.junit.platform.commons.JUnitException;
 import org.junit.platform.commons.PreconditionViolationException;
 import org.junit.platform.commons.util.CollectionUtils;
 import org.junit.platform.commons.util.Preconditions;
+import org.junit.platform.engine.CancellationToken;
 import org.junit.platform.engine.DiscoveryFilter;
 import org.junit.platform.engine.DiscoveryIssue;
 import org.junit.platform.engine.DiscoverySelector;
@@ -244,16 +246,18 @@ public final class EngineTestKit {
 		Preconditions.notNull(discoveryRequest, "EngineDiscoveryRequest must not be null");
 
 		ExecutionRecorder executionRecorder = new ExecutionRecorder();
-		executeUsingLauncherOrchestration(testEngine, discoveryRequest, executionRecorder);
+		executeUsingLauncherOrchestration(testEngine, discoveryRequest, executionRecorder, CancellationToken.create());
 		return executionRecorder.getExecutionResults();
 	}
 
 	private static void executeUsingLauncherOrchestration(TestEngine testEngine,
-			LauncherDiscoveryRequest discoveryRequest, EngineExecutionListener listener) {
+			LauncherDiscoveryRequest discoveryRequest, EngineExecutionListener listener,
+			CancellationToken cancellationToken) {
 		LauncherDiscoveryResult discoveryResult = discoverUsingOrchestrator(testEngine, discoveryRequest);
 		TestDescriptor engineTestDescriptor = discoveryResult.getEngineTestDescriptor(testEngine);
 		Preconditions.notNull(engineTestDescriptor, "TestEngine did not yield a TestDescriptor");
-		withRequestLevelStore(store -> new EngineExecutionOrchestrator().execute(discoveryResult, listener, store));
+		withRequestLevelStore(
+			store -> new EngineExecutionOrchestrator().execute(discoveryResult, listener, store, cancellationToken));
 	}
 
 	private static void withRequestLevelStore(Consumer<NamespacedHierarchicalStore<Namespace>> action) {
@@ -308,7 +312,10 @@ public final class EngineTestKit {
 		private final LauncherDiscoveryRequestBuilder requestBuilder = LauncherDiscoveryRequestBuilder.request() //
 				.enableImplicitConfigurationParameters(false) //
 				.outputDirectoryProvider(DisabledOutputDirectoryProvider.INSTANCE);
+
 		private final TestEngine testEngine;
+
+		private @Nullable CancellationToken cancellationToken;
 
 		private Builder(TestEngine testEngine) {
 			this.testEngine = testEngine;
@@ -431,6 +438,15 @@ public final class EngineTestKit {
 		}
 
 		/**
+		 * @since 6.0
+		 */
+		@API(status = EXPERIMENTAL, since = "6.0")
+		public Builder cancellationToken(CancellationToken cancellationToken) {
+			this.cancellationToken = Preconditions.notNull(cancellationToken, "cancellationToken must not be null");
+			return this;
+		}
+
+		/**
 		 * Discover tests for the configured {@link TestEngine},
 		 * {@linkplain DiscoverySelector discovery selectors},
 		 * {@linkplain DiscoveryFilter discovery filters}, and
@@ -464,7 +480,8 @@ public final class EngineTestKit {
 		public EngineExecutionResults execute() {
 			LauncherDiscoveryRequest request = this.requestBuilder.build();
 			ExecutionRecorder executionRecorder = new ExecutionRecorder();
-			EngineTestKit.executeUsingLauncherOrchestration(this.testEngine, request, executionRecorder);
+			EngineTestKit.executeUsingLauncherOrchestration(this.testEngine, request, executionRecorder,
+				requireNonNullElseGet(this.cancellationToken, CancellationToken::create));
 			return executionRecorder.getExecutionResults();
 		}
 

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/descriptor/RunnerTestDescriptor.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/descriptor/RunnerTestDescriptor.java
@@ -74,6 +74,10 @@ public class RunnerTestDescriptor extends VintageTestDescriptor {
 		return new RunnerRequest(this.runner);
 	}
 
+	public Runner getRunner() {
+		return this.runner;
+	}
+
 	@Override
 	protected boolean tryToExcludeFromRunner(Description description) {
 		boolean excluded = tryToFilterRunner(description);

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/execution/RunListenerAdapter.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/execution/RunListenerAdapter.java
@@ -103,6 +103,10 @@ class RunListenerAdapter extends RunListener {
 
 	@Override
 	public void testRunFinished(Result result) {
+		testRunFinished();
+	}
+
+	void testRunFinished() {
 		reportContainerFinished(testRun.getRunnerTestDescriptor());
 	}
 

--- a/junit-vintage-engine/src/test/java/org/junit/vintage/engine/VintageTestEngineExecutionTests.java
+++ b/junit-vintage-engine/src/test/java/org/junit/vintage/engine/VintageTestEngineExecutionTests.java
@@ -44,6 +44,7 @@ import org.junit.AssumptionViolatedException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.DisabledInEclipse;
 import org.junit.platform.commons.util.ReflectionUtils;
+import org.junit.platform.engine.CancellationToken;
 import org.junit.platform.engine.EngineExecutionListener;
 import org.junit.platform.engine.ExecutionRequest;
 import org.junit.platform.engine.TestDescriptor;
@@ -943,7 +944,7 @@ class VintageTestEngineExecutionTests {
 		var engineTestDescriptor = testEngine.discover(discoveryRequest, UniqueId.forEngine(testEngine.getId()));
 		testEngine.execute(
 			ExecutionRequest.create(engineTestDescriptor, listener, discoveryRequest.getConfigurationParameters(),
-				dummyOutputDirectoryProvider(), dummyNamespacedHierarchicalStore()));
+				dummyOutputDirectoryProvider(), dummyNamespacedHierarchicalStore(), CancellationToken.create()));
 	}
 
 	private static LauncherDiscoveryRequest request(Class<?> testClass) {

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/AbstractJupiterTestEngineTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/AbstractJupiterTestEngineTests.java
@@ -97,6 +97,14 @@ public abstract class AbstractJupiterTestEngineTests {
 		return EngineTestKit.discover(this.engine, request);
 	}
 
+	protected EngineTestKit.Builder jupiterTestEngine() {
+		return EngineTestKit.engine(this.engine) //
+				.outputDirectoryProvider(dummyOutputDirectoryProvider()) //
+				.configurationParameter(STACKTRACE_PRUNING_ENABLED_PROPERTY_NAME, String.valueOf(false)) //
+				.configurationParameter(CRITICAL_DISCOVERY_ISSUE_SEVERITY_PROPERTY_NAME, Severity.INFO.name()) //
+				.enableImplicitConfigurationParameters(false);
+	}
+
 	protected static LauncherDiscoveryRequestBuilder defaultRequest() {
 		return request() //
 				.outputDirectoryProvider(dummyOutputDirectoryProvider()) //

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/ExecutionCancellationTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/ExecutionCancellationTests.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2015-2025 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.engine;
+
+import static java.util.Objects.requireNonNull;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
+import static org.junit.platform.testkit.engine.EventConditions.container;
+import static org.junit.platform.testkit.engine.EventConditions.engine;
+import static org.junit.platform.testkit.engine.EventConditions.event;
+import static org.junit.platform.testkit.engine.EventConditions.finishedSuccessfully;
+import static org.junit.platform.testkit.engine.EventConditions.reportEntry;
+import static org.junit.platform.testkit.engine.EventConditions.skippedWithReason;
+import static org.junit.platform.testkit.engine.EventConditions.started;
+import static org.junit.platform.testkit.engine.EventConditions.test;
+
+import java.util.Map;
+
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.TestReporter;
+import org.junit.platform.engine.CancellationToken;
+
+class ExecutionCancellationTests extends AbstractJupiterTestEngineTests {
+
+	@Test
+	void canCancelExecutionWhileTestsAreRunning() {
+		var testClass = TestCase.class;
+		var cancellationToken = CancellationToken.create();
+
+		TestCase.cancellationToken = cancellationToken;
+
+		var results = jupiterTestEngine() //
+				.selectors(selectClass(testClass)) //
+				.cancellationToken(cancellationToken) //
+				.execute();
+
+		results.allEvents().assertEventsMatchExactly( //
+			event(engine(), started()), //
+			event(container(testClass), started()), //
+			event(test("first"), started()), //
+			event(test("first"), reportEntry(Map.of("cancelled", "true"))), //
+			event(test("first"), finishedSuccessfully()), //
+			event(test("second"), skippedWithReason("Test execution cancelled")), //
+			event(container(testClass), finishedSuccessfully()), //
+			event(engine(), finishedSuccessfully()));
+	}
+
+	@AfterEach
+	void resetCancellationToken() {
+		TestCase.cancellationToken = null;
+	}
+
+	@SuppressWarnings("JUnitMalformedDeclaration")
+	@TestMethodOrder(OrderAnnotation.class)
+	static class TestCase {
+
+		static @Nullable CancellationToken cancellationToken;
+
+		@Test
+		@Order(1)
+		void first() {
+			requiredCancellationToken().cancel();
+		}
+
+		@AfterEach
+		void afterEach(TestReporter reporter) {
+			reporter.publishEntry("cancelled", String.valueOf(requiredCancellationToken().isCancellationRequested()));
+		}
+
+		@Test
+		@Order(2)
+		void second() {
+			fail("should not be called");
+		}
+
+		private CancellationToken requiredCancellationToken() {
+			return requireNonNull(cancellationToken);
+		}
+	}
+
+}

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/HierarchicalTestExecutorTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/HierarchicalTestExecutorTests.java
@@ -39,6 +39,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.function.ThrowingConsumer;
+import org.junit.platform.engine.CancellationToken;
 import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.engine.EngineExecutionListener;
 import org.junit.platform.engine.ExecutionRequest;
@@ -81,7 +82,7 @@ class HierarchicalTestExecutorTests {
 	private HierarchicalTestExecutor<MyEngineExecutionContext> createExecutor(
 			HierarchicalTestExecutorService executorService) {
 		var request = ExecutionRequest.create(root, listener, mock(ConfigurationParameters.class),
-			dummyOutputDirectoryProvider(), dummyNamespacedHierarchicalStore());
+			dummyOutputDirectoryProvider(), dummyNamespacedHierarchicalStore(), CancellationToken.create());
 		return new HierarchicalTestExecutor<>(request, rootContext, executorService,
 			OpenTest4JAwareThrowableCollector::new);
 	}

--- a/platform-tests/src/test/java/org/junit/platform/suite/engine/SuiteEngineTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/suite/engine/SuiteEngineTests.java
@@ -38,6 +38,7 @@ import org.junit.jupiter.engine.descriptor.JupiterEngineDescriptor;
 import org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.platform.engine.CancellationToken;
 import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.engine.DiscoveryIssue;
 import org.junit.platform.engine.DiscoveryIssue.Severity;
@@ -644,13 +645,15 @@ class SuiteEngineTests {
 
 		EngineExecutionListener listener = mock(EngineExecutionListener.class);
 		NamespacedHierarchicalStore<Namespace> requestLevelStore = NamespacedHierarchicalStoreProviders.dummyNamespacedHierarchicalStore();
+		CancellationToken cancellationToken = CancellationToken.create();
 
 		ExecutionRequest request = ExecutionRequest.create(engineDescriptor, listener,
-			mock(ConfigurationParameters.class), mock(OutputDirectoryProvider.class), requestLevelStore);
+			mock(ConfigurationParameters.class), mock(OutputDirectoryProvider.class), requestLevelStore,
+			cancellationToken);
 
 		new SuiteTestEngine().execute(request);
 
-		verify(mockDescriptor).execute(same(listener), same(requestLevelStore));
+		verify(mockDescriptor).execute(same(listener), same(requestLevelStore), same(cancellationToken));
 	}
 
 	@Suite

--- a/platform-tests/src/test/java/org/junit/platform/testkit/engine/EngineTestKitTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/testkit/engine/EngineTestKitTests.java
@@ -80,7 +80,7 @@ class EngineTestKitTests {
 			ArgumentCaptor<NamespacedHierarchicalStore<Namespace>> storeCaptor = forClass(
 				NamespacedHierarchicalStore.class);
 
-			verify(mockOrchestrator).execute(any(), any(), storeCaptor.capture());
+			verify(mockOrchestrator).execute(any(), any(), storeCaptor.capture(), any());
 			assertNotNull(storeCaptor.getValue(), "Request level store should be passed to execute");
 		}
 	}


### PR DESCRIPTION
## Overview

* Introduce `CancellationToken` interface and default implementation
* Add `Launcher.execute(TestPlan, CancellationToken, ...)` method
* Add `ExecutionRequest.getCancellationToken()` method
* Implement support for cancellation for engines extending
  `HierarchicalTestEngine`

Eventually resolves #1880.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://docs.junit.org/snapshot/user-guide/) and [Release Notes](https://docs.junit.org/snapshot/user-guide/#release-notes)
