### PR TITLE
Add `TestTask::getTestDescriptor` method

### DIFF
--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/HierarchicalTestExecutorService.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/HierarchicalTestExecutorService.java
@@ -10,6 +10,7 @@
 
 package org.junit.platform.engine.support.hierarchical;
 
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.util.List;
@@ -18,6 +19,7 @@ import java.util.concurrent.Future;
 import org.apiguardian.api.API;
 import org.jspecify.annotations.Nullable;
 import org.junit.platform.engine.ExecutionRequest;
+import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.support.hierarchical.Node.ExecutionMode;
 
 /**
@@ -94,6 +96,16 @@ public interface HierarchicalTestExecutorService extends AutoCloseable {
 		 * Get the {@linkplain ResourceLock resource lock} of this task.
 		 */
 		ResourceLock getResourceLock();
+
+		/**
+		 * Get the {@linkplain TestDescriptor test descriptor} of this task.
+		 *
+		 * @throws UnsupportedOperationException if not supported for this TestTask implementation
+		 */
+		@API(status = EXPERIMENTAL, since = "6.0")
+		default TestDescriptor getTestDescriptor() {
+			throw new UnsupportedOperationException();
+		}
 
 		/**
 		 * Execute this task.

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/HierarchicalTestExecutorService.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/HierarchicalTestExecutorService.java
@@ -101,6 +101,7 @@ public interface HierarchicalTestExecutorService extends AutoCloseable {
 		 * Get the {@linkplain TestDescriptor test descriptor} of this task.
 		 *
 		 * @throws UnsupportedOperationException if not supported for this TestTask implementation
+		 * @since 6.0
 		 */
 		@API(status = EXPERIMENTAL, since = "6.0")
 		default TestDescriptor getTestDescriptor() {

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/NodeTestTask.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/NodeTestTask.java
@@ -87,6 +87,11 @@ class NodeTestTask<C extends EngineExecutionContext> implements TestTask {
 	}
 
 	@Override
+	public TestDescriptor getTestDescriptor() {
+		return testDescriptor;
+	}
+
+	@Override
 	public String toString() {
 		return "NodeTestTask [" + testDescriptor + "]";
 	}


### PR DESCRIPTION
## Overview

Added TestTask::getTestDescriptor as described in the issue. A TestTask should always correspond to an specific test node, so making its descriptor public for further analysis in custom test engines could be useful.

Resolves #4711.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://docs.junit.org/snapshot/user-guide/) and [Release Notes](https://docs.junit.org/snapshot/user-guide/#release-notes)
