### PR TITLE
Enable ErrorProne checks and fix resulting findings

### DIFF
--- a/documentation/src/main/java/example/domain/Person.java
+++ b/documentation/src/main/java/example/domain/Person.java
@@ -12,7 +12,7 @@ package example.domain;
 
 import java.time.LocalDate;
 
-public class Person {
+public final class Person {
 
 	public enum Gender {
 		F, M

--- a/gradle/plugins/common/src/main/kotlin/junitbuild.java-nullability-conventions.gradle.kts
+++ b/gradle/plugins/common/src/main/kotlin/junitbuild.java-nullability-conventions.gradle.kts
@@ -19,9 +19,23 @@ nullaway {
 
 tasks.withType<JavaCompile>().configureEach {
 	options.errorprone {
-		disableAllChecks = true
+		val onJ9 = java.toolchain.implementation.orNull == JvmImplementation.J9
+		if (name == "compileJava" && !onJ9) {
+			disable(
+				"BadImport",
+				"UnnecessaryLambda",
+				"AnnotateFormatMethod",
+				"StringSplitter",
+				"DoNotCallSuggester",
+				"InlineMeSuggester",
+				"ImmutableEnumChecker",
+				"MissingSummary"
+			)
+		} else {
+			disableAllChecks = true
+		}
 		nullaway {
-			if (java.toolchain.implementation.orNull == JvmImplementation.J9) {
+			if (onJ9) {
 				disable()
 			} else {
 				enable()

--- a/gradle/plugins/common/src/main/kotlin/junitbuild.java-nullability-conventions.gradle.kts
+++ b/gradle/plugins/common/src/main/kotlin/junitbuild.java-nullability-conventions.gradle.kts
@@ -31,6 +31,7 @@ tasks.withType<JavaCompile>().configureEach {
 				"ImmutableEnumChecker",
 				"MissingSummary"
 			)
+			error("PackageLocation")
 		} else {
 			disableAllChecks = true
 		}

--- a/gradle/plugins/common/src/main/kotlin/junitbuild.java-nullability-conventions.gradle.kts
+++ b/gradle/plugins/common/src/main/kotlin/junitbuild.java-nullability-conventions.gradle.kts
@@ -22,14 +22,26 @@ tasks.withType<JavaCompile>().configureEach {
 		val onJ9 = java.toolchain.implementation.orNull == JvmImplementation.J9
 		if (name == "compileJava" && !onJ9) {
 			disable(
+
+				// This check is opinionated wrt. which method names it considers unsuitable for import which includes
+				// a few of our own methods in `ReflectionUtils` etc.
 				"BadImport",
+
+				// The findings of this check are subjective because a named constant can be more readable in many cases
 				"UnnecessaryLambda",
+
+				// Resolving findings for these checks requires ErrorProne's annotations which we don't want to use
 				"AnnotateFormatMethod",
-				"StringSplitter",
 				"DoNotCallSuggester",
 				"InlineMeSuggester",
 				"ImmutableEnumChecker",
-				"MissingSummary"
+
+				// Resolving findings for this checks requires using Guava which we don't want to use
+				"StringSplitter",
+
+				// Produces a lot of findings that we consider to be false positives, for example for package-private
+				// classes and methods
+				"MissingSummary",
 			)
 			error("PackageLocation")
 		} else {

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
@@ -116,7 +116,7 @@ public class Assertions {
 	 * <p>See Javadoc for {@link #fail(String)} for an explanation of this method's
 	 * generic return type {@code V}.
 	 */
-	@SuppressWarnings("NullAway")
+	@SuppressWarnings({ "NullAway", "TypeParameterUnusedInFormals" })
 	public static <V> V fail() {
 		AssertionUtils.fail();
 		return null; // appeasing the compiler: this line will never be executed.
@@ -136,7 +136,7 @@ public class Assertions {
 	 * Stream.of().map(entry -> fail("should not be called"));
 	 * }</pre>
 	 */
-	@SuppressWarnings("NullAway")
+	@SuppressWarnings({ "NullAway", "TypeParameterUnusedInFormals" })
 	public static <V> V fail(@Nullable String message) {
 		AssertionUtils.fail(message);
 		return null; // appeasing the compiler: this line will never be executed.
@@ -149,7 +149,7 @@ public class Assertions {
 	 * <p>See Javadoc for {@link #fail(String)} for an explanation of this method's
 	 * generic return type {@code V}.
 	 */
-	@SuppressWarnings("NullAway")
+	@SuppressWarnings({ "NullAway", "TypeParameterUnusedInFormals" })
 	public static <V> V fail(@Nullable String message, @Nullable Throwable cause) {
 		AssertionUtils.fail(message, cause);
 		return null; // appeasing the compiler: this line will never be executed.
@@ -161,7 +161,7 @@ public class Assertions {
 	 * <p>See Javadoc for {@link #fail(String)} for an explanation of this method's
 	 * generic return type {@code V}.
 	 */
-	@SuppressWarnings("NullAway")
+	@SuppressWarnings({ "NullAway", "TypeParameterUnusedInFormals" })
 	public static <V> V fail(@Nullable Throwable cause) {
 		AssertionUtils.fail(cause);
 		return null; // appeasing the compiler: this line will never be executed.
@@ -174,7 +174,7 @@ public class Assertions {
 	 * <p>See Javadoc for {@link #fail(String)} for an explanation of this method's
 	 * generic return type {@code V}.
 	 */
-	@SuppressWarnings("NullAway")
+	@SuppressWarnings({ "NullAway", "TypeParameterUnusedInFormals" })
 	public static <V> V fail(Supplier<@Nullable String> messageSupplier) {
 		AssertionUtils.fail(messageSupplier);
 		return null; // appeasing the compiler: this line will never be executed.
@@ -1741,7 +1741,7 @@ public class Assertions {
 	// --- assertNotEquals -----------------------------------------------------
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * @since 5.4
 	 */
@@ -1751,7 +1751,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * @since 5.4
 	 */
@@ -1761,7 +1761,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * @since 5.4
 	 */
@@ -1771,7 +1771,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * @since 5.4
 	 */
@@ -1781,7 +1781,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>Fails with the supplied failure {@code message}.
 	 *
@@ -1793,7 +1793,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>Fails with the supplied failure {@code message}.
 	 *
@@ -1805,7 +1805,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>Fails with the supplied failure {@code message}.
 	 *
@@ -1817,7 +1817,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>Fails with the supplied failure {@code message}.
 	 *
@@ -1829,7 +1829,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>If necessary, the failure message will be retrieved lazily from the
 	 * supplied {@code messageSupplier}.
@@ -1842,7 +1842,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>If necessary, the failure message will be retrieved lazily from the
 	 * supplied {@code messageSupplier}.
@@ -1856,7 +1856,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>If necessary, the failure message will be retrieved lazily from the
 	 * supplied {@code messageSupplier}.
@@ -1870,7 +1870,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>If necessary, the failure message will be retrieved lazily from the
 	 * supplied {@code messageSupplier}.
@@ -1884,7 +1884,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * @since 5.4
 	 */
@@ -1894,7 +1894,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * @since 5.4
 	 */
@@ -1904,7 +1904,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * @since 5.4
 	 */
@@ -1914,7 +1914,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * @since 5.4
 	 */
@@ -1924,7 +1924,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>Fails with the supplied failure {@code message}.
 	 *
@@ -1936,7 +1936,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>Fails with the supplied failure {@code message}.
 	 *
@@ -1948,7 +1948,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>Fails with the supplied failure {@code message}.
 	 *
@@ -1960,7 +1960,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>Fails with the supplied failure {@code message}.
 	 *
@@ -1972,7 +1972,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>If necessary, the failure message will be retrieved lazily from the
 	 * supplied {@code messageSupplier}.
@@ -1985,7 +1985,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>If necessary, the failure message will be retrieved lazily from the
 	 * supplied {@code messageSupplier}.
@@ -1999,7 +1999,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>If necessary, the failure message will be retrieved lazily from the
 	 * supplied {@code messageSupplier}.
@@ -2013,7 +2013,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>If necessary, the failure message will be retrieved lazily from the
 	 * supplied {@code messageSupplier}.
@@ -2027,7 +2027,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * @since 5.4
 	 */
@@ -2037,7 +2037,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * @since 5.4
 	 */
@@ -2047,7 +2047,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * @since 5.4
 	 */
@@ -2057,7 +2057,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * @since 5.4
 	 */
@@ -2067,7 +2067,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>Fails with the supplied failure {@code message}.
 	 *
@@ -2079,7 +2079,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>Fails with the supplied failure {@code message}.
 	 *
@@ -2091,7 +2091,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>Fails with the supplied failure {@code message}.
 	 *
@@ -2103,7 +2103,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>Fails with the supplied failure {@code message}.
 	 *
@@ -2116,7 +2116,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>If necessary, the failure message will be retrieved lazily from the
 	 * supplied {@code messageSupplier}.
@@ -2129,7 +2129,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>If necessary, the failure message will be retrieved lazily from the
 	 * supplied {@code messageSupplier}.
@@ -2143,7 +2143,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>If necessary, the failure message will be retrieved lazily from the
 	 * supplied {@code messageSupplier}.
@@ -2157,7 +2157,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>If necessary, the failure message will be retrieved lazily from the
 	 * supplied {@code messageSupplier}.
@@ -2171,7 +2171,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * @since 5.4
 	 */
@@ -2181,7 +2181,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * @since 5.4
 	 */
@@ -2191,7 +2191,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * @since 5.4
 	 */
@@ -2201,7 +2201,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * @since 5.4
 	 */
@@ -2211,7 +2211,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>Fails with the supplied failure {@code message}.
 	 *
@@ -2223,7 +2223,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>Fails with the supplied failure {@code message}.
 	 *
@@ -2235,7 +2235,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>Fails with the supplied failure {@code message}.
 	 *
@@ -2247,7 +2247,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>Fails with the supplied failure {@code message}.
 	 *
@@ -2259,7 +2259,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>If necessary, the failure message will be retrieved lazily from the
 	 * supplied {@code messageSupplier}.
@@ -2272,7 +2272,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>If necessary, the failure message will be retrieved lazily from the
 	 * supplied {@code messageSupplier}.
@@ -2286,7 +2286,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>If necessary, the failure message will be retrieved lazily from the
 	 * supplied {@code messageSupplier}.
@@ -2300,7 +2300,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>If necessary, the failure message will be retrieved lazily from the
 	 * supplied {@code messageSupplier}.
@@ -2314,7 +2314,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>Inequality imposed by this method is consistent with
 	 * {@link Float#equals(Object)} and {@link Float#compare(float, float)}.
@@ -2327,7 +2327,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>Inequality imposed by this method is consistent with
 	 * {@link Float#equals(Object)} and {@link Float#compare(float, float)}.
@@ -2340,7 +2340,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>Inequality imposed by this method is consistent with
 	 * {@link Float#equals(Object)} and {@link Float#compare(float, float)}.
@@ -2353,7 +2353,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>Inequality imposed by this method is consistent with
 	 * {@link Float#equals(Object)} and {@link Float#compare(float, float)}.
@@ -2366,7 +2366,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>Inequality imposed by this method is consistent with
 	 * {@link Float#equals(Object)} and {@link Float#compare(float, float)}.
@@ -2381,7 +2381,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>Inequality imposed by this method is consistent with
 	 * {@link Float#equals(Object)} and {@link Float#compare(float, float)}.
@@ -2396,7 +2396,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>Inequality imposed by this method is consistent with
 	 * {@link Float#equals(Object)} and {@link Float#compare(float, float)}.
@@ -2411,7 +2411,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>Inequality imposed by this method is consistent with
 	 * {@link Float#equals(Object)} and {@link Float#compare(float, float)}.
@@ -2426,7 +2426,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>Inequality imposed by this method is consistent with
 	 * {@link Float#equals(Object)} and {@link Float#compare(float, float)}.
@@ -2439,7 +2439,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>Inequality imposed by this method is consistent with
 	 * {@link Float#equals(Object)} and {@link Float#compare(float, float)}.
@@ -2453,7 +2453,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>Inequality imposed by this method is consistent with
 	 * {@link Float#equals(Object)} and {@link Float#compare(float, float)}.
@@ -2467,7 +2467,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>Inequality imposed by this method is consistent with
 	 * {@link Float#equals(Object)} and {@link Float#compare(float, float)}.
@@ -2481,7 +2481,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal
 	 * within the given {@code delta}.
 	 *
 	 * <p>Inequality imposed by this method is consistent with
@@ -2495,7 +2495,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal
 	 * within the given {@code delta}.
 	 *
 	 * <p>Inequality imposed by this method is consistent with
@@ -2511,7 +2511,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal
 	 * within the given {@code delta}.
 	 *
 	 * <p>Inequality imposed by this method is consistent with
@@ -2526,7 +2526,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>Inequality imposed by this method is consistent with
 	 * {@link Double#equals(Object)} and {@link Double#compare(double, double)}.
@@ -2539,7 +2539,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>Inequality imposed by this method is consistent with
 	 * {@link Double#equals(Object)} and {@link Double#compare(double, double)}.
@@ -2552,7 +2552,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>Inequality imposed by this method is consistent with
 	 * {@link Double#equals(Object)} and {@link Double#compare(double, double)}.
@@ -2565,7 +2565,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>Inequality imposed by this method is consistent with
 	 * {@link Double#equals(Object)} and {@link Double#compare(double, double)}.
@@ -2578,7 +2578,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>Inequality imposed by this method is consistent with
 	 * {@link Double#equals(Object)} and {@link Double#compare(double, double)}.
@@ -2593,7 +2593,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>Inequality imposed by this method is consistent with
 	 * {@link Double#equals(Object)} and {@link Double#compare(double, double)}.
@@ -2608,7 +2608,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>Inequality imposed by this method is consistent with
 	 * {@link Double#equals(Object)} and {@link Double#compare(double, double)}.
@@ -2623,7 +2623,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>Inequality imposed by this method is consistent with
 	 * {@link Double#equals(Object)} and {@link Double#compare(double, double)}.
@@ -2638,7 +2638,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>Inequality imposed by this method is consistent with
 	 * {@link Double#equals(Object)} and {@link Double#compare(double, double)}.
@@ -2651,7 +2651,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>Inequality imposed by this method is consistent with
 	 * {@link Double#equals(Object)} and {@link Double#compare(double, double)}.
@@ -2665,7 +2665,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>Inequality imposed by this method is consistent with
 	 * {@link Double#equals(Object)} and {@link Double#compare(double, double)}.
@@ -2679,7 +2679,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>Inequality imposed by this method is consistent with
 	 * {@link Double#equals(Object)} and {@link Double#compare(double, double)}.
@@ -2693,7 +2693,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal
 	 * within the given {@code delta}.
 	 *
 	 * <p>Inequality imposed by this method is consistent with
@@ -2707,7 +2707,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal
 	 * within the given {@code delta}.
 	 *
 	 * <p>Inequality imposed by this method is consistent with
@@ -2723,7 +2723,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal
 	 * within the given {@code delta}.
 	 *
 	 * <p>Inequality imposed by this method is consistent with
@@ -2738,7 +2738,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * @since 5.4
 	 */
@@ -2748,7 +2748,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * @since 5.4
 	 */
@@ -2758,7 +2758,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * @since 5.4
 	 */
@@ -2768,7 +2768,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * @since 5.4
 	 */
@@ -2778,7 +2778,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>Fails with the supplied failure {@code message}.
 	 *
@@ -2790,7 +2790,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>Fails with the supplied failure {@code message}.
 	 *
@@ -2802,7 +2802,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>Fails with the supplied failure {@code message}.
 	 *
@@ -2814,7 +2814,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>Fails with the supplied failure {@code message}.
 	 *
@@ -2827,7 +2827,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>If necessary, the failure message will be retrieved lazily from the
 	 * supplied {@code messageSupplier}.
@@ -2840,7 +2840,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>If necessary, the failure message will be retrieved lazily from the
 	 * supplied {@code messageSupplier}.
@@ -2854,7 +2854,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>If necessary, the failure message will be retrieved lazily from the
 	 * supplied {@code messageSupplier}.
@@ -2868,7 +2868,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>If necessary, the failure message will be retrieved lazily from the
 	 * supplied {@code messageSupplier}.
@@ -2882,7 +2882,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>Fails if both are {@code null}.
 	 *
@@ -2893,7 +2893,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>Fails if both are {@code null}.
 	 *
@@ -2906,7 +2906,7 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Assert</em> that {@code expected} and {@code actual} are not equal.
+	 * <em>Assert</em> that {@code unexpected} and {@code actual} are not equal.
 	 *
 	 * <p>Fails if both are {@code null}.
 	 *
@@ -3098,7 +3098,7 @@ public class Assertions {
 	 * and all exceptions will be aggregated and reported in a {@link MultipleFailuresError}.
 	 * In addition, all aggregated exceptions will be added as {@linkplain
 	 * Throwable#addSuppressed(Throwable) suppressed exceptions} to the
-	 * {@code MultipleFailuresError}. However, if an {@code executable} throws an
+	 * {@code MultipleFailuresError}. However, if one of the {@code executables} throws an
 	 * <em>unrecoverable</em> exception &mdash; for example, an {@link OutOfMemoryError}
 	 * &mdash; execution will halt immediately, and the unrecoverable exception will be
 	 * rethrown <em>as is</em> but <em>masked</em> as an unchecked exception.

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assumptions.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assumptions.java
@@ -278,6 +278,7 @@ public class Assumptions {
 	 * @since 5.9
 	 */
 	@API(status = STABLE, since = "5.9")
+	@SuppressWarnings("TypeParameterUnusedInFormals")
 	public static <V> V abort() {
 		throw new TestAbortedException();
 	}
@@ -301,6 +302,7 @@ public class Assumptions {
 	 * @since 5.9
 	 */
 	@API(status = STABLE, since = "5.9")
+	@SuppressWarnings("TypeParameterUnusedInFormals")
 	public static <V> V abort(String message) {
 		throw new TestAbortedException(message);
 	}
@@ -317,6 +319,7 @@ public class Assumptions {
 	 * @since 5.9
 	 */
 	@API(status = STABLE, since = "5.9")
+	@SuppressWarnings("TypeParameterUnusedInFormals")
 	public static <V> V abort(Supplier<String> messageSupplier) {
 		throw new TestAbortedException(messageSupplier.get());
 	}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/OS.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/OS.java
@@ -147,8 +147,8 @@ public enum OS {
 	}
 
 	/**
-	 * @return {@code true} if <em>this</em> {@code OS} is known to be the
-	 * operating system on which the current JVM is executing
+	 * {@return {@code true} if <em>this</em> {@code OS} is known to be the
+	 * operating system on which the current JVM is executing}
 	 */
 	public boolean isCurrentOs() {
 		return this == CURRENT_OS;

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExtensionContext.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExtensionContext.java
@@ -751,7 +751,7 @@ public interface ExtensionContext {
 	 * mixing data between extensions or across different invocations within the
 	 * lifecycle of a single extension.
 	 */
-	class Namespace {
+	final class Namespace {
 
 		/**
 		 * The default, global namespace which allows access to stored data from

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/MediaType.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/MediaType.java
@@ -35,7 +35,7 @@ import org.junit.platform.commons.util.Preconditions;
  * @see ExtensionContext#publishFile(String, MediaType, ThrowingConsumer)
  */
 @API(status = MAINTAINED, since = "5.13.3")
-public class MediaType {
+public final class MediaType {
 
 	private static final Pattern PATTERN;
 	static {

--- a/junit-jupiter-api/src/templates/resources/main/org/junit/jupiter/api/condition/JRE.java.jte
+++ b/junit-jupiter-api/src/templates/resources/main/org/junit/jupiter/api/condition/JRE.java.jte
@@ -113,9 +113,9 @@ public enum JRE {
 	}
 
 	/**
-	 * @return {@code true} if <em>this</em> {@code JRE} is known to be the
+	 * {@return {@code true} if <em>this</em> {@code JRE} is known to be the
 	 * Java Runtime Environment version for the currently executing JVM or if
-	 * the version is {@link #OTHER}
+	 * the version is {@link #OTHER}}
 	 *
 	 * @see #currentJre()
 	 * @see #currentVersionNumber()
@@ -125,8 +125,8 @@ public enum JRE {
 	}
 
 	/**
-	 * @return the {@link JRE} for the currently executing JVM, potentially
-	 * {@link #OTHER}
+	 * {@return the {@link JRE} for the currently executing JVM, potentially
+	 * {@link #OTHER}}
 	 *
 	 * @since 5.7
 	 * @see #currentVersionNumber()
@@ -139,8 +139,8 @@ public enum JRE {
 	}
 
 	/**
-	 * @return the {@link JRE} for the currently executing JVM, potentially
-	 * {@link #OTHER}
+	 * {@return the {@link JRE} for the currently executing JVM, potentially
+	 * {@link #OTHER}}
 	 *
 	 * @since 5.12
 	 * @see #currentVersionNumber()
@@ -156,8 +156,8 @@ public enum JRE {
 	}
 
 	/**
-	 * @return the version number for the currently executing JVM, or {@code -1}
-	 * if the current JVM version could not be determined
+	 * {@return the version number for the currently executing JVM, or {@code -1}
+	 * if the current JVM version could not be determined}
 	 *
 	 * @since 5.12
 	 * @see Runtime.Version#feature()
@@ -169,10 +169,10 @@ public enum JRE {
 	}
 
 	/**
-	 * @return {@code true} if the supplied version number is known to be the
+	 * {@return {@code true} if the supplied version number is known to be the
 	 * Java Runtime Environment version for the currently executing JVM or if
 	 * the supplied version number is {@code -1} and the current JVM version
-	 * could not be determined
+	 * could not be determined}
 	 *
 	 * @since 5.12
 	 * @see Runtime.Version#feature()

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/NestedClassTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/NestedClassTestDescriptor.java
@@ -10,7 +10,6 @@
 
 package org.junit.jupiter.engine.descriptor;
 
-import static java.util.Collections.emptyList;
 import static org.apiguardian.api.API.Status.INTERNAL;
 import static org.junit.jupiter.engine.descriptor.DisplayNameUtils.createDisplayNameSupplierForNestedClass;
 import static org.junit.jupiter.engine.descriptor.ResourceLockAware.enclosingInstanceTypesDependentResourceLocksProviderEvaluator;
@@ -92,9 +91,9 @@ public class NestedClassTestDescriptor extends ClassBasedTestDescriptor {
 		if (parent instanceof TestClassAware testClassAwareParent) {
 			List<Class<?>> result = new ArrayList<>(testClassAwareParent.getEnclosingTestClasses());
 			result.add(testClassAwareParent.getTestClass());
-			return result;
+			return List.copyOf(result);
 		}
-		return emptyList();
+		return List.of();
 	}
 
 	// --- ClassBasedTestDescriptor --------------------------------------------

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/InterceptingExecutableInvoker.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/InterceptingExecutableInvoker.java
@@ -119,10 +119,10 @@ public class InterceptingExecutableInvoker {
 				ReflectiveInvocationContext<E> invocationContext, ExtensionContext extensionContext) throws Throwable;
 
 		static ReflectiveInterceptorCall<Method, @Nullable Void> ofVoidMethod(VoidMethodInterceptorCall call) {
-			return ((interceptorChain, invocation, invocationContext, extensionContext) -> {
+			return (interceptorChain, invocation, invocationContext, extensionContext) -> {
 				call.apply(interceptorChain, invocation, invocationContext, extensionContext);
 				return null;
-			});
+			};
 		}
 
 		interface VoidMethodInterceptorCall {

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
@@ -526,6 +526,7 @@ class TempDirectory implements BeforeAllCallback, BeforeEachCallback, ParameterR
 			return exception;
 		}
 
+		@SuppressWarnings("EmptyCatch")
 		private Path tryToDeleteOnExit(Path path) {
 			try {
 				path.toFile().deleteOnExit();

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TestInfoParameterResolver.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TestInfoParameterResolver.java
@@ -90,7 +90,7 @@ class TestInfoParameterResolver implements ParameterResolver {
 			// @formatter:on
 		}
 
-		@SuppressWarnings("OptionalAssignedToNull")
+		@SuppressWarnings({ "OptionalAssignedToNull", "NullableOptional" })
 		private static @Nullable Object nullSafeGet(@Nullable Optional<?> optional) {
 			return optional != null ? optional.orElse(null) : null;
 		}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TimeoutConfiguration.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TimeoutConfiguration.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Timeout.DEFAULT_TIMEOUT_THREAD_MODE_PROPERTY
 import static org.junit.jupiter.api.Timeout.ThreadMode.SAME_THREAD;
 import static org.junit.jupiter.api.Timeout.ThreadMode.SEPARATE_THREAD;
 
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -126,7 +127,7 @@ class TimeoutConfiguration {
 	private Optional<ThreadMode> parseTimeoutThreadModeConfiguration() {
 		return extensionContext.getConfigurationParameter(DEFAULT_TIMEOUT_THREAD_MODE_PROPERTY_NAME).map(value -> {
 			try {
-				ThreadMode threadMode = ThreadMode.valueOf(value.toUpperCase());
+				ThreadMode threadMode = ThreadMode.valueOf(value.toUpperCase(Locale.ROOT));
 				if (threadMode == ThreadMode.INFERRED) {
 					logger.warn(
 						() -> "Invalid timeout thread mode '%s', only %s and %s can be used as configuration parameter for %s.".formatted(

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TimeoutDuration.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TimeoutDuration.java
@@ -12,6 +12,7 @@ package org.junit.jupiter.engine.extension;
 
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
+import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Timeout;
@@ -35,7 +36,7 @@ record TimeoutDuration(long value, TimeUnit unit) {
 
 	@Override
 	public String toString() {
-		String label = unit.name().toLowerCase();
+		String label = unit.name().toLowerCase(Locale.ROOT);
 		if (value == 1 && label.endsWith("s")) {
 			label = label.substring(0, label.length() - 1);
 		}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TimeoutInvocationFactory.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TimeoutInvocationFactory.java
@@ -80,7 +80,7 @@ class TimeoutInvocationFactory {
 	@SuppressWarnings("try")
 	static class SingleThreadExecutorResource extends ExecutorResource {
 
-		@SuppressWarnings("unused")
+		@SuppressWarnings({ "unused", "ThreadPriorityCheck" })
 		SingleThreadExecutorResource() {
 			super(Executors.newSingleThreadScheduledExecutor(runnable -> {
 				Thread thread = new Thread(runnable, "junit-jupiter-timeout-watcher");

--- a/junit-jupiter-migrationsupport/src/main/java/org/junit/jupiter/migrationsupport/rules/ExpectedExceptionSupport.java
+++ b/junit-jupiter-migrationsupport/src/main/java/org/junit/jupiter/migrationsupport/rules/ExpectedExceptionSupport.java
@@ -10,8 +10,6 @@
 
 package org.junit.jupiter.migrationsupport.rules;
 
-import static java.lang.Boolean.FALSE;
-import static java.lang.Boolean.TRUE;
 import static org.apiguardian.api.API.Status.DEPRECATED;
 
 import org.apiguardian.api.API;
@@ -57,13 +55,13 @@ public class ExpectedExceptionSupport implements AfterEachCallback, TestExecutio
 
 	@Override
 	public void handleTestExecutionException(ExtensionContext context, Throwable throwable) throws Throwable {
-		getStore(context).put(EXCEPTION_WAS_HANDLED, TRUE);
+		getStore(context).put(EXCEPTION_WAS_HANDLED, true);
 		this.support.handleTestExecutionException(context, throwable);
 	}
 
 	@Override
 	public void afterEach(ExtensionContext context) throws Exception {
-		Boolean handled = getStore(context).getOrComputeIfAbsent(EXCEPTION_WAS_HANDLED, key -> FALSE, Boolean.class);
+		Boolean handled = getStore(context).getOrComputeIfAbsent(EXCEPTION_WAS_HANDLED, key -> false, Boolean.class);
 		if (handled != null && !handled) {
 			this.support.afterEach(context);
 		}

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedClassContext.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedClassContext.java
@@ -60,14 +60,14 @@ class ParameterizedClassContext implements ParameterizedDeclarationContext<Class
 			this.injectionType = InjectionType.FIELDS;
 		}
 
-		this.beforeMethods = findLifecycleMethodsAndAssertStaticAndNonPrivate(testClass, testInstanceLifecycle,
-			TOP_DOWN, BeforeParameterizedClassInvocation.class, BeforeParameterizedClassInvocation::injectArguments,
+		this.beforeMethods = findLifecycleMethodsAndAssertStaticAndNonPrivate(testClass, TOP_DOWN,
+			BeforeParameterizedClassInvocation.class, BeforeParameterizedClassInvocation::injectArguments,
 			this.resolverFacade);
 
 		// Make a local copy since findAnnotatedMethods() returns an immutable list.
-		this.afterMethods = new ArrayList<>(findLifecycleMethodsAndAssertStaticAndNonPrivate(testClass,
-			testInstanceLifecycle, BOTTOM_UP, AfterParameterizedClassInvocation.class,
-			AfterParameterizedClassInvocation::injectArguments, this.resolverFacade));
+		this.afterMethods = new ArrayList<>(findLifecycleMethodsAndAssertStaticAndNonPrivate(testClass, BOTTOM_UP,
+			AfterParameterizedClassInvocation.class, AfterParameterizedClassInvocation::injectArguments,
+			this.resolverFacade));
 
 		// Since the bottom-up ordering of afterMethods will later be reversed when the
 		// AfterParameterizedClassInvocationMethodInvoker extensions are executed within
@@ -146,8 +146,8 @@ class ParameterizedClassContext implements ParameterizedDeclarationContext<Class
 	}
 
 	private static <A extends Annotation> List<ArgumentSetLifecycleMethod> findLifecycleMethodsAndAssertStaticAndNonPrivate(
-			Class<?> testClass, TestInstance.Lifecycle testInstanceLifecycle, HierarchyTraversalMode traversalMode,
-			Class<A> annotationType, Predicate<A> injectArgumentsPredicate, ResolverFacade resolverFacade) {
+			Class<?> testClass, HierarchyTraversalMode traversalMode, Class<A> annotationType,
+			Predicate<A> injectArgumentsPredicate, ResolverFacade resolverFacade) {
 
 		List<Method> methods = findAnnotatedMethods(testClass, annotationType, traversalMode);
 

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedInvocationNameFormatter.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedInvocationNameFormatter.java
@@ -98,6 +98,7 @@ class ParameterizedInvocationNameFormatter {
 		}
 	}
 
+	@SuppressWarnings("JdkObsolete")
 	private String formatSafely(int invocationIndex, EvaluatedArgumentSet arguments) {
 		ArgumentsContext context = new ArgumentsContext(invocationIndex, arguments.getConsumedNames(),
 			arguments.getName());
@@ -200,6 +201,7 @@ class ParameterizedInvocationNameFormatter {
 	private record PlaceholderPosition(int index, String placeholder) {
 	}
 
+	@SuppressWarnings("ArrayRecordComponent")
 	private record ArgumentsContext(int invocationIndex, @Nullable Object[] consumedArguments,
 			Optional<String> argumentSetName) {
 	}

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ResolverFacade.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ResolverFacade.java
@@ -234,8 +234,8 @@ class ResolverFacade {
 		ResolverFacade lifecycleMethodResolverFacade = create(method, annotation);
 
 		Map<ParameterDeclaration, ResolvableParameterDeclaration> parameterDeclarationMapping = new HashMap<>();
-		List<String> errors = validateLifecycleMethodParameters(method, annotation, originalResolverFacade,
-			lifecycleMethodResolverFacade, parameterDeclarationMapping);
+		List<String> errors = validateLifecycleMethodParameters(originalResolverFacade, lifecycleMethodResolverFacade,
+			parameterDeclarationMapping);
 
 		return Try //
 				.call(() -> configurationErrorOrSuccess(errors,
@@ -336,8 +336,8 @@ class ResolverFacade {
 				.collect(toMap(Map.Entry::getKey, entry -> entry.getValue().get(0), (d, __) -> d, TreeMap::new)));
 	}
 
-	private static List<String> validateLifecycleMethodParameters(Method method, Annotation annotation,
-			ResolverFacade originalResolverFacade, ResolverFacade lifecycleMethodResolverFacade,
+	private static List<String> validateLifecycleMethodParameters(ResolverFacade originalResolverFacade,
+			ResolverFacade lifecycleMethodResolverFacade,
 			Map<ParameterDeclaration, ResolvableParameterDeclaration> parameterDeclarationMapping) {
 		List<ParameterDeclaration> actualDeclarations = lifecycleMethodResolverFacade.indexedParameterDeclarations.getAll();
 		List<String> errors = new ArrayList<>();

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvArgumentsProvider.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvArgumentsProvider.java
@@ -103,6 +103,7 @@ class CsvArgumentsProvider extends AnnotationBasedArgumentsProvider<CsvSource> {
 		return ((NamedCsvRecord) record).getHeader();
 	}
 
+	@SuppressWarnings({ "ReferenceEquality", "StringEquality" })
 	private static @Nullable String resolveNullMarker(String record) {
 		return record == CsvReaderFactory.DefaultFieldModifier.NULL_MARKER ? null : record;
 	}

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/function/Try.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/function/Try.java
@@ -249,7 +249,7 @@ public abstract class Try<V extends @Nullable Object> {
 
 	}
 
-	private static class Success<V extends @Nullable Object> extends Try<V> {
+	private static final class Success<V extends @Nullable Object> extends Try<V> {
 
 		private final V value;
 
@@ -327,7 +327,7 @@ public abstract class Try<V extends @Nullable Object> {
 		}
 	}
 
-	private static class Failure<V extends @Nullable Object> extends Try<V> {
+	private static final class Failure<V extends @Nullable Object> extends Try<V> {
 
 		private final Exception cause;
 

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/logging/LogRecordListener.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/logging/LogRecordListener.java
@@ -75,7 +75,7 @@ public class LogRecordListener {
 	 * @see #stream(Class)
 	 * @see #stream(Class, Level)
 	 */
-	@SuppressWarnings("ConstantValue")
+	@SuppressWarnings({ "ConstantValue", "ReferenceEquality" })
 	public Stream<LogRecord> stream(Level level) {
 		// NOTE: we cannot use org.junit.platform.commons.util.Preconditions here
 		// since that would introduce a package cycle.
@@ -129,7 +129,7 @@ public class LogRecordListener {
 	 * @see #stream(Level)
 	 * @see #stream(Class)
 	 */
-	@SuppressWarnings("ConstantValue")
+	@SuppressWarnings({ "ConstantValue", "ReferenceEquality" })
 	public Stream<LogRecord> stream(Class<?> clazz, Level level) {
 		// NOTE: we cannot use org.junit.platform.commons.util.Preconditions here
 		// since that would introduce a package cycle.

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/AnnotationSupport.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/AnnotationSupport.java
@@ -70,6 +70,7 @@ public final class AnnotationSupport {
 	 * @see #findRepeatableAnnotations(Optional, Class)
 	 */
 	@API(status = MAINTAINED, since = "1.3")
+	@SuppressWarnings("NullableOptional")
 	public static boolean isAnnotated(@Nullable Optional<? extends AnnotatedElement> element,
 			Class<? extends Annotation> annotationType) {
 
@@ -112,6 +113,7 @@ public final class AnnotationSupport {
 	 * @see #findAnnotation(AnnotatedElement, Class)
 	 */
 	@API(status = MAINTAINED, since = "1.1")
+	@SuppressWarnings("NullableOptional")
 	public static <A extends Annotation> Optional<A> findAnnotation(
 			@Nullable Optional<? extends AnnotatedElement> element, Class<A> annotationType) {
 
@@ -253,6 +255,7 @@ public final class AnnotationSupport {
 	 * @see #findRepeatableAnnotations(AnnotatedElement, Class)
 	 */
 	@API(status = MAINTAINED, since = "1.5")
+	@SuppressWarnings("NullableOptional")
 	public static <A extends Annotation> List<A> findRepeatableAnnotations(
 			@Nullable Optional<? extends AnnotatedElement> element, Class<A> annotationType) {
 

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/scanning/DefaultClasspathScanner.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/scanning/DefaultClasspathScanner.java
@@ -10,7 +10,6 @@
 
 package org.junit.platform.commons.support.scanning;
 
-import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.joining;
 import static org.apiguardian.api.API.Status.INTERNAL;
 import static org.junit.platform.commons.support.scanning.ClasspathFilters.CLASS_FILE_SUFFIX;
@@ -341,19 +340,18 @@ public class DefaultClasspathScanner implements ClasspathScanner {
 	}
 
 	private List<URI> getRootUrisForPackage(String basePackageName) {
+		List<URI> uris = new ArrayList<>();
 		try {
 			Enumeration<URL> resources = getClassLoader().getResources(packagePath(basePackageName));
-			List<URI> uris = new ArrayList<>();
 			while (resources.hasMoreElements()) {
 				URL resource = resources.nextElement();
 				uris.add(resource.toURI());
 			}
-			return uris;
 		}
 		catch (Exception ex) {
 			logger.warn(ex, () -> "Error reading URIs from class loader for base package " + basePackageName);
-			return emptyList();
 		}
+		return uris;
 	}
 
 }

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/AnnotationUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/AnnotationUtils.java
@@ -326,7 +326,7 @@ public final class AnnotationUtils {
 		findRepeatableAnnotations(element.getAnnotations(), annotationType, containerType, inherited, found, visited);
 	}
 
-	@SuppressWarnings("unchecked")
+	@SuppressWarnings({ "unchecked", "GetClassOnAnnotation" })
 	private static <A extends Annotation> void findRepeatableAnnotations(Annotation[] candidates,
 			Class<A> annotationType, Class<? extends Annotation> containerType, boolean inherited, Set<A> found,
 			Set<Annotation> visited) {

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ExceptionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ExceptionUtils.java
@@ -76,7 +76,7 @@ public final class ExceptionUtils {
 		return ExceptionUtils.throwAs(t);
 	}
 
-	@SuppressWarnings("unchecked")
+	@SuppressWarnings({ "unchecked", "TypeParameterUnusedInFormals" })
 	private static <T extends Throwable> T throwAs(Throwable t) throws T {
 		throw (T) t;
 	}

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
@@ -217,6 +217,11 @@ public final class ReflectionUtils {
 
 		classNameToTypeMap = Collections.unmodifiableMap(classNamesToTypes);
 
+		primitiveToWrapperMap = createPrimitivesToWrapperMap();
+	}
+
+	@SuppressWarnings("IdentityHashMapUsage")
+	private static Map<Class<?>, Class<?>> createPrimitivesToWrapperMap() {
 		Map<Class<?>, Class<?>> primitivesToWrappers = new IdentityHashMap<>(8);
 
 		primitivesToWrappers.put(boolean.class, Boolean.class);
@@ -228,7 +233,7 @@ public final class ReflectionUtils {
 		primitivesToWrappers.put(float.class, Float.class);
 		primitivesToWrappers.put(double.class, Double.class);
 
-		primitiveToWrapperMap = Collections.unmodifiableMap(primitivesToWrappers);
+		return Collections.unmodifiableMap(primitivesToWrappers);
 	}
 
 	public static boolean isPublic(Class<?> clazz) {
@@ -637,13 +642,12 @@ public final class ReflectionUtils {
 	 * @see #tryToReadFieldValue(Class, String, Object)
 	 */
 	@API(status = INTERNAL, since = "1.4")
-	@SuppressWarnings("NullAway")
 	public static Try<@Nullable Object> tryToReadFieldValue(Field field, @Nullable Object instance) {
 		Preconditions.notNull(field, "Field must not be null");
 		Preconditions.condition((instance != null || isStatic(field)),
 			() -> String.format("Cannot read non-static field [%s] on a null instance.", field));
 
-		return Try.call(() -> makeAccessible(field).get(instance));
+		return Try.<@Nullable Object> call(() -> makeAccessible(field).get(instance));
 	}
 
 	/**
@@ -1421,6 +1425,7 @@ public final class ReflectionUtils {
 	 * @since 1.11
 	 */
 	@API(status = INTERNAL, since = "1.11")
+	@SuppressWarnings("ReferenceEquality")
 	public static Method getInterfaceMethodIfPossible(Method method, @Nullable Class<?> targetClass) {
 		if (!isPublic(method) || method.getDeclaringClass().isInterface()) {
 			return method;

--- a/junit-platform-commons/src/testFixtures/java/org/junit/platform/commons/test/ConcurrencyTestingUtils.java
+++ b/junit-platform-commons/src/testFixtures/java/org/junit/platform/commons/test/ConcurrencyTestingUtils.java
@@ -32,6 +32,7 @@ public class ConcurrencyTestingUtils {
 		});
 	}
 
+	@SuppressWarnings("Finally")
 	public static <T extends @Nullable Object> List<T> executeConcurrently(int threads, Callable<T> action)
 			throws Exception {
 		ExecutorService executorService = Executors.newFixedThreadPool(threads);

--- a/junit-platform-console/src/main/java/org/junit/platform/console/options/ConsoleUtils.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/options/ConsoleUtils.java
@@ -35,6 +35,7 @@ public class ConsoleUtils {
 	/**
 	 * {@return the charset of the console}
 	 */
+	@SuppressWarnings("SystemConsoleNull")
 	public static Charset charset() {
 		Console console = System.console();
 		return console != null ? console.charset() : Charset.defaultCharset();

--- a/junit-platform-console/src/main/java/org/junit/platform/console/options/Details.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/options/Details.java
@@ -12,6 +12,8 @@ package org.junit.platform.console.options;
 
 import static org.apiguardian.api.API.Status.INTERNAL;
 
+import java.util.Locale;
+
 import org.apiguardian.api.API;
 
 /**
@@ -58,7 +60,7 @@ public enum Details {
 	 */
 	@Override
 	public String toString() {
-		return name().toLowerCase();
+		return name().toLowerCase(Locale.ROOT);
 	}
 
 }

--- a/junit-platform-console/src/main/java/org/junit/platform/console/options/SelectorConverter.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/options/SelectorConverter.java
@@ -73,6 +73,7 @@ class SelectorConverter {
 		}
 	}
 
+	@SuppressWarnings("JavaLangClash")
 	static class Package implements ITypeConverter<PackageSelector> {
 		@Override
 		public PackageSelector convert(String value) {
@@ -80,6 +81,7 @@ class SelectorConverter {
 		}
 	}
 
+	@SuppressWarnings("JavaLangClash")
 	static class Class implements ITypeConverter<ClassSelector> {
 		@Override
 		public ClassSelector convert(String value) {

--- a/junit-platform-console/src/main/java/org/junit/platform/console/options/Theme.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/options/Theme.java
@@ -14,6 +14,7 @@ import static org.apiguardian.api.API.Status.INTERNAL;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.Locale;
 
 import org.apiguardian.api.API;
 import org.junit.platform.engine.TestExecutionResult;
@@ -129,7 +130,7 @@ public enum Theme {
 	 */
 	@Override
 	public final String toString() {
-		return name().toLowerCase();
+		return name().toLowerCase(Locale.ROOT);
 	}
 
 }

--- a/junit-platform-console/src/main/java/org/junit/platform/console/tasks/ColorPalette.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/tasks/ColorPalette.java
@@ -13,9 +13,11 @@ package org.junit.platform.console.tasks;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.Reader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.EnumMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 import java.util.function.Function;
@@ -89,8 +91,8 @@ class ColorPalette {
 	}
 
 	private static Map<Style, String> toOverrideMap(Properties properties) {
-		Map<String, String> upperCaseProperties = properties.entrySet().stream().collect(
-			Collectors.toMap(entry -> ((String) entry.getKey()).toUpperCase(), entry -> (String) entry.getValue()));
+		Map<String, String> upperCaseProperties = properties.entrySet().stream().collect(Collectors.toMap(
+			entry -> ((String) entry.getKey()).toUpperCase(Locale.ROOT), entry -> (String) entry.getValue()));
 
 		return Arrays.stream(Style.values()).filter(style -> upperCaseProperties.containsKey(style.name())).collect(
 			Collectors.toMap(Function.identity(), style -> upperCaseProperties.get(style.name())));
@@ -108,7 +110,7 @@ class ColorPalette {
 	}
 
 	private static Properties getProperties(Path path) {
-		try (FileReader fileReader = new FileReader(path.toFile())) {
+		try (FileReader fileReader = new FileReader(path.toFile(), StandardCharsets.UTF_8)) {
 			return getProperties(fileReader);
 		}
 		catch (IOException e) {

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/FilterResult.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/FilterResult.java
@@ -80,14 +80,14 @@ public class FilterResult {
 	}
 
 	/**
-	 * @return {@code true} if the filtered object should be included
+	 * {@return {@code true} if the filtered object should be included}
 	 */
 	public boolean included() {
 		return this.included;
 	}
 
 	/**
-	 * @return {@code true} if the filtered object should be excluded
+	 * {@return {@code true} if the filtered object should be excluded}
 	 */
 	public boolean excluded() {
 		return !included();

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/TestDescriptor.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/TestDescriptor.java
@@ -371,15 +371,15 @@ public interface TestDescriptor {
 		CONTAINER_AND_TEST;
 
 		/**
-		 * @return {@code true} if this type represents a descriptor that can
-		 * contain other descriptors
+		 * {@return {@code true} if this type represents a descriptor that can
+		 * contain other descriptors}
 		 */
 		public boolean isContainer() {
 			return this == CONTAINER || this == CONTAINER_AND_TEST;
 		}
 
 		/**
-		 * @return {@code true} if this type represents a descriptor for a test
+		 * {@return {@code true} if this type represents a descriptor for a test}
 		 */
 		public boolean isTest() {
 			return this == TEST || this == CONTAINER_AND_TEST;

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/UniqueId.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/UniqueId.java
@@ -35,7 +35,7 @@ import org.junit.platform.commons.util.ToStringBuilder;
  * @since 1.0
  */
 @API(status = STABLE, since = "1.0")
-public class UniqueId implements Cloneable, Serializable {
+public final class UniqueId implements Cloneable, Serializable {
 
 	@Serial
 	private static final long serialVersionUID = 1L;
@@ -295,7 +295,7 @@ public class UniqueId implements Cloneable, Serializable {
 	 * <em>value</em>.
 	 */
 	@API(status = STABLE, since = "1.0")
-	public static class Segment implements Serializable {
+	public static final class Segment implements Serializable {
 
 		@Serial
 		private static final long serialVersionUID = 1L;

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/ClassSelector.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/ClassSelector.java
@@ -46,7 +46,7 @@ import org.junit.platform.engine.DiscoverySelectorIdentifier;
  * @see org.junit.platform.engine.support.descriptor.ClassSource
  */
 @API(status = STABLE, since = "1.0")
-public class ClassSelector implements DiscoverySelector {
+public final class ClassSelector implements DiscoverySelector {
 
 	private final @Nullable ClassLoader classLoader;
 

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/ClasspathResourceSelector.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/ClasspathResourceSelector.java
@@ -53,7 +53,7 @@ import org.junit.platform.engine.DiscoverySelectorIdentifier;
  * @see #getClasspathResourceName()
  */
 @API(status = STABLE, since = "1.0")
-public class ClasspathResourceSelector implements DiscoverySelector {
+public final class ClasspathResourceSelector implements DiscoverySelector {
 
 	private final String classpathResourceName;
 

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/ClasspathRootSelector.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/ClasspathRootSelector.java
@@ -44,7 +44,7 @@ import org.junit.platform.engine.DiscoverySelectorIdentifier;
  * @see Thread#getContextClassLoader()
  */
 @API(status = STABLE, since = "1.0")
-public class ClasspathRootSelector implements DiscoverySelector {
+public final class ClasspathRootSelector implements DiscoverySelector {
 
 	private final URI classpathRoot;
 

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/DirectorySelector.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/DirectorySelector.java
@@ -40,7 +40,7 @@ import org.junit.platform.engine.DiscoverySelectorIdentifier;
  * @see #getRawPath()
  */
 @API(status = STABLE, since = "1.0")
-public class DirectorySelector implements DiscoverySelector {
+public final class DirectorySelector implements DiscoverySelector {
 
 	private final String path;
 

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/FilePosition.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/FilePosition.java
@@ -37,7 +37,7 @@ import org.junit.platform.commons.util.ToStringBuilder;
  * @since 1.7
  */
 @API(status = STABLE, since = "1.7")
-public class FilePosition implements Serializable {
+public final class FilePosition implements Serializable {
 
 	@Serial
 	private static final long serialVersionUID = 1L;

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/FileSelector.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/FileSelector.java
@@ -42,7 +42,7 @@ import org.junit.platform.engine.DiscoverySelectorIdentifier;
  * @see #getRawPath()
  */
 @API(status = STABLE, since = "1.0")
-public class FileSelector implements DiscoverySelector {
+public final class FileSelector implements DiscoverySelector {
 
 	private final String path;
 

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/IterationSelector.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/IterationSelector.java
@@ -45,7 +45,7 @@ import org.junit.platform.engine.DiscoverySelectorIdentifier;
  * @see DiscoverySelectors#selectIteration(DiscoverySelector, int...)
  */
 @API(status = MAINTAINED, since = "1.13.3")
-public class IterationSelector implements DiscoverySelector {
+public final class IterationSelector implements DiscoverySelector {
 
 	private final DiscoverySelector parentSelector;
 	private final SortedSet<Integer> iterationIndices;

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/MethodSelector.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/MethodSelector.java
@@ -58,7 +58,7 @@ import org.junit.platform.engine.DiscoverySelectorIdentifier;
  * @see org.junit.platform.engine.support.descriptor.MethodSource
  */
 @API(status = STABLE, since = "1.0")
-public class MethodSelector implements DiscoverySelector {
+public final class MethodSelector implements DiscoverySelector {
 
 	private final @Nullable ClassLoader classLoader;
 	private final String className;

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/ModuleSelector.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/ModuleSelector.java
@@ -31,7 +31,7 @@ import org.junit.platform.engine.DiscoverySelectorIdentifier;
  * @see DiscoverySelectors#selectModules(java.util.Set)
  */
 @API(status = STABLE, since = "1.1")
-public class ModuleSelector implements DiscoverySelector {
+public final class ModuleSelector implements DiscoverySelector {
 
 	private final String moduleName;
 

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/NestedClassSelector.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/NestedClassSelector.java
@@ -51,7 +51,7 @@ import org.junit.platform.engine.DiscoverySelectorIdentifier;
  * @see ClassSelector
  */
 @API(status = STABLE, since = "1.6")
-public class NestedClassSelector implements DiscoverySelector {
+public final class NestedClassSelector implements DiscoverySelector {
 
 	private final @Nullable ClassLoader classLoader;
 

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/NestedMethodSelector.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/NestedMethodSelector.java
@@ -56,7 +56,7 @@ import org.junit.platform.engine.DiscoverySelectorIdentifier;
  * @see MethodSelector
  */
 @API(status = STABLE, since = "1.6")
-public class NestedMethodSelector implements DiscoverySelector {
+public final class NestedMethodSelector implements DiscoverySelector {
 
 	private final NestedClassSelector nestedClassSelector;
 	private final MethodSelector methodSelector;

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/PackageSelector.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/PackageSelector.java
@@ -31,7 +31,7 @@ import org.junit.platform.engine.DiscoverySelectorIdentifier;
  * @see org.junit.platform.engine.support.descriptor.PackageSource
  */
 @API(status = STABLE, since = "1.0")
-public class PackageSelector implements DiscoverySelector {
+public final class PackageSelector implements DiscoverySelector {
 
 	private final String packageName;
 

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/UniqueIdSelector.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/UniqueIdSelector.java
@@ -32,7 +32,7 @@ import org.junit.platform.engine.UniqueId;
  * @see DiscoverySelectors#selectUniqueId(UniqueId)
  */
 @API(status = STABLE, since = "1.0")
-public class UniqueIdSelector implements DiscoverySelector {
+public final class UniqueIdSelector implements DiscoverySelector {
 
 	private final UniqueId uniqueId;
 

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/UriSelector.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/UriSelector.java
@@ -35,7 +35,7 @@ import org.junit.platform.engine.DiscoverySelectorIdentifier;
  * @see org.junit.platform.engine.support.descriptor.UriSource
  */
 @API(status = STABLE, since = "1.0")
-public class UriSelector implements DiscoverySelector {
+public final class UriSelector implements DiscoverySelector {
 
 	private final URI uri;
 

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/reporting/FileEntry.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/reporting/FileEntry.java
@@ -14,6 +14,7 @@ import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import java.nio.file.Path;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Optional;
 
 import org.apiguardian.api.API;
@@ -43,7 +44,7 @@ public final class FileEntry {
 		return new FileEntry(path, mediaType);
 	}
 
-	private final LocalDateTime timestamp = LocalDateTime.now();
+	private final LocalDateTime timestamp = LocalDateTime.now(ZoneId.systemDefault());
 	private final Path path;
 
 	private final @Nullable String mediaType;

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/reporting/ReportEntry.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/reporting/ReportEntry.java
@@ -13,6 +13,7 @@ package org.junit.platform.engine.reporting;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -32,7 +33,7 @@ import org.junit.platform.commons.util.ToStringBuilder;
 @API(status = STABLE, since = "1.0")
 public final class ReportEntry {
 
-	private final LocalDateTime timestamp = LocalDateTime.now();
+	private final LocalDateTime timestamp = LocalDateTime.now(ZoneId.systemDefault());
 	private final Map<String, String> keyValuePairs = new LinkedHashMap<>();
 
 	private ReportEntry() {

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/AbstractTestDescriptor.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/AbstractTestDescriptor.java
@@ -190,6 +190,7 @@ public abstract class AbstractTestDescriptor implements TestDescriptor {
 	}
 
 	@Override
+	@SuppressWarnings("EqualsGetClass")
 	public final boolean equals(Object other) {
 		if (other == null) {
 			return false;

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/ClassSource.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/ClassSource.java
@@ -43,7 +43,7 @@ import org.junit.platform.engine.TestSource;
  * @see org.junit.platform.engine.discovery.ClassSelector
  */
 @API(status = STABLE, since = "1.0")
-public class ClassSource implements TestSource {
+public final class ClassSource implements TestSource {
 
 	@Serial
 	private static final long serialVersionUID = 1L;

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/ClasspathResourceSource.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/ClasspathResourceSource.java
@@ -33,7 +33,7 @@ import org.junit.platform.engine.TestSource;
  * @see org.junit.platform.engine.discovery.ClasspathResourceSelector
  */
 @API(status = STABLE, since = "1.0")
-public class ClasspathResourceSource implements TestSource {
+public final class ClasspathResourceSource implements TestSource {
 
 	@Serial
 	private static final long serialVersionUID = 1L;

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/CompositeTestSource.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/CompositeTestSource.java
@@ -29,7 +29,7 @@ import org.junit.platform.engine.TestSource;
  * @since 1.0
  */
 @API(status = STABLE, since = "1.0")
-public class CompositeTestSource implements TestSource {
+public final class CompositeTestSource implements TestSource {
 
 	@Serial
 	private static final long serialVersionUID = 1L;

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/DirectorySource.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/DirectorySource.java
@@ -29,7 +29,7 @@ import org.junit.platform.commons.util.ToStringBuilder;
  * @see org.junit.platform.engine.discovery.DirectorySelector
  */
 @API(status = STABLE, since = "1.0")
-public class DirectorySource implements FileSystemSource {
+public final class DirectorySource implements FileSystemSource {
 
 	@Serial
 	private static final long serialVersionUID = 1L;

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/FilePosition.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/FilePosition.java
@@ -32,7 +32,7 @@ import org.junit.platform.commons.util.ToStringBuilder;
  * @since 1.0
  */
 @API(status = STABLE, since = "1.0")
-public class FilePosition implements Serializable {
+public final class FilePosition implements Serializable {
 
 	@Serial
 	private static final long serialVersionUID = 1L;

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/FileSource.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/FileSource.java
@@ -33,7 +33,7 @@ import org.junit.platform.commons.util.ToStringBuilder;
  * @see org.junit.platform.engine.discovery.FileSelector
  */
 @API(status = STABLE, since = "1.0")
-public class FileSource implements FileSystemSource {
+public final class FileSource implements FileSystemSource {
 
 	@Serial
 	private static final long serialVersionUID = 1L;

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/MethodSource.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/MethodSource.java
@@ -36,7 +36,7 @@ import org.junit.platform.engine.TestSource;
  * @see org.junit.platform.engine.discovery.MethodSelector
  */
 @API(status = STABLE, since = "1.0")
-public class MethodSource implements TestSource {
+public final class MethodSource implements TestSource {
 
 	@Serial
 	private static final long serialVersionUID = 1L;

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/PackageSource.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/PackageSource.java
@@ -30,7 +30,7 @@ import org.junit.platform.engine.TestSource;
  * @see org.junit.platform.engine.discovery.PackageSelector
  */
 @API(status = STABLE, since = "1.0")
-public class PackageSource implements TestSource {
+public final class PackageSource implements TestSource {
 
 	@Serial
 	private static final long serialVersionUID = 1L;

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/discovery/DiscoveryIssueReporter.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/discovery/DiscoveryIssueReporter.java
@@ -165,6 +165,7 @@ public interface DiscoveryIssueReporter {
 		 *
 		 * @return the composed condition; never {@code null}
 		 */
+		@SuppressWarnings("ShortCircuitBoolean")
 		default Condition<T> and(Condition<? super T> that) {
 			Preconditions.notNull(that, "condition must not be null");
 			return value -> this.check(value) & that.check(value);

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/ExclusiveResource.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/ExclusiveResource.java
@@ -92,6 +92,7 @@ public class ExclusiveResource {
 	}
 
 	@Override
+	@SuppressWarnings("EqualsGetClass")
 	public boolean equals(Object o) {
 		if (this == o) {
 			return true;

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/ForkJoinPoolHierarchicalTestExecutorService.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/ForkJoinPoolHierarchicalTestExecutorService.java
@@ -21,7 +21,6 @@ import java.lang.reflect.Constructor;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.Callable;
@@ -161,9 +160,9 @@ public class ForkJoinPoolHierarchicalTestExecutorService implements Hierarchical
 			new ExclusiveTask(tasks.get(0)).execSync();
 			return;
 		}
-		Deque<ExclusiveTask> isolatedTasks = new LinkedList<>();
-		Deque<ExclusiveTask> sameThreadTasks = new LinkedList<>();
-		Deque<ExclusiveTask> concurrentTasksInReverseOrder = new LinkedList<>();
+		Deque<ExclusiveTask> isolatedTasks = new ArrayDeque<>();
+		Deque<ExclusiveTask> sameThreadTasks = new ArrayDeque<>();
+		Deque<ExclusiveTask> concurrentTasksInReverseOrder = new ArrayDeque<>();
 		forkConcurrentTasks(tasks, isolatedTasks, sameThreadTasks, concurrentTasksInReverseOrder);
 		executeSync(sameThreadTasks);
 		joinConcurrentTasksInReverseOrderToEnableWorkStealing(concurrentTasksInReverseOrder);

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/NodeTestTask.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/NodeTestTask.java
@@ -241,6 +241,7 @@ class NodeTestTask<C extends EngineExecutionContext> implements TestTask {
 		private final Map<UniqueId, DynamicTaskState> unfinishedTasks = new ConcurrentHashMap<>();
 
 		@Override
+		@SuppressWarnings("FutureReturnValueIgnored")
 		public void execute(TestDescriptor testDescriptor) {
 			execute(testDescriptor, taskContext.listener());
 		}

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/store/Namespace.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/store/Namespace.java
@@ -28,7 +28,7 @@ import org.junit.platform.commons.util.Preconditions;
  * lifecycle of a single extension.
  */
 @API(status = EXPERIMENTAL, since = "6.0")
-public class Namespace {
+public final class Namespace {
 
 	/**
 	 * The default, global namespace which allows access to stored data from

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestIdentifier.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestIdentifier.java
@@ -52,6 +52,7 @@ public final class TestIdentifier implements Serializable {
 	@Serial
 	private static final long serialVersionUID = 1L;
 	@Serial
+	@SuppressWarnings("UnusedVariable")
 	private static final ObjectStreamField[] serialPersistentFields = ObjectStreamClass.lookup(
 		SerializedForm.class).getFields();
 

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/EngineDiscoveryOrchestrator.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/EngineDiscoveryOrchestrator.java
@@ -15,9 +15,9 @@ import static org.apiguardian.api.API.Status.INTERNAL;
 import static org.junit.platform.engine.Filter.composeFilters;
 import static org.junit.platform.launcher.core.LauncherPhase.getDiscoveryIssueFailurePhase;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -177,7 +177,7 @@ public class EngineDiscoveryOrchestrator {
 
 		engineFilterer.performSanityChecks();
 
-		List<PostDiscoveryFilter> filters = new LinkedList<>(postDiscoveryFilters);
+		List<PostDiscoveryFilter> filters = new ArrayList<>(postDiscoveryFilters);
 		filters.addAll(request.getPostDiscoveryFilters());
 
 		applyPostDiscoveryFilters(testEngineDescriptors, filters);
@@ -238,7 +238,7 @@ public class EngineDiscoveryOrchestrator {
 
 	private void populateExclusionReasonInMap(Optional<String> reason, TestDescriptor testDescriptor,
 			Map<String, List<TestDescriptor>> excludedTestDescriptorsByReason) {
-		excludedTestDescriptorsByReason.computeIfAbsent(reason.orElse("Unknown"), list -> new LinkedList<>()).add(
+		excludedTestDescriptorsByReason.computeIfAbsent(reason.orElse("Unknown"), __ -> new ArrayList<>()).add(
 			testDescriptor);
 	}
 

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/StreamInterceptor.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/StreamInterceptor.java
@@ -12,6 +12,7 @@ package org.junit.platform.launcher.core;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.nio.charset.Charset;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.Optional;
@@ -138,7 +139,7 @@ class StreamInterceptor extends PrintStream {
 			}
 			int length = count - position;
 			count -= length;
-			return new String(buf, position, length);
+			return new String(buf, position, length, Charset.defaultCharset());
 		}
 	}
 }

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/discovery/AbortOnFailureLauncherDiscoveryListener.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/discovery/AbortOnFailureLauncherDiscoveryListener.java
@@ -19,7 +19,7 @@ import org.junit.platform.launcher.LauncherDiscoveryListener;
  * @since 1.6
  * @see LauncherDiscoveryListeners#abortOnFailure()
  */
-class AbortOnFailureLauncherDiscoveryListener implements LauncherDiscoveryListener {
+final class AbortOnFailureLauncherDiscoveryListener implements LauncherDiscoveryListener {
 
 	@Override
 	public void engineDiscoveryFinished(UniqueId engineId, EngineDiscoveryResult result) {

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/discovery/LoggingLauncherDiscoveryListener.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/discovery/LoggingLauncherDiscoveryListener.java
@@ -31,7 +31,7 @@ import org.junit.platform.launcher.LauncherDiscoveryRequest;
  * @since 1.6
  * @see LauncherDiscoveryListeners#logging()
  */
-class LoggingLauncherDiscoveryListener implements LauncherDiscoveryListener {
+final class LoggingLauncherDiscoveryListener implements LauncherDiscoveryListener {
 
 	private static final Logger logger = LoggerFactory.getLogger(LoggingLauncherDiscoveryListener.class);
 

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/tagexpression/ShuntingYard.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/tagexpression/ShuntingYard.java
@@ -111,7 +111,7 @@ class ShuntingYard {
 
 	private ParseStatus findOperands(Token token, Operator currentOperator) {
 		while (currentOperator.hasLowerPrecedenceThan(previousOperator())
-				|| currentOperator.hasSamePrecedenceAs(previousOperator()) && currentOperator.isLeftAssociative()) {
+				|| (currentOperator.hasSamePrecedenceAs(previousOperator()) && currentOperator.isLeftAssociative())) {
 			TokenWith<Operator> tokenWithWithOperator = operators.pop();
 			ParseStatus parseStatus = tokenWithWithOperator.element().createAndAddExpressionTo(expressions,
 				tokenWithWithOperator.token());

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/tagexpression/Tokenizer.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/tagexpression/Tokenizer.java
@@ -10,7 +10,6 @@
 
 package org.junit.platform.launcher.tagexpression;
 
-import static java.util.Collections.emptyList;
 import static java.util.regex.Pattern.CASE_INSENSITIVE;
 
 import java.util.ArrayList;
@@ -30,14 +29,14 @@ class Tokenizer {
 
 	List<Token> tokenize(@Nullable String infixTagExpression) {
 		if (infixTagExpression == null) {
-			return emptyList();
+			return List.of();
 		}
 		List<Token> parts = new ArrayList<>();
 		Matcher matcher = PATTERN.matcher(infixTagExpression);
 		while (matcher.find()) {
 			parts.add(new Token(matcher.start(), matcher.group()));
 		}
-		return parts;
+		return List.copyOf(parts);
 	}
 
 }

--- a/junit-platform-reporting/src/main/java/org/junit/platform/reporting/legacy/xml/LegacyXmlReportGeneratingListener.java
+++ b/junit-platform-reporting/src/main/java/org/junit/platform/reporting/legacy/xml/LegacyXmlReportGeneratingListener.java
@@ -19,6 +19,7 @@ import java.io.Writer;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Clock;
+import java.time.ZoneId;
 
 import javax.xml.stream.XMLStreamException;
 
@@ -53,7 +54,7 @@ public class LegacyXmlReportGeneratingListener implements TestExecutionListener 
 	private @Nullable XmlReportData reportData;
 
 	public LegacyXmlReportGeneratingListener(Path reportsDir, PrintWriter out) {
-		this(reportsDir, out, Clock.systemDefaultZone());
+		this(reportsDir, out, Clock.system(ZoneId.systemDefault()));
 	}
 
 	// For tests only

--- a/junit-platform-reporting/src/main/java/org/junit/platform/reporting/open/xml/OpenTestReportGeneratingListener.java
+++ b/junit-platform-reporting/src/main/java/org/junit/platform/reporting/open/xml/OpenTestReportGeneratingListener.java
@@ -149,6 +149,7 @@ public class OpenTestReportGeneratingListener implements TestExecutionListener {
 		return config.getBoolean(GIT_ENABLED_PROPERTY_NAME).orElse(false);
 	}
 
+	@SuppressWarnings("EmptyCatch")
 	private void reportInfrastructure(ConfigurationParameters config) {
 		eventsFileWriter.append(infrastructure(), infrastructure -> {
 			try {

--- a/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/Events.java
+++ b/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/Events.java
@@ -376,6 +376,7 @@ public final class Events {
 	 * @param out the {@code OutputStream} to print to; never {@code null}
 	 * @return this {@code Events} object for method chaining; never {@code null}
 	 */
+	@SuppressWarnings("DefaultCharset")
 	public Events debug(OutputStream out) {
 		Preconditions.notNull(out, "OutputStream must not be null");
 		debug(new PrintWriter(out, true));

--- a/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/Executions.java
+++ b/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/Executions.java
@@ -205,6 +205,7 @@ public final class Executions {
 	 * @param out the {@code OutputStream} to print to; never {@code null}
 	 * @return this {@code Executions} object for method chaining; never {@code null}
 	 */
+	@SuppressWarnings("DefaultCharset")
 	public Executions debug(OutputStream out) {
 		Preconditions.notNull(out, "OutputStream must not be null");
 		debug(new PrintWriter(out, true));
@@ -217,6 +218,7 @@ public final class Executions {
 	 * @param writer the {@code Writer} to print to; never {@code null}
 	 * @return this {@code Executions} object for method chaining; never {@code null}
 	 */
+	@SuppressWarnings("DefaultCharset")
 	public Executions debug(Writer writer) {
 		Preconditions.notNull(writer, "Writer must not be null");
 		debug(new PrintWriter(writer, true));

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/execution/TestRun.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/execution/TestRun.java
@@ -254,6 +254,7 @@ class TestRun {
 		 *
 		 * @param description the {@code Description} to look up
 		 */
+		@SuppressWarnings("ReferenceEquality")
 		Optional<VintageTestDescriptor> getUnambiguously(Description description) {
 			if (descriptors.isEmpty()) {
 				return Optional.empty();

--- a/platform-tests/src/processStarter/java/org/junit/platform/tests/process/WatchedProcess.java
+++ b/platform-tests/src/processStarter/java/org/junit/platform/tests/process/WatchedProcess.java
@@ -55,6 +55,7 @@ public class WatchedProcess {
 		}
 	}
 
+	@SuppressWarnings("EmptyCatch")
 	private static void closeQuietly(Optional<OutputStream> fileStream) {
 		if (fileStream.isEmpty()) {
 			return;

--- a/platform-tooling-support-tests/platform-tooling-support-tests.gradle.kts
+++ b/platform-tooling-support-tests/platform-tooling-support-tests.gradle.kts
@@ -1,6 +1,7 @@
 import com.gradle.develocity.agent.gradle.internal.test.TestDistributionConfigurationInternal
 import junitbuild.extensions.capitalized
 import junitbuild.extensions.dependencyProject
+import net.ltgt.gradle.errorprone.errorprone
 import org.gradle.api.tasks.PathSensitivity.RELATIVE
 import org.gradle.kotlin.dsl.support.listFilesOrdered
 import java.time.Duration
@@ -147,6 +148,12 @@ val archUnit by testing.suites.registering(JvmTestSuite::class) {
 				}
 			}
 		}
+	}
+}
+
+tasks.compileJava {
+	options.errorprone {
+		disableAllChecks = true
 	}
 }
 


### PR DESCRIPTION
* Classes with equals calling `getClass()` may potentially problematic.
  I made them `final` where they were "effectively" `final` by only
  having private or package-private constructors.

* I switched from `LinkedList` to `ArrayList` or `ArrayDeque` based on
  ErrorProne's recommendations.

<!-- Please describe your changes here and list any open questions you might have. -->

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://docs.junit.org/snapshot/user-guide/) and [Release Notes](https://docs.junit.org/snapshot/user-guide/#release-notes)
