### PR TITLE
Improve message of discovery issues for ineffective `@Order` annotations

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.13.3.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.13.3.adoc
@@ -59,6 +59,7 @@ repository on GitHub.
   that both `null` and _blank_ values are supported for reason strings and that such
   values will result in an _empty_ `Optional` returned from
   `ConditionEvaluationResult.getReason()`.
+* Improve message of discovery issues reported for ineffective `@Order` annotations.
 
 
 [[release-notes-5.13.3-junit-vintage]]

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/ClassOrderingVisitor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/ClassOrderingVisitor.java
@@ -28,7 +28,6 @@ import org.junit.platform.commons.util.LruCache;
 import org.junit.platform.engine.DiscoveryIssue;
 import org.junit.platform.engine.DiscoveryIssue.Severity;
 import org.junit.platform.engine.TestDescriptor;
-import org.junit.platform.engine.support.descriptor.ClassSource;
 import org.junit.platform.engine.support.discovery.DiscoveryIssueReporter;
 import org.junit.platform.engine.support.discovery.DiscoveryIssueReporter.Condition;
 
@@ -49,10 +48,12 @@ class ClassOrderingVisitor extends AbstractOrderingVisitor {
 		this.globalOrderer = createGlobalOrderer(configuration);
 		this.noOrderAnnotation = issueReporter.createReportingCondition(
 			testDescriptor -> !isAnnotated(testDescriptor.getTestClass(), Order.class), testDescriptor -> {
-				String message = "Ineffective @Order annotation on class '%s'. It will not be applied because ClassOrderer.OrderAnnotation is not in use.".formatted(
-					testDescriptor.getTestClass().getName());
+				String message = "Ineffective @Order annotation on class '%s'. ".formatted(
+					testDescriptor.getTestClass().getName())
+						+ "The annotation may be directly present or meta-present on the class. "
+						+ "It will not be applied because ClassOrderer.OrderAnnotation is not in use.";
 				return DiscoveryIssue.builder(Severity.INFO, message) //
-						.source(ClassSource.from(testDescriptor.getTestClass())) //
+						.source(testDescriptor.getSource()) //
 						.build();
 			});
 	}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/ClassOrderingVisitor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/ClassOrderingVisitor.java
@@ -48,10 +48,11 @@ class ClassOrderingVisitor extends AbstractOrderingVisitor {
 		this.globalOrderer = createGlobalOrderer(configuration);
 		this.noOrderAnnotation = issueReporter.createReportingCondition(
 			testDescriptor -> !isAnnotated(testDescriptor.getTestClass(), Order.class), testDescriptor -> {
-				String message = "Ineffective @Order annotation on class '%s'. ".formatted(
-					testDescriptor.getTestClass().getName())
-						+ "The annotation may be directly present or meta-present on the class. "
-						+ "It will not be applied because ClassOrderer.OrderAnnotation is not in use.";
+				String message = """
+						Ineffective @Order annotation on class '%s'. \
+						It will not be applied because ClassOrderer.OrderAnnotation is not in use. \
+						Note that the annotation may be either directly present or meta-present on the class."""//
+						.formatted(testDescriptor.getTestClass().getName());
 				return DiscoveryIssue.builder(Severity.INFO, message) //
 						.source(testDescriptor.getSource()) //
 						.build();

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/MethodOrderingVisitor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/MethodOrderingVisitor.java
@@ -30,7 +30,6 @@ import org.junit.platform.commons.support.ReflectionSupport;
 import org.junit.platform.engine.DiscoveryIssue;
 import org.junit.platform.engine.DiscoveryIssue.Severity;
 import org.junit.platform.engine.TestDescriptor;
-import org.junit.platform.engine.support.descriptor.MethodSource;
 import org.junit.platform.engine.support.discovery.DiscoveryIssueReporter;
 import org.junit.platform.engine.support.discovery.DiscoveryIssueReporter.Condition;
 
@@ -50,10 +49,12 @@ class MethodOrderingVisitor extends AbstractOrderingVisitor {
 		this.configuration = configuration;
 		this.noOrderAnnotation = issueReporter.createReportingCondition(
 			testDescriptor -> !isAnnotated(testDescriptor.getTestMethod(), Order.class), testDescriptor -> {
-				String message = "Ineffective @Order annotation on method '%s'. It will not be applied because MethodOrderer.OrderAnnotation is not in use.".formatted(
-					testDescriptor.getTestMethod().toGenericString());
+				String message = "Ineffective @Order annotation on method '%s'. ".formatted(
+					testDescriptor.getTestMethod().toGenericString())
+						+ "The annotation may be directly present or meta-present on the method. "
+						+ "It will not be applied because MethodOrderer.OrderAnnotation is not in use.";
 				return DiscoveryIssue.builder(Severity.INFO, message) //
-						.source(MethodSource.from(testDescriptor.getTestMethod())) //
+						.source(testDescriptor.getSource()) //
 						.build();
 			});
 		this.methodsBeforeNestedClassesOrderer = createMethodsBeforeNestedClassesOrderer();

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/MethodOrderingVisitor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/MethodOrderingVisitor.java
@@ -49,10 +49,11 @@ class MethodOrderingVisitor extends AbstractOrderingVisitor {
 		this.configuration = configuration;
 		this.noOrderAnnotation = issueReporter.createReportingCondition(
 			testDescriptor -> !isAnnotated(testDescriptor.getTestMethod(), Order.class), testDescriptor -> {
-				String message = "Ineffective @Order annotation on method '%s'. ".formatted(
-					testDescriptor.getTestMethod().toGenericString())
-						+ "The annotation may be directly present or meta-present on the method. "
-						+ "It will not be applied because MethodOrderer.OrderAnnotation is not in use.";
+				String message = """
+						Ineffective @Order annotation on method '%s'. \
+						It will not be applied because MethodOrderer.OrderAnnotation is not in use. \
+						Note that the annotation may be either directly present or meta-present on the method."""//
+						.formatted(testDescriptor.getTestMethod().toGenericString());
 				return DiscoveryIssue.builder(Severity.INFO, message) //
 						.source(testDescriptor.getSource()) //
 						.build();

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/OrderedClassTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/OrderedClassTests.java
@@ -205,8 +205,9 @@ class OrderedClassTests {
 		assertThat(discoveryIssues).extracting(DiscoveryIssue::severity).containsOnly(Severity.INFO);
 		assertThat(discoveryIssues).extracting(DiscoveryIssue::message) //
 				.allMatch(it -> it.startsWith("Ineffective @Order annotation on class")
-						&& it.contains("The annotation may be directly present or meta-present on the class.")
-						&& it.endsWith("It will not be applied because ClassOrderer.OrderAnnotation is not in use."));
+						&& it.contains("It will not be applied because ClassOrderer.OrderAnnotation is not in use.")
+						&& it.endsWith(
+							"Note that the annotation may be either directly present or meta-present on the class."));
 		assertThat(discoveryIssues).extracting(DiscoveryIssue::source).extracting(Optional::orElseThrow) //
 				.containsExactlyInAnyOrder(ClassSource.from(A_TestCase.class), ClassSource.from(C_TestCase.class));
 	}

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/OrderedClassTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/OrderedClassTests.java
@@ -205,6 +205,7 @@ class OrderedClassTests {
 		assertThat(discoveryIssues).extracting(DiscoveryIssue::severity).containsOnly(Severity.INFO);
 		assertThat(discoveryIssues).extracting(DiscoveryIssue::message) //
 				.allMatch(it -> it.startsWith("Ineffective @Order annotation on class")
+						&& it.contains("The annotation may be directly present or meta-present on the class.")
 						&& it.endsWith("It will not be applied because ClassOrderer.OrderAnnotation is not in use."));
 		assertThat(discoveryIssues).extracting(DiscoveryIssue::source).extracting(Optional::orElseThrow) //
 				.containsExactlyInAnyOrder(ClassSource.from(A_TestCase.class), ClassSource.from(C_TestCase.class));

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/OrderedMethodTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/OrderedMethodTests.java
@@ -374,8 +374,9 @@ class OrderedMethodTests {
 		assertThat(discoveryIssues).extracting(DiscoveryIssue::severity).containsOnly(Severity.INFO);
 		assertThat(discoveryIssues).extracting(DiscoveryIssue::message) //
 				.allMatch(it -> it.startsWith("Ineffective @Order annotation on method")
-						&& it.contains("The annotation may be directly present or meta-present on the method.")
-						&& it.endsWith("It will not be applied because MethodOrderer.OrderAnnotation is not in use."));
+						&& it.contains("It will not be applied because MethodOrderer.OrderAnnotation is not in use.")
+						&& it.endsWith(
+							"Note that the annotation may be either directly present or meta-present on the method."));
 		var testClass = WithoutTestMethodOrderTestCase.class;
 		assertThat(discoveryIssues).extracting(DiscoveryIssue::source).extracting(Optional::orElseThrow) //
 				.containsExactlyInAnyOrder(MethodSource.from(testClass.getDeclaredMethod("test1")),

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/OrderedMethodTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/OrderedMethodTests.java
@@ -374,6 +374,7 @@ class OrderedMethodTests {
 		assertThat(discoveryIssues).extracting(DiscoveryIssue::severity).containsOnly(Severity.INFO);
 		assertThat(discoveryIssues).extracting(DiscoveryIssue::message) //
 				.allMatch(it -> it.startsWith("Ineffective @Order annotation on method")
+						&& it.contains("The annotation may be directly present or meta-present on the method.")
 						&& it.endsWith("It will not be applied because MethodOrderer.OrderAnnotation is not in use."));
 		var testClass = WithoutTestMethodOrderTestCase.class;
 		assertThat(discoveryIssues).extracting(DiscoveryIssue::source).extracting(Optional::orElseThrow) //


### PR DESCRIPTION
## Overview

Resolves #4713.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://docs.junit.org/snapshot/user-guide/) and [Release Notes](https://docs.junit.org/snapshot/user-guide/#release-notes)
