### PR TITLE
Remove `java.*` packages from `Import-Package` headers in all jars

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.13.4.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.13.4.adoc
@@ -10,6 +10,16 @@ link:{junit-framework-repo}+/milestone/101?closed=1+[5.13.4] milestone page in t
 repository on GitHub.
 
 
+[[release-notes-5.13.4-overall-improvements]]
+=== Overall Changes
+
+[[release-notes-5.13.4-overall-new-features-and-improvements]]
+==== New Features and Improvements
+
+* Remove `java.*` packages from `Import-Package` headers in all jar manifests to maximize
+  compatibility with older OSGi runtimes.
+
+
 [[release-notes-5.13.4-junit-platform]]
 === JUnit Platform
 

--- a/gradle/plugins/common/src/main/kotlin/junitbuild.osgi-conventions.gradle.kts
+++ b/gradle/plugins/common/src/main/kotlin/junitbuild.osgi-conventions.gradle.kts
@@ -67,6 +67,11 @@ tasks.withType<Jar>().named {
 				# Instruct the APIGuardianAnnotations how to operate.
 				# See https://bnd.bndtools.org/instructions/export-apiguardian.html
 				-export-apiguardian: *;version=${'$'}{versionmask;===;${'$'}{version_cleanup;${'$'}{task.archiveVersion}}}
+
+				# Avoid including java packages in Import-Package header to maximize compatibility with older OSGi runtimes.
+				# See https://bnd.bndtools.org/instructions/noimportjava.html
+				# Issue: https://github.com/junit-team/junit-framework/issues/4733
+				-noimportjava: true
 			"""
 		)
 


### PR DESCRIPTION
... to maximize compatibility with older OSGi runtimes.

Resolves #4733.

<!-- Please describe your changes here and list any open questions you might have. -->

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://docs.junit.org/snapshot/user-guide/) and [Release Notes](https://docs.junit.org/snapshot/user-guide/#release-notes)
