### PR TITLE
Fix obsolete code in `ParameterizedInvocationNameFormatter`

### DIFF
--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedInvocationNameFormatter.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedInvocationNameFormatter.java
@@ -21,7 +21,6 @@ import static org.junit.jupiter.params.ParameterizedInvocationConstants.INDEX_PL
 import static org.junit.platform.commons.util.StringUtils.isNotBlank;
 
 import java.text.FieldPosition;
-import java.text.Format;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -40,7 +39,6 @@ import org.junit.jupiter.api.extension.ExtensionConfigurationException;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.platform.commons.JUnitException;
 import org.junit.platform.commons.util.Preconditions;
-import org.junit.platform.commons.util.StringUtils;
 
 /**
  * @since 5.0
@@ -229,15 +227,10 @@ class ParameterizedInvocationNameFormatter {
 
 	private static class MessageFormatPartialFormatter implements PartialFormatter {
 
-		@SuppressWarnings("UnnecessaryUnicodeEscape")
-		private static final char ELLIPSIS = '\u2026';
-
 		private final MessageFormat messageFormat;
-		private final int argumentMaxLength;
 
-		MessageFormatPartialFormatter(String pattern, int argumentMaxLength) {
+		MessageFormatPartialFormatter(String pattern, int ignored) {
 			this.messageFormat = new MessageFormat(pattern);
-			this.argumentMaxLength = argumentMaxLength;
 		}
 
 		// synchronized because MessageFormat is not thread-safe
@@ -247,22 +240,8 @@ class ParameterizedInvocationNameFormatter {
 		}
 
 		private @Nullable Object[] makeReadable(@Nullable Object[] arguments) {
-			Format[] formats = messageFormat.getFormatsByArgumentIndex();
-			@Nullable
-			Object[] result = Arrays.copyOf(arguments, Math.min(arguments.length, formats.length), Object[].class);
-			for (int i = 0; i < result.length; i++) {
-				if (formats[i] == null) {
-					result[i] = truncateIfExceedsMaxLength(StringUtils.nullSafeToString(arguments[i]));
-				}
-			}
-			return result;
-		}
-
-		private @Nullable String truncateIfExceedsMaxLength(@Nullable String argument) {
-			if (argument != null && argument.length() > this.argumentMaxLength) {
-				return argument.substring(0, this.argumentMaxLength - 1) + ELLIPSIS;
-			}
-			return argument;
+			return Arrays.copyOf(arguments,
+				Math.min(arguments.length, messageFormat.getFormatsByArgumentIndex().length), Object[].class);
 		}
 	}
 


### PR DESCRIPTION


while inspecting 

-https://github.com/junit-team/junit-framework/issues/4714

i was wondering whats all these obsolete code used for?

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://docs.junit.org/snapshot/user-guide/) and [Release Notes](https://docs.junit.org/snapshot/user-guide/#release-notes)
