### PR TITLE
Introduce `LauncherExecutionRequest`

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-6.0.0-M2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-6.0.0-M2.adoc
@@ -23,10 +23,19 @@ repository on GitHub.
 
 * Discontinue `junit-platform-suite-commons` which is now integrated into
   `junit-platform-suite`.
+* Deprecate `Launcher.execute(TestPlan, TestExecutionListener[])` and
+  `Launcher.execute(LauncherDiscoveryRequest, TestExecutionListener[])` in favor of
+  `Launcher.execute(LauncherExecutionRequest)`
 
 [[release-notes-6.0.0-M2-junit-platform-new-features-and-improvements]]
 ==== New Features and Improvements
 
+* Introduce new `Launcher.execute(LauncherExecutionRequest)` API with corresponding
+  `LauncherExecutionRequestBuilder` to enable the addition of parameters to test
+  executions without additional overloads of `execute`.
+* Introduce `LauncherDiscoveryRequestBuilder.forExecution()` method as a convenience
+  method for constructing a `LauncherExecutionRequest` that contains a
+  `LauncherDiscoveryRequest`.
 * Introduce `TestTask.getTestDescriptor()` method for use in
   `HierarchicalTestExecutorService` implementations.
 

--- a/documentation/src/test/java/example/UsingTheLauncherDemo.java
+++ b/documentation/src/test/java/example/UsingTheLauncherDemo.java
@@ -23,6 +23,7 @@ import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.launcher.Launcher;
 import org.junit.platform.launcher.LauncherDiscoveryListener;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
+import org.junit.platform.launcher.LauncherExecutionRequest;
 import org.junit.platform.launcher.LauncherSession;
 import org.junit.platform.launcher.LauncherSessionListener;
 import org.junit.platform.launcher.PostDiscoveryFilter;
@@ -30,6 +31,7 @@ import org.junit.platform.launcher.TestExecutionListener;
 import org.junit.platform.launcher.TestPlan;
 import org.junit.platform.launcher.core.LauncherConfig;
 import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
+import org.junit.platform.launcher.core.LauncherExecutionRequestBuilder;
 import org.junit.platform.launcher.core.LauncherFactory;
 import org.junit.platform.launcher.listeners.SummaryGeneratingListener;
 import org.junit.platform.launcher.listeners.TestExecutionSummary;
@@ -74,7 +76,7 @@ class UsingTheLauncherDemo {
 	void execution() {
 		// @formatter:off
 		// tag::execution[]
-		LauncherDiscoveryRequest request = LauncherDiscoveryRequestBuilder.request()
+		LauncherDiscoveryRequest discoveryRequest = LauncherDiscoveryRequestBuilder.request()
 			.selectors(
 				selectPackage("com.example.mytests"),
 				selectClass(MyTestClass.class)
@@ -94,11 +96,11 @@ class UsingTheLauncherDemo {
 			// Register a listener of your choice
 			launcher.registerTestExecutionListeners(listener);
 			// Discover tests and build a test plan
-			TestPlan testPlan = launcher.discover(request);
+			TestPlan testPlan = launcher.discover(discoveryRequest);
 			// Execute test plan
-			launcher.execute(testPlan);
-			// Alternatively, execute the request directly
-			launcher.execute(request);
+			launcher.execute(LauncherExecutionRequestBuilder.request(testPlan).build());
+			// Alternatively, execute the discoveryRequest request directly
+			launcher.execute(LauncherExecutionRequestBuilder.request(discoveryRequest).build());
 		}
 
 		TestExecutionSummary summary = listener.getSummary();
@@ -128,8 +130,9 @@ class UsingTheLauncherDemo {
 			.addTestExecutionListeners(new CustomTestExecutionListener())
 			.build();
 
-		LauncherDiscoveryRequest request = LauncherDiscoveryRequestBuilder.request()
+		LauncherExecutionRequest request = LauncherDiscoveryRequestBuilder.request()
 			.selectors(selectPackage("com.example.mytests"))
+			.forExecution()
 			.build();
 
 		try (LauncherSession session = LauncherFactory.openSession(launcherConfig)) {

--- a/documentation/src/test/java/example/sharedresources/SharedResourceDemo.java
+++ b/documentation/src/test/java/example/sharedresources/SharedResourceDemo.java
@@ -39,7 +39,7 @@ class SharedResourceDemo {
 				// tag::custom_line_break[]
 				.build());
 
-		launcher.execute(request().build());
+		launcher.execute(request().forExecution().build());
 
 		assertSame(firstCustomEngine.socket, secondCustomEngine.socket);
 		assertTrue(firstCustomEngine.socket.isClosed(), "socket should be closed");

--- a/junit-platform-console/src/main/java/org/junit/platform/console/tasks/ConsoleTestExecutor.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/tasks/ConsoleTestExecutor.java
@@ -143,7 +143,7 @@ public class ConsoleTestExecutor {
 		LauncherDiscoveryRequestBuilder discoveryRequestBuilder = toDiscoveryRequestBuilder(discoveryOptions);
 		reportsDir.ifPresent(dir -> discoveryRequestBuilder.configurationParameter(OUTPUT_DIR_PROPERTY_NAME,
 			dir.toAbsolutePath().toString()));
-		launcher.execute(discoveryRequestBuilder.build());
+		launcher.execute(discoveryRequestBuilder.forExecution().build());
 	}
 
 	private Optional<ClassLoader> createCustomClassLoader() {

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/Launcher.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/Launcher.java
@@ -10,9 +10,12 @@
 
 package org.junit.platform.launcher;
 
+import static org.apiguardian.api.API.Status.DEPRECATED;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import org.apiguardian.api.API;
+import org.junit.platform.launcher.core.LauncherExecutionRequestBuilder;
 
 /**
  * The {@code Launcher} API is the main entry point for client code that
@@ -105,8 +108,16 @@ public interface Launcher {
 	 *
 	 * @param launcherDiscoveryRequest the launcher discovery request; never {@code null}
 	 * @param listeners additional test execution listeners; never {@code null}
+	 * @deprecated Please use {@link #execute(LauncherExecutionRequest)} instead.
 	 */
-	void execute(LauncherDiscoveryRequest launcherDiscoveryRequest, TestExecutionListener... listeners);
+	@Deprecated
+	@API(status = DEPRECATED, since = "6.0")
+	default void execute(LauncherDiscoveryRequest launcherDiscoveryRequest, TestExecutionListener... listeners) {
+		var executionRequest = LauncherExecutionRequestBuilder.request(launcherDiscoveryRequest) //
+				.listeners(listeners) //
+				.build();
+		execute(executionRequest);
+	}
 
 	/**
 	 * Execute the supplied {@link TestPlan} and notify
@@ -123,8 +134,44 @@ public interface Launcher {
 	 * @param testPlan the test plan to execute; never {@code null}
 	 * @param listeners additional test execution listeners; never {@code null}
 	 * @since 1.4
+	 * @deprecated Please use {@link #execute(LauncherExecutionRequest)} instead.
 	 */
-	@API(status = STABLE, since = "1.4")
-	void execute(TestPlan testPlan, TestExecutionListener... listeners);
+	@Deprecated
+	@API(status = DEPRECATED, since = "6.0")
+	default void execute(TestPlan testPlan, TestExecutionListener... listeners) {
+		var executionRequest = LauncherExecutionRequestBuilder.request(testPlan) //
+				.listeners(listeners) //
+				.build();
+		execute(executionRequest);
+	}
+
+	/**
+	 * Execute tests according to the supplied {@link LauncherExecutionRequest}
+	 * {@linkplain #registerTestExecutionListeners registered listeners} about
+	 * the progress and results of the execution.
+	 *
+	 * <p>Test execution listeners supplied
+	 * {@linkplain LauncherExecutionRequest#getAdditionalTestExecutionListeners()
+	 * as part of the request} are registered in addition to already registered
+	 * listeners but only for the supplied execution request.
+	 *
+	 * @apiNote If the execution request contains a {@link TestPlan} rather than
+	 * a {@link LauncherDiscoveryRequest}, it must not have been executed
+	 * previously.
+	 *
+	 * <p>If the execution request contains a {@link LauncherDiscoveryRequest},
+	 * calling this method will cause test discovery to be executed for all
+	 * registered engines. If the same {@link LauncherDiscoveryRequest} was
+	 * previously passed to {@link #discover(LauncherDiscoveryRequest)}, you
+	 * should instead provide the resulting {@link TestPlan} as part of the
+	 * supplied execution request to avoid the potential performance degradation
+	 * (e.g., classpath scanning) of running test discovery twice.
+	 *
+	 * @param launcherExecutionRequest the launcher execution request; never
+	 * {@code null}
+	 * @since 6.0
+	 */
+	@API(status = MAINTAINED, since = "6.0")
+	void execute(LauncherExecutionRequest launcherExecutionRequest);
 
 }

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/LauncherConstants.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/LauncherConstants.java
@@ -257,8 +257,7 @@ public class LauncherConstants {
 	 * <p>If not specified, the {@code Launcher} will report discovery issues
 	 * during the discovery phase if
 	 * {@link Launcher#discover(LauncherDiscoveryRequest)} is called, and during
-	 * the execution phase if
-	 * {@link Launcher#execute(LauncherDiscoveryRequest, TestExecutionListener...)}
+	 * the execution phase if {@link Launcher#execute(LauncherExecutionRequest)}
 	 * is called.
 	 *
 	 * @since 1.13

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/LauncherDiscoveryRequest.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/LauncherDiscoveryRequest.java
@@ -43,6 +43,8 @@ import org.junit.platform.engine.EngineDiscoveryRequest;
  * in the test plan.</li>
  * </ul>
  *
+ * <p>This interface is not intended to be implemented by clients.
+ *
  * @since 1.0
  * @see org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder
  * @see EngineDiscoveryRequest

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/LauncherExecutionRequest.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/LauncherExecutionRequest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2015-2025 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.launcher;
+
+import static org.apiguardian.api.API.Status.MAINTAINED;
+
+import java.util.Collection;
+import java.util.Optional;
+
+import org.apiguardian.api.API;
+
+/**
+ * {@code LauncherExecutionRequest} encapsulates a request for test execution
+ * passed to the {@link Launcher}.
+ *
+ * <p>Most importantly, a {@code LauncherExecutionRequest} contains either a
+ * {@link LauncherDiscoveryRequest} for on-the-fly test discovery or a
+ * {@link TestPlan} that has previously been discovered.
+ *
+ * <p>Moreover, a {@code LauncherExecutionRequest} may contain the following:
+ *
+ * <ul>
+ * <li>Additional {@linkplain TestExecutionListener Test Execution Listeners}
+ * that should be notified of events pertaining to this execution request.</li>
+ * </ul>
+ *
+ * <p>This interface is not intended to be implemented by clients.
+ *
+ * @since 6.0
+ * @see org.junit.platform.launcher.core.LauncherExecutionRequestBuilder
+ * @see Launcher#execute(LauncherExecutionRequest)
+ */
+@API(status = MAINTAINED, since = "6.0")
+public interface LauncherExecutionRequest {
+
+	/**
+	 * {@return the test plan for this execution request}
+	 *
+	 * <p>If absent, a {@link TestPlan} will be present.
+	 */
+	Optional<TestPlan> getTestPlan();
+
+	/**
+	 * {@return the discovery request for this execution request}
+	 *
+	 * <p>If absent, a {@link TestPlan} will be present.
+	 */
+	Optional<LauncherDiscoveryRequest> getDiscoveryRequest();
+
+	/**
+	 * {@return the collection of additional test execution listeners that
+	 * should be notified about events pertaining to this execution request}
+	 */
+	Collection<? extends TestExecutionListener> getAdditionalTestExecutionListeners();
+
+}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/LauncherInterceptor.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/LauncherInterceptor.java
@@ -32,8 +32,9 @@ import org.jspecify.annotations.Nullable;
  *     </li>
  *     <li>
  *         calls to {@link Launcher#discover(LauncherDiscoveryRequest)},
- *         {@link Launcher#execute(TestPlan, TestExecutionListener...)}, and
- *         {@link Launcher#execute(LauncherDiscoveryRequest, TestExecutionListener...)}
+ *         {@link Launcher#execute(TestPlan, TestExecutionListener...)},
+ *         {@link Launcher#execute(LauncherDiscoveryRequest, TestExecutionListener...)},
+ *         and {@link Launcher#execute(LauncherExecutionRequest)},
  *     </li>
  * </ul>
  *

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestExecutionListener.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestExecutionListener.java
@@ -22,7 +22,8 @@ import org.junit.platform.engine.reporting.ReportEntry;
 
 /**
  * Register a concrete implementation of this interface with a {@link Launcher}
- * to be notified of events that occur during test execution.
+ * or {@link LauncherExecutionRequest} to be notified of events that occur
+ * during test execution.
  *
  * <p>All methods in this interface have empty <em>default</em> implementations.
  * Concrete implementations may therefore override one or more of these methods

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DefaultLauncher.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DefaultLauncher.java
@@ -24,6 +24,7 @@ import org.junit.platform.engine.support.store.NamespacedHierarchicalStore;
 import org.junit.platform.launcher.Launcher;
 import org.junit.platform.launcher.LauncherDiscoveryListener;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
+import org.junit.platform.launcher.LauncherExecutionRequest;
 import org.junit.platform.launcher.PostDiscoveryFilter;
 import org.junit.platform.launcher.TestExecutionListener;
 import org.junit.platform.launcher.TestPlan;
@@ -84,27 +85,23 @@ class DefaultLauncher implements Launcher {
 	}
 
 	@Override
-	public void execute(LauncherDiscoveryRequest discoveryRequest, TestExecutionListener... listeners) {
-		Preconditions.notNull(discoveryRequest, "LauncherDiscoveryRequest must not be null");
-		Preconditions.notNull(listeners, "TestExecutionListener array must not be null");
-		Preconditions.containsNoNullElements(listeners, "individual listeners must not be null");
-		execute(InternalTestPlan.from(discover(discoveryRequest, EXECUTION)), listeners);
-	}
-
-	@Override
-	public void execute(TestPlan testPlan, TestExecutionListener... listeners) {
-		Preconditions.notNull(testPlan, "TestPlan must not be null");
-		Preconditions.condition(testPlan instanceof InternalTestPlan, "TestPlan was not returned by this Launcher");
-		Preconditions.notNull(listeners, "TestExecutionListener array must not be null");
-		Preconditions.containsNoNullElements(listeners, "individual listeners must not be null");
-		execute((InternalTestPlan) testPlan, listeners);
+	public void execute(LauncherExecutionRequest launcherExecutionRequest) {
+		var testPlan = launcherExecutionRequest.getTestPlan().map(it -> {
+			Preconditions.condition(it instanceof InternalTestPlan, "TestPlan was not returned by this Launcher");
+			return ((InternalTestPlan) it);
+		}).orElseGet(() -> {
+			Preconditions.condition(launcherExecutionRequest.getDiscoveryRequest().isPresent(),
+				"Either a TestPlan or LauncherDiscoveryRequest must be present in the LauncherExecutionRequest");
+			return InternalTestPlan.from(discover(launcherExecutionRequest.getDiscoveryRequest().get(), EXECUTION));
+		});
+		execute(testPlan, launcherExecutionRequest.getAdditionalTestExecutionListeners());
 	}
 
 	private LauncherDiscoveryResult discover(LauncherDiscoveryRequest discoveryRequest, LauncherPhase phase) {
 		return discoveryOrchestrator.discover(discoveryRequest, phase);
 	}
 
-	private void execute(InternalTestPlan internalTestPlan, TestExecutionListener[] listeners) {
+	private void execute(InternalTestPlan internalTestPlan, Collection<? extends TestExecutionListener> listeners) {
 		try (NamespacedHierarchicalStore<Namespace> requestLevelStore = createRequestLevelStore()) {
 			executionOrchestrator.execute(internalTestPlan, requestLevelStore, listeners);
 		}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DefaultLauncherExecutionRequest.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DefaultLauncherExecutionRequest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2015-2025 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.launcher.core;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+import org.jspecify.annotations.Nullable;
+import org.junit.platform.launcher.LauncherDiscoveryRequest;
+import org.junit.platform.launcher.LauncherExecutionRequest;
+import org.junit.platform.launcher.TestExecutionListener;
+import org.junit.platform.launcher.TestPlan;
+
+/**
+ * @since 6.0
+ */
+final class DefaultLauncherExecutionRequest implements LauncherExecutionRequest {
+
+	private final @Nullable LauncherDiscoveryRequest discoveryRequest;
+	private final @Nullable TestPlan testPlan;
+	private final List<? extends TestExecutionListener> executionListeners;
+
+	DefaultLauncherExecutionRequest(@Nullable LauncherDiscoveryRequest discoveryRequest, @Nullable TestPlan testPlan,
+			Collection<? extends TestExecutionListener> executionListeners) {
+		this.discoveryRequest = discoveryRequest;
+		this.testPlan = testPlan;
+		this.executionListeners = List.copyOf(executionListeners);
+	}
+
+	@Override
+	public Optional<LauncherDiscoveryRequest> getDiscoveryRequest() {
+		return Optional.ofNullable(discoveryRequest);
+	}
+
+	@Override
+	public Optional<TestPlan> getTestPlan() {
+		return Optional.ofNullable(testPlan);
+	}
+
+	@Override
+	public Collection<? extends TestExecutionListener> getAdditionalTestExecutionListeners() {
+		return executionListeners;
+	}
+}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DefaultLauncherSession.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DefaultLauncherSession.java
@@ -22,6 +22,7 @@ import org.junit.platform.engine.support.store.NamespacedHierarchicalStore;
 import org.junit.platform.launcher.Launcher;
 import org.junit.platform.launcher.LauncherDiscoveryListener;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
+import org.junit.platform.launcher.LauncherExecutionRequest;
 import org.junit.platform.launcher.LauncherInterceptor;
 import org.junit.platform.launcher.LauncherSession;
 import org.junit.platform.launcher.LauncherSessionListener;
@@ -116,13 +117,20 @@ class DefaultLauncherSession implements LauncherSession {
 			throw new PreconditionViolationException("Launcher session has already been closed");
 		}
 
+		@SuppressWarnings("deprecation")
 		@Override
 		public void execute(LauncherDiscoveryRequest launcherDiscoveryRequest, TestExecutionListener... listeners) {
 			throw new PreconditionViolationException("Launcher session has already been closed");
 		}
 
+		@SuppressWarnings("deprecation")
 		@Override
 		public void execute(TestPlan testPlan, TestExecutionListener... listeners) {
+			throw new PreconditionViolationException("Launcher session has already been closed");
+		}
+
+		@Override
+		public void execute(LauncherExecutionRequest launcherExecutionRequest) {
 			throw new PreconditionViolationException("Launcher session has already been closed");
 		}
 	}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DelegatingLauncher.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DelegatingLauncher.java
@@ -13,6 +13,7 @@ package org.junit.platform.launcher.core;
 import org.junit.platform.launcher.Launcher;
 import org.junit.platform.launcher.LauncherDiscoveryListener;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
+import org.junit.platform.launcher.LauncherExecutionRequest;
 import org.junit.platform.launcher.TestExecutionListener;
 import org.junit.platform.launcher.TestPlan;
 
@@ -42,14 +43,20 @@ class DelegatingLauncher implements Launcher {
 		return delegate.discover(launcherDiscoveryRequest);
 	}
 
+	@SuppressWarnings("deprecation")
 	@Override
 	public void execute(LauncherDiscoveryRequest launcherDiscoveryRequest, TestExecutionListener... listeners) {
 		delegate.execute(launcherDiscoveryRequest, listeners);
 	}
 
+	@SuppressWarnings("deprecation")
 	@Override
 	public void execute(TestPlan testPlan, TestExecutionListener... listeners) {
 		delegate.execute(testPlan, listeners);
 	}
 
+	@Override
+	public void execute(LauncherExecutionRequest launcherExecutionRequest) {
+		delegate.execute(launcherExecutionRequest);
+	}
 }

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/EngineExecutionOrchestrator.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/EngineExecutionOrchestrator.java
@@ -16,6 +16,7 @@ import static org.junit.platform.launcher.LauncherConstants.STACKTRACE_PRUNING_E
 import static org.junit.platform.launcher.core.LauncherPhase.getDiscoveryIssueFailurePhase;
 import static org.junit.platform.launcher.core.ListenerRegistry.forEngineExecutionListeners;
 
+import java.util.Collection;
 import java.util.Optional;
 import java.util.function.Consumer;
 
@@ -56,7 +57,7 @@ public class EngineExecutionOrchestrator {
 	}
 
 	void execute(InternalTestPlan internalTestPlan, NamespacedHierarchicalStore<Namespace> requestLevelStore,
-			TestExecutionListener... listeners) {
+			Collection<? extends TestExecutionListener> listeners) {
 		ConfigurationParameters configurationParameters = internalTestPlan.getConfigurationParameters();
 		ListenerRegistry<TestExecutionListener> testExecutionListenerListeners = buildListenerRegistryForExecution(
 			listeners);
@@ -213,8 +214,8 @@ public class EngineExecutionOrchestrator {
 	}
 
 	private ListenerRegistry<TestExecutionListener> buildListenerRegistryForExecution(
-			TestExecutionListener... listeners) {
-		if (listeners.length == 0) {
+			Collection<? extends TestExecutionListener> listeners) {
+		if (listeners.isEmpty()) {
 			return this.listenerRegistry;
 		}
 		return ListenerRegistry.copyOf(this.listenerRegistry).addAll(listeners);

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/InterceptingLauncher.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/InterceptingLauncher.java
@@ -13,6 +13,7 @@ package org.junit.platform.launcher.core;
 import org.jspecify.annotations.Nullable;
 import org.junit.platform.launcher.Launcher;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
+import org.junit.platform.launcher.LauncherExecutionRequest;
 import org.junit.platform.launcher.LauncherInterceptor;
 import org.junit.platform.launcher.TestExecutionListener;
 import org.junit.platform.launcher.TestPlan;
@@ -46,6 +47,14 @@ class InterceptingLauncher extends DelegatingLauncher {
 	public void execute(TestPlan testPlan, TestExecutionListener... listeners) {
 		interceptor.<@Nullable Object> intercept(() -> {
 			super.execute(testPlan, listeners);
+			return null;
+		});
+	}
+
+	@Override
+	public void execute(LauncherExecutionRequest launcherExecutionRequest) {
+		interceptor.<@Nullable Object> intercept(() -> {
+			super.execute(launcherExecutionRequest);
 			return null;
 		});
 	}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherDiscoveryRequestBuilder.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherDiscoveryRequestBuilder.java
@@ -324,6 +324,17 @@ public final class LauncherDiscoveryRequestBuilder {
 	}
 
 	/**
+	 * Builds this discovery request and returns a new builder for creating a
+	 * {@link org.junit.platform.launcher.LauncherExecutionRequest} that is
+	 * initialized to contain the resulting discovery request.
+	 *
+	 * @return a new {@link LauncherExecutionRequestBuilder}
+	 */
+	public LauncherExecutionRequestBuilder forExecution() {
+		return LauncherExecutionRequestBuilder.request(build());
+	}
+
+	/**
 	 * Build the {@link LauncherDiscoveryRequest} that has been configured via
 	 * this builder.
 	 */

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherDiscoveryRequestBuilder.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherDiscoveryRequestBuilder.java
@@ -10,6 +10,7 @@
 
 package org.junit.platform.launcher.core;
 
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
 import static org.junit.platform.launcher.LauncherConstants.OUTPUT_DIR_PROPERTY_NAME;
@@ -329,7 +330,9 @@ public final class LauncherDiscoveryRequestBuilder {
 	 * initialized to contain the resulting discovery request.
 	 *
 	 * @return a new {@link LauncherExecutionRequestBuilder}
+	 * @since 6.0
 	 */
+	@API(status = EXPERIMENTAL, since = "6.0")
 	public LauncherExecutionRequestBuilder forExecution() {
 		return LauncherExecutionRequestBuilder.request(build());
 	}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherExecutionRequestBuilder.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherExecutionRequestBuilder.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2015-2025 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.launcher.core;
+
+import static org.apiguardian.api.API.Status.MAINTAINED;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+
+import org.apiguardian.api.API;
+import org.jspecify.annotations.Nullable;
+import org.junit.platform.commons.util.Preconditions;
+import org.junit.platform.launcher.LauncherDiscoveryRequest;
+import org.junit.platform.launcher.LauncherExecutionRequest;
+import org.junit.platform.launcher.TestExecutionListener;
+import org.junit.platform.launcher.TestPlan;
+
+/**
+ * The {@code LauncherExecutionRequestBuilder} provides a light-weight DSL for
+ * generating a {@link LauncherExecutionRequest}.
+ *
+ * @since 6.0
+ * @see LauncherExecutionRequest
+ */
+@API(status = MAINTAINED, since = "6.0")
+public final class LauncherExecutionRequestBuilder {
+
+	/**
+	 * Create a new {@code LauncherExecutionRequestBuilder} from the supplied
+	 * {@link LauncherDiscoveryRequest}.
+	 *
+	 * @return a new builder
+	 */
+	public static LauncherExecutionRequestBuilder request(LauncherDiscoveryRequest discoveryRequest) {
+		Preconditions.notNull(discoveryRequest, "LauncherDiscoveryRequest must not be null");
+		return new LauncherExecutionRequestBuilder(discoveryRequest, null);
+	}
+
+	/**
+	 * Create a new {@code LauncherExecutionRequestBuilder} from the supplied
+	 * {@link TestPlan}.
+	 *
+	 * @return a new builder
+	 */
+	public static LauncherExecutionRequestBuilder request(TestPlan testPlan) {
+		Preconditions.notNull(testPlan, "TestPlan must not be null");
+		return new LauncherExecutionRequestBuilder(null, testPlan);
+	}
+
+	private final @Nullable LauncherDiscoveryRequest discoveryRequest;
+	private final @Nullable TestPlan testPlan;
+	private final Collection<TestExecutionListener> executionListeners = new ArrayList<>();
+
+	private LauncherExecutionRequestBuilder(@Nullable LauncherDiscoveryRequest discoveryRequest,
+			@Nullable TestPlan testPlan) {
+
+		this.discoveryRequest = discoveryRequest;
+		this.testPlan = testPlan;
+	}
+
+	/**
+	 * Add all supplied execution listeners to the request.
+	 *
+	 * @param listeners the {@code TestExecutionListener} to add; never
+	 * {@code null}
+	 * @return this builder for method chaining
+	 * @see TestExecutionListener
+	 */
+	public LauncherExecutionRequestBuilder listeners(TestExecutionListener... listeners) {
+		Preconditions.notNull(listeners, "TestExecutionListener array must not be null");
+		Preconditions.containsNoNullElements(listeners, "individual listeners must not be null");
+		Collections.addAll(this.executionListeners, listeners);
+		return this;
+	}
+
+	/**
+	 * Build the {@link LauncherExecutionRequest} that has been configured via
+	 * this builder.
+	 */
+	public LauncherExecutionRequest build() {
+		return new DefaultLauncherExecutionRequest(discoveryRequest, testPlan, executionListeners);
+	}
+
+}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/SessionPerRequestLauncher.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/SessionPerRequestLauncher.java
@@ -19,6 +19,7 @@ import org.junit.platform.engine.support.store.NamespacedHierarchicalStore;
 import org.junit.platform.launcher.Launcher;
 import org.junit.platform.launcher.LauncherDiscoveryListener;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
+import org.junit.platform.launcher.LauncherExecutionRequest;
 import org.junit.platform.launcher.LauncherInterceptor;
 import org.junit.platform.launcher.LauncherSession;
 import org.junit.platform.launcher.LauncherSessionListener;
@@ -60,6 +61,7 @@ class SessionPerRequestLauncher implements Launcher {
 		}
 	}
 
+	@SuppressWarnings("deprecation")
 	@Override
 	public void execute(LauncherDiscoveryRequest launcherDiscoveryRequest, TestExecutionListener... listeners) {
 		try (LauncherSession session = createSession()) {
@@ -67,10 +69,18 @@ class SessionPerRequestLauncher implements Launcher {
 		}
 	}
 
+	@SuppressWarnings("deprecation")
 	@Override
 	public void execute(TestPlan testPlan, TestExecutionListener... listeners) {
 		try (LauncherSession session = createSession()) {
 			session.getLauncher().execute(testPlan, listeners);
+		}
+	}
+
+	@Override
+	public void execute(LauncherExecutionRequest launcherExecutionRequest) {
+		try (LauncherSession session = createSession()) {
+			session.getLauncher().execute(launcherExecutionRequest);
 		}
 	}
 

--- a/junit-vintage-engine/src/test/java/org/junit/vintage/engine/JUnit4ParameterizedTests.java
+++ b/junit-vintage-engine/src/test/java/org/junit/vintage/engine/JUnit4ParameterizedTests.java
@@ -64,6 +64,7 @@ class JUnit4ParameterizedTests {
 				.selectors(selector)
 				.filters(includeEngines("junit-vintage"))
 				.enableImplicitConfigurationParameters(false)
+				.forExecution()
 				.build()
 		);
 		// @formatter:on

--- a/junit-vintage-engine/src/test/java/org/junit/vintage/engine/VintageLauncherIntegrationTests.java
+++ b/junit-vintage-engine/src/test/java/org/junit/vintage/engine/VintageLauncherIntegrationTests.java
@@ -31,7 +31,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.fixtures.TrackLogRecords;
 import org.junit.platform.commons.logging.LogRecordListener;
 import org.junit.platform.engine.TestExecutionResult;
-import org.junit.platform.launcher.LauncherDiscoveryRequest;
 import org.junit.platform.launcher.PostDiscoveryFilter;
 import org.junit.platform.launcher.TestExecutionListener;
 import org.junit.platform.launcher.TestIdentifier;
@@ -263,26 +262,30 @@ class VintageLauncherIntegrationTests {
 
 	private TestPlan discover(LauncherDiscoveryRequestBuilder requestBuilder) {
 		var launcher = LauncherFactory.create();
-		return launcher.discover(toRequest(requestBuilder));
+		return launcher.discover(toDiscoveryRequest(requestBuilder).build());
 	}
 
 	private Map<TestIdentifier, TestExecutionResult> execute(LauncherDiscoveryRequestBuilder requestBuilder) {
 		Map<TestIdentifier, TestExecutionResult> results = new LinkedHashMap<>();
-		var request = toRequest(requestBuilder);
 		var launcher = LauncherFactory.create();
-		launcher.execute(request, new TestExecutionListener() {
+		var listener = new TestExecutionListener() {
 			@Override
 			public void executionFinished(TestIdentifier testIdentifier, TestExecutionResult testExecutionResult) {
 				results.put(testIdentifier, testExecutionResult);
 			}
-		});
+		};
+		var executionRequest = toDiscoveryRequest(requestBuilder) //
+				.forExecution() //
+				.listeners(listener) //
+				.build();
+		launcher.execute(executionRequest);
 		return results;
 	}
 
-	private LauncherDiscoveryRequest toRequest(LauncherDiscoveryRequestBuilder requestBuilder) {
-		return requestBuilder.filters(includeEngines(ENGINE_ID)) //
-				.enableImplicitConfigurationParameters(false) //
-				.build();
+	private LauncherDiscoveryRequestBuilder toDiscoveryRequest(LauncherDiscoveryRequestBuilder requestBuilder) {
+		return requestBuilder //
+				.filters(includeEngines(ENGINE_ID)) //
+				.enableImplicitConfigurationParameters(false);
 	}
 
 }

--- a/platform-tests/src/test/java/org/junit/platform/launcher/core/DefaultLauncherTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/core/DefaultLauncherTests.java
@@ -181,7 +181,10 @@ class DefaultLauncherTests {
 		inOrder.verify(discoveryListener).launcherDiscoveryFinished(request);
 
 		var listener = mock(TestExecutionListener.class);
-		launcher.execute(testPlan, listener);
+		var executionRequest = LauncherExecutionRequestBuilder.request(testPlan) //
+				.listeners(listener) //
+				.build();
+		launcher.execute(executionRequest);
 
 		var testExecutionResult = ArgumentCaptor.forClass(TestExecutionResult.class);
 		verify(listener).executionStarted(engineIdentifier);
@@ -216,7 +219,7 @@ class DefaultLauncherTests {
 		};
 
 		var listener = mock(TestExecutionListener.class);
-		createLauncher(engine).execute(request().build(), listener);
+		createLauncher(engine).execute(request().forExecution().listeners(listener).build());
 
 		var testExecutionResult = ArgumentCaptor.forClass(TestExecutionResult.class);
 		verify(listener).executionStarted(any());
@@ -240,7 +243,7 @@ class DefaultLauncherTests {
 		};
 
 		var listener = mock(TestExecutionListener.class);
-		createLauncher(engine).execute(request().build(), listener);
+		createLauncher(engine).execute(request().forExecution().listeners(listener).build());
 
 		var testExecutionResult = ArgumentCaptor.forClass(TestExecutionResult.class);
 		verify(listener).executionStarted(any());
@@ -264,7 +267,7 @@ class DefaultLauncherTests {
 		};
 
 		var listener = mock(TestExecutionListener.class);
-		createLauncher(engine).execute(request().build(), listener);
+		createLauncher(engine).execute(request().forExecution().listeners(listener).build());
 
 		var testExecutionResult = ArgumentCaptor.forClass(TestExecutionResult.class);
 		verify(listener).executionStarted(any());
@@ -289,7 +292,7 @@ class DefaultLauncherTests {
 		};
 
 		var listener = mock(TestExecutionListener.class);
-		createLauncher(engine).execute(request().build(), listener);
+		createLauncher(engine).execute(request().forExecution().listeners(listener).build());
 
 		var testExecutionResult = ArgumentCaptor.forClass(TestExecutionResult.class);
 		verify(listener).executionStarted(any());
@@ -316,7 +319,7 @@ class DefaultLauncherTests {
 		};
 
 		var listener = mock(TestExecutionListener.class);
-		createLauncher(engine).execute(request().build(), listener);
+		createLauncher(engine).execute(request().forExecution().listeners(listener).build());
 
 		var testExecutionResult = ArgumentCaptor.forClass(TestExecutionResult.class);
 		verify(listener).executionStarted(any());
@@ -339,7 +342,7 @@ class DefaultLauncherTests {
 		};
 
 		var listener = mock(TestExecutionListener.class);
-		createLauncher(engine).execute(request().build(), listener);
+		createLauncher(engine).execute(request().forExecution().listeners(listener).build());
 
 		verify(listener).executionSkipped(any(TestIdentifier.class), eq("not today"));
 		verify(listener, times(0)).executionStarted(any());
@@ -359,7 +362,7 @@ class DefaultLauncherTests {
 		};
 
 		var listener = mock(TestExecutionListener.class);
-		createLauncher(engine).execute(request().build(), listener);
+		createLauncher(engine).execute(request().forExecution().listeners(listener).build());
 
 		verify(listener).executionStarted(any());
 		verify(listener).executionFinished(any(), eq(successful()));
@@ -427,7 +430,7 @@ class DefaultLauncherTests {
 		var engine = new TestEngineSpy();
 
 		var launcher = createLauncher(engine);
-		launcher.execute(request().build());
+		launcher.execute(request().forExecution().build());
 
 		var configurationParameters = requireNonNull(engine.requestForExecution).getConfigurationParameters();
 		assertThat(configurationParameters.get("key")).isNotPresent();
@@ -438,7 +441,7 @@ class DefaultLauncherTests {
 		var engine = new TestEngineSpy();
 
 		var launcher = createLauncher(engine);
-		launcher.execute(request().configurationParameter("key", "value").build());
+		launcher.execute(request().configurationParameter("key", "value").forExecution().build());
 
 		var configurationParameters = requireNonNull(engine.requestForExecution).getConfigurationParameters();
 		assertThat(configurationParameters.get("key")).isPresent();
@@ -453,7 +456,7 @@ class DefaultLauncherTests {
 			var engine = new TestEngineSpy();
 
 			var launcher = createLauncher(engine);
-			launcher.execute(request().build());
+			launcher.execute(request().forExecution().build());
 
 			var configurationParameters = requireNonNull(engine.requestForExecution).getConfigurationParameters();
 			var optionalFoo = configurationParameters.get(FOO);
@@ -471,7 +474,7 @@ class DefaultLauncherTests {
 		var listener = new SummaryGeneratingListener();
 
 		var launcher = createLauncher(engine);
-		launcher.execute(request().build(), listener);
+		launcher.execute(request().forExecution().listeners(listener).build());
 
 		assertThat(listener.getSummary()).isNotNull();
 		assertThat(listener.getSummary().getContainersFoundCount()).isEqualTo(1);
@@ -553,7 +556,7 @@ class DefaultLauncherTests {
 
 		var launcher = createLauncher(engine);
 		var listener = mock(TestExecutionListener.class);
-		launcher.execute(request().build(), listener);
+		launcher.execute(request().forExecution().listeners(listener).build());
 
 		var inOrder = inOrder(listener);
 		var testPlanArgumentCaptor = ArgumentCaptor.forClass(TestPlan.class);
@@ -590,10 +593,11 @@ class DefaultLauncherTests {
 		var testPlan = launcher.discover(request().build());
 		verify(engine, times(1)).discover(any(), any());
 
-		launcher.execute(testPlan);
+		var executionRequest = LauncherExecutionRequestBuilder.request(testPlan).build();
+		launcher.execute(executionRequest);
 		verify(engine, times(1)).execute(any());
 
-		var e = assertThrows(PreconditionViolationException.class, () -> launcher.execute(testPlan));
+		var e = assertThrows(PreconditionViolationException.class, () -> launcher.execute(executionRequest));
 		assertEquals("TestPlan must only be executed once", e.getMessage());
 	}
 
@@ -640,7 +644,12 @@ class DefaultLauncherTests {
 		var launcher = createLauncher(engine);
 		TestExecutionListener listener = mock();
 
-		launcher.execute(request().configurationParameter(DRY_RUN_PROPERTY_NAME, "true").build(), listener);
+		var request = request() //
+				.configurationParameter(DRY_RUN_PROPERTY_NAME, "true") //
+				.forExecution() //
+				.listeners(listener) //
+				.build();
+		launcher.execute(request);
 
 		var inOrder = inOrder(listener);
 		inOrder.verify(listener).testPlanExecutionStarted(any());
@@ -994,15 +1003,19 @@ class DefaultLauncherTests {
 			return null;
 		}).when(executionListener).executionFinished(any(), any());
 
-		var builder = request() //
+		var launcher = createLauncher(engine);
+
+		var discoveryRequestBuilder = request() //
 				.enableImplicitConfigurationParameters(false) //
 				.configurationParameter(DISCOVERY_ISSUE_FAILURE_PHASE_PROPERTY_NAME, "execution") //
 				.configurationParameter(DEFAULT_DISCOVERY_LISTENER_CONFIGURATION_PROPERTY_NAME, "logging");
-		var request = configurer.apply(builder).build();
-		var launcher = createLauncher(engine);
+		var discoveryRequest = configurer.apply(discoveryRequestBuilder).build();
+		var testPlan = launcher.discover(discoveryRequest);
 
-		var testPlan = launcher.discover(request);
-		launcher.execute(testPlan, executionListener);
+		var executionRequest = LauncherExecutionRequestBuilder.request(testPlan) //
+				.listeners(executionListener) //
+				.build();
+		launcher.execute(executionRequest);
 
 		var inOrder = inOrder(executionListener);
 		var testIdentifier = ArgumentCaptor.forClass(TestIdentifier.class);

--- a/platform-tests/src/test/java/org/junit/platform/launcher/core/LauncherConfigurationParametersTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/core/LauncherConfigurationParametersTests.java
@@ -169,11 +169,14 @@ class LauncherConfigurationParametersTests {
 
 	@Test
 	void getValueInExtensionContext() {
+		var summary = new SummaryGeneratingListener();
 		var request = LauncherDiscoveryRequestBuilder.request() //
 				.configurationParameter("thing", "one else!") //
-				.selectors(DiscoverySelectors.selectClass(Something.class)).build();
-		var summary = new SummaryGeneratingListener();
-		LauncherFactory.create().execute(request, summary);
+				.selectors(DiscoverySelectors.selectClass(Something.class)) //
+				.forExecution() //
+				.listeners(summary) //
+				.build();
+		LauncherFactory.create().execute(request);
 		assertEquals(0, summary.getSummary().getTestsFailedCount());
 	}
 

--- a/platform-tests/src/test/java/org/junit/platform/launcher/core/LauncherFactoryTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/core/LauncherFactoryTests.java
@@ -80,7 +80,7 @@ class LauncherFactoryTests {
 
 			NoopTestExecutionListener.called = false;
 
-			launcher.execute(request().build());
+			launcher.execute(request().forExecution().build());
 
 			assertTrue(NoopTestExecutionListener.called);
 		});
@@ -101,7 +101,7 @@ class LauncherFactoryTests {
 				UnusedTestExecutionListener.called = false;
 				AnotherUnusedTestExecutionListener.called = false;
 
-				launcher.execute(request().build());
+				launcher.execute(request().forExecution().build());
 
 				var logMessage = listener.stream(ServiceLoaderRegistry.class) //
 						.map(LogRecord::getMessage) //
@@ -316,19 +316,25 @@ class LauncherFactoryTests {
 					.enableTestEngineAutoRegistration(false) //
 					.addTestEngines(engine) //
 					.build();
-			var launcher = LauncherFactory.create(config);
-			var request = request().configurationParameter(LauncherConstants.STACKTRACE_PRUNING_ENABLED_PROPERTY_NAME,
-				"false").build();
 
 			AtomicReference<TestExecutionResult> result = new AtomicReference<>();
-			launcher.execute(request, new TestExecutionListener() {
+			var listener = new TestExecutionListener() {
 				@Override
 				public void executionFinished(TestIdentifier testIdentifier, TestExecutionResult testExecutionResult) {
 					if (testIdentifier.getParentId().isEmpty()) {
 						result.set(testExecutionResult);
 					}
 				}
-			});
+			};
+
+			var request = request() //
+					.configurationParameter(LauncherConstants.STACKTRACE_PRUNING_ENABLED_PROPERTY_NAME, "false") //
+					.forExecution() //
+					.listeners(listener) //
+					.build();
+
+			var launcher = LauncherFactory.create(config);
+			launcher.execute(request);
 
 			assertThat(requireNonNull(result.get()).getThrowable().orElseThrow()) //
 					.hasRootCauseMessage("from execution") //
@@ -345,16 +351,22 @@ class LauncherFactoryTests {
 				.build();
 
 		try (LauncherSession session = LauncherFactory.openSession(config)) {
-			var launcher = session.getLauncher();
-			var request = request().selectors(selectClass(SessionTrackingTestCase.class)).build();
 
 			AtomicReference<Throwable> errorRef = new AtomicReference<>();
-			launcher.execute(request, new TestExecutionListener() {
+			var listener = new TestExecutionListener() {
 				@Override
 				public void executionFinished(TestIdentifier testIdentifier, TestExecutionResult testExecutionResult) {
 					testExecutionResult.getThrowable().ifPresent(errorRef::set);
 				}
-			});
+			};
+
+			var request = request() //
+					.selectors(selectClass(SessionTrackingTestCase.class)) //
+					.forExecution() //
+					.listeners(listener) //
+					.build();
+
+			session.getLauncher().execute(request);
 
 			assertThat(errorRef.get()).isNull();
 		}
@@ -367,16 +379,22 @@ class LauncherFactoryTests {
 				.build();
 
 		try (LauncherSession session = LauncherFactory.openSession(config)) {
-			var launcher = session.getLauncher();
-			var request = request().selectors(selectClass(SessionStoringTestCase.class)).build();
 
 			AtomicReference<Throwable> errorRef = new AtomicReference<>();
-			launcher.execute(request, new TestExecutionListener() {
+			var listener = new TestExecutionListener() {
 				@Override
 				public void executionFinished(TestIdentifier testIdentifier, TestExecutionResult testExecutionResult) {
 					testExecutionResult.getThrowable().ifPresent(errorRef::set);
 				}
-			});
+			};
+
+			var request = request() //
+					.selectors(selectClass(SessionStoringTestCase.class)) //
+					.forExecution() //
+					.listeners(listener) //
+					.build();
+
+			session.getLauncher().execute(request);
 
 			assertThat(errorRef.get()).isNull();
 		}
@@ -390,10 +408,12 @@ class LauncherFactoryTests {
 				.build();
 
 		try (LauncherSession session = LauncherFactory.openSession(config)) {
-			var launcher = session.getLauncher();
-			var request = request().selectors(selectClass(SessionResourceAutoCloseTestCase.class)).build();
+			var request = request() //
+					.selectors(selectClass(SessionResourceAutoCloseTestCase.class)) //
+					.forExecution() //
+					.build();
 
-			launcher.execute(request);
+			session.getLauncher().execute(request);
 			assertThat(CloseTrackingResource.closed).isFalse();
 		}
 
@@ -406,10 +426,12 @@ class LauncherFactoryTests {
 		var config = LauncherConfig.builder().build();
 
 		try (LauncherSession session = LauncherFactory.openSession(config)) {
-			var launcher = session.getLauncher();
-			var request = request().selectors(selectClass(RequestResourceAutoCloseTestCase.class)).build();
+			var request = request() //
+					.selectors(selectClass(RequestResourceAutoCloseTestCase.class)) //
+					.forExecution() //
+					.build();
 
-			launcher.execute(request);
+			session.getLauncher().execute(request);
 
 			assertThat(CloseTrackingResource.closed).isTrue();
 		}

--- a/platform-tests/src/test/java/org/junit/platform/launcher/core/StoreSharingTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/core/StoreSharingTests.java
@@ -20,7 +20,7 @@ import org.junit.platform.engine.support.store.Namespace;
 import org.junit.platform.fakes.TestEngineSpy;
 import org.junit.platform.fakes.TestEngineStub;
 import org.junit.platform.launcher.Launcher;
-import org.junit.platform.launcher.LauncherDiscoveryRequest;
+import org.junit.platform.launcher.LauncherExecutionRequest;
 
 /**
  * @since 5.13
@@ -54,8 +54,9 @@ class StoreSharingTests {
 					.addTestEngines(engineWriter, engineReader) //
 					.build());
 
-		LauncherDiscoveryRequest discoveryRequest = LauncherDiscoveryRequestBuilder //
+		LauncherExecutionRequest discoveryRequest = LauncherDiscoveryRequestBuilder //
 				.request() //
+				.forExecution() //
 				.build();
 
 		launcher.execute(discoveryRequest);

--- a/platform-tests/src/test/java/org/junit/platform/launcher/core/StreamInterceptingTestExecutionListenerIntegrationTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/core/StreamInterceptingTestExecutionListenerIntegrationTests.java
@@ -72,12 +72,14 @@ class StreamInterceptingTestExecutionListenerIntegrationTests {
 		}).when(listener).executionStarted(any());
 
 		var launcher = createLauncher(engine);
-		var discoveryRequest = request()//
+		var executionRequest = request()//
 				.selectors(selectUniqueId(test.getUniqueId()))//
 				.configurationParameter(configParam, String.valueOf(true))//
 				.configurationParameter(LauncherConstants.CAPTURE_MAX_BUFFER_PROPERTY_NAME, String.valueOf(5))//
+				.forExecution()//
+				.listeners(listener)//
 				.build();
-		launcher.execute(discoveryRequest, listener);
+		launcher.execute(executionRequest);
 
 		var testPlanArgumentCaptor = ArgumentCaptor.forClass(TestPlan.class);
 		var inOrder = inOrder(listener);
@@ -105,12 +107,14 @@ class StreamInterceptingTestExecutionListenerIntegrationTests {
 		assertThat(StreamInterceptor.registerStderr(1)).isPresent();
 
 		var launcher = createLauncher(engine);
-		var discoveryRequest = request()//
+		var listener = mock(TestExecutionListener.class);
+		var executionRequest = request()//
 				.selectors(selectUniqueId(test.getUniqueId()))//
 				.configurationParameter(configParam, String.valueOf(true))//
+				.forExecution()//
+				.listeners(listener)//
 				.build();
-		var listener = mock(TestExecutionListener.class);
-		launcher.execute(discoveryRequest, listener);
+		launcher.execute(executionRequest);
 
 		verify(listener, never()).reportingEntryPublished(any(), any());
 	}

--- a/platform-tests/src/test/java/org/junit/platform/launcher/jfr/FlightRecordingExecutionListenerIntegrationTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/jfr/FlightRecordingExecutionListenerIntegrationTests.java
@@ -45,6 +45,7 @@ public class FlightRecordingExecutionListenerIntegrationTests {
 		var request = request() //
 				.selectors(selectClass(TestCase.class)) //
 				.outputDirectoryProvider(hierarchicalOutputDirectoryProvider(tempDir)) //
+				.forExecution() //
 				.build();
 
 		launcher.execute(request);

--- a/platform-tests/src/test/java/org/junit/platform/launcher/listeners/LoggingListenerTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/listeners/LoggingListenerTests.java
@@ -91,9 +91,12 @@ public class LoggingListenerTests {
 				.build();
 		var request = request() //
 				.selectors(selectClass(TestCase.class)) //
-				.filters(includeEngines("junit-jupiter")).build();
+				.filters(includeEngines("junit-jupiter")) //
+				.forExecution() //
+				.listeners(listener) //
+				.build();
 		LauncherFactory.create(config) //
-				.execute(request, listener);
+				.execute(request);
 	}
 
 	@SuppressWarnings("JUnitMalformedDeclaration")

--- a/platform-tests/src/test/java/org/junit/platform/launcher/listeners/UniqueIdTrackingListenerIntegrationTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/listeners/UniqueIdTrackingListenerIntegrationTests.java
@@ -208,13 +208,7 @@ class UniqueIdTrackingListenerIntegrationTests {
 
 	private List<String> executeTests(Map<String, String> configurationParameters, ClassSelector... classSelectors) {
 		List<String> uniqueIds = new ArrayList<>();
-		var request = request()//
-				.selectors(classSelectors)//
-				.filters(includeEngines("junit-jupiter"))//
-				.configurationParameters(configurationParameters)//
-				.configurationParameter(WORKING_DIR_PROPERTY_NAME, workingDir.toAbsolutePath().toString())//
-				.build();
-		LauncherFactory.create().execute(request, new TestExecutionListener() {
+		var listener = new TestExecutionListener() {
 
 			@Nullable
 			private TestPlan testPlan;
@@ -241,7 +235,16 @@ class UniqueIdTrackingListenerIntegrationTests {
 					uniqueIds.add(testIdentifier.getUniqueId());
 				}
 			}
-		});
+		};
+		var request = request()//
+				.selectors(classSelectors)//
+				.filters(includeEngines("junit-jupiter"))//
+				.configurationParameters(configurationParameters)//
+				.configurationParameter(WORKING_DIR_PROPERTY_NAME, workingDir.toAbsolutePath().toString())//
+				.forExecution()//
+				.listeners(listener)//
+				.build();
+		LauncherFactory.create().execute(request);
 		return uniqueIds;
 	}
 

--- a/platform-tests/src/test/java/org/junit/platform/reporting/legacy/xml/LegacyXmlReportGeneratingListenerTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/reporting/legacy/xml/LegacyXmlReportGeneratingListenerTests.java
@@ -432,8 +432,12 @@ class LegacyXmlReportGeneratingListenerTests {
 		var reportListener = new LegacyXmlReportGeneratingListener(tempDirectory.toString(), out, clock);
 		var launcher = createLauncher(engine);
 		launcher.registerTestExecutionListeners(reportListener);
-		launcher.execute(request().configurationParameter(LauncherConstants.STACKTRACE_PRUNING_ENABLED_PROPERTY_NAME,
-			"false").selectors(selectUniqueId(UniqueId.forEngine(engine.getId()))).build());
+		var request = request() //
+				.configurationParameter(LauncherConstants.STACKTRACE_PRUNING_ENABLED_PROPERTY_NAME, "false") //
+				.selectors(selectUniqueId(UniqueId.forEngine(engine.getId()))) //
+				.forExecution() //
+				.build();
+		launcher.execute(request);
 	}
 
 	private Match readValidXmlFile(Path xmlFile) throws Exception {

--- a/platform-tests/src/test/java/org/junit/platform/reporting/open/xml/OpenTestReportGeneratingListenerTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/reporting/open/xml/OpenTestReportGeneratingListenerTests.java
@@ -304,8 +304,10 @@ public class OpenTestReportGeneratingListenerTests {
 				.configurationParameter(CAPTURE_STDERR_PROPERTY_NAME, String.valueOf(true)) //
 				.configurationParameter(OUTPUT_DIR_PROPERTY_NAME, outputDir.toString()) //
 				.configurationParameters(extraConfigurationParameters) //
+				.forExecution() //
+				.listeners(new OpenTestReportGeneratingListener(tempDirectory)) //
 				.build();
-		createLauncher(engine).execute(request, new OpenTestReportGeneratingListener(tempDirectory));
+		createLauncher(engine).execute(request);
 	}
 
 }


### PR DESCRIPTION
## Overview

The new `Launcher.execute(LauncherExecutionRequest)` method paves the
road for adding additional parameters to test execution without having
to add additional overloads of `execute()`. For example, for #1880
we will likely need to introduce a `CancellationToken` (as drafted
in #4709). Instead of having to add two new overloads, such changes will
then be easy because only `LauncherExecutionRequest` will need to be
changed.

`LauncherExecutionRequestBuilder` provides a fluent API for constructing
execution requests starting either with a `TestPlan` or a
`LauncherDiscoveryRequest`. In addition,
`LauncherDiscoveryRequestBuilder.forExecution()` is a convenience method
to create an execution request from a discovery request.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://docs.junit.org/snapshot/user-guide/) and [Release Notes](https://docs.junit.org/snapshot/user-guide/#release-notes)
