### PR TITLE
Allow `Stream<? extends TestTemplateInvocationContext>` return types

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-6.0.0-M2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-6.0.0-M2.adoc
@@ -61,7 +61,10 @@ repository on GitHub.
 [[release-notes-6.0.0-M2-junit-jupiter-deprecations-and-breaking-changes]]
 ==== Deprecations and Breaking Changes
 
-* ❓
+* Change return type of `provideTestTemplateInvocationContexts(ExtensionContext)` method
+  of the `TestTemplateInvocationContextProvider` interface from
+  `Stream<TestTemplateInvocationContext>` to
+  `Stream<? extends TestTemplateInvocationContext>`.
 
 [[release-notes-6.0.0-M2-junit-jupiter-new-features-and-improvements]]
 ==== New Features and Improvements

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/TestTemplateInvocationContextProvider.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/TestTemplateInvocationContextProvider.java
@@ -91,7 +91,7 @@ public interface TestTemplateInvocationContextProvider extends Extension {
 	 * @see #supportsTestTemplate
 	 * @see ExtensionContext
 	 */
-	Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(ExtensionContext context);
+	Stream<? extends TestTemplateInvocationContext> provideTestTemplateInvocationContexts(ExtensionContext context);
 
 	/**
 	 * Signal that this provider may provide zero

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/RepeatedTestExtension.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/RepeatedTestExtension.java
@@ -20,7 +20,6 @@ import java.util.stream.Stream;
 
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
 import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
 import org.junit.platform.commons.util.Preconditions;
 
@@ -38,7 +37,7 @@ class RepeatedTestExtension implements TestTemplateInvocationContextProvider {
 	}
 
 	@Override
-	public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(ExtensionContext context) {
+	public Stream<RepeatedTestInvocationContext> provideTestTemplateInvocationContexts(ExtensionContext context) {
 		Method testMethod = context.getRequiredTestMethod();
 		String displayName = context.getDisplayName();
 		RepeatedTest repeatedTest = findAnnotation(testMethod, RepeatedTest.class).get();

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedClassContext.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedClassContext.java
@@ -28,13 +28,12 @@ import java.util.List;
 import java.util.function.Predicate;
 
 import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.extension.ClassTemplateInvocationContext;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.platform.commons.JUnitException;
 import org.junit.platform.commons.support.HierarchyTraversalMode;
 import org.junit.platform.commons.util.ReflectionUtils;
 
-class ParameterizedClassContext implements ParameterizedDeclarationContext<ClassTemplateInvocationContext> {
+class ParameterizedClassContext implements ParameterizedDeclarationContext<ParameterizedClassInvocationContext> {
 
 	private final Class<?> testClass;
 	private final ParameterizedClass annotation;
@@ -124,7 +123,7 @@ class ParameterizedClassContext implements ParameterizedDeclarationContext<Class
 	}
 
 	@Override
-	public ClassTemplateInvocationContext createInvocationContext(ParameterizedInvocationNameFormatter formatter,
+	public ParameterizedClassInvocationContext createInvocationContext(ParameterizedInvocationNameFormatter formatter,
 			Arguments arguments, int invocationIndex) {
 		return new ParameterizedClassInvocationContext(this, formatter, arguments, invocationIndex);
 	}

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedClassExtension.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedClassExtension.java
@@ -21,7 +21,6 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.extension.ClassTemplateInvocationContext;
 import org.junit.jupiter.api.extension.ClassTemplateInvocationContextProvider;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
@@ -35,7 +34,7 @@ import org.junit.platform.commons.PreconditionViolationException;
 /**
  * @since 5.13
  */
-class ParameterizedClassExtension extends ParameterizedInvocationContextProvider<ClassTemplateInvocationContext>
+class ParameterizedClassExtension extends ParameterizedInvocationContextProvider<ParameterizedClassInvocationContext>
 		implements ClassTemplateInvocationContextProvider, ParameterResolver {
 
 	private static final String DECLARATION_CONTEXT_KEY = "context";
@@ -70,7 +69,7 @@ class ParameterizedClassExtension extends ParameterizedInvocationContextProvider
 	}
 
 	@Override
-	public Stream<? extends ClassTemplateInvocationContext> provideClassTemplateInvocationContexts(
+	public Stream<ParameterizedClassInvocationContext> provideClassTemplateInvocationContexts(
 			ExtensionContext extensionContext) {
 
 		return provideInvocationContexts(extensionContext, getDeclarationContext(extensionContext));

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestContext.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestContext.java
@@ -12,7 +12,6 @@ package org.junit.jupiter.params;
 
 import java.lang.reflect.Method;
 
-import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.platform.commons.util.Preconditions;
 
@@ -22,7 +21,7 @@ import org.junit.platform.commons.util.Preconditions;
  *
  * @since 5.3
  */
-class ParameterizedTestContext implements ParameterizedDeclarationContext<TestTemplateInvocationContext> {
+class ParameterizedTestContext implements ParameterizedDeclarationContext<ParameterizedTestInvocationContext> {
 
 	private final Class<?> testClass;
 	private final Method method;
@@ -77,7 +76,7 @@ class ParameterizedTestContext implements ParameterizedDeclarationContext<TestTe
 	}
 
 	@Override
-	public TestTemplateInvocationContext createInvocationContext(ParameterizedInvocationNameFormatter formatter,
+	public ParameterizedTestInvocationContext createInvocationContext(ParameterizedInvocationNameFormatter formatter,
 			Arguments arguments, int invocationIndex) {
 		return new ParameterizedTestInvocationContext(this, formatter, arguments, invocationIndex);
 	}

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestExtension.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestExtension.java
@@ -18,13 +18,12 @@ import java.util.stream.Stream;
 
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
-import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
 import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
 
 /**
  * @since 5.0
  */
-class ParameterizedTestExtension extends ParameterizedInvocationContextProvider<TestTemplateInvocationContext>
+class ParameterizedTestExtension extends ParameterizedInvocationContextProvider<ParameterizedTestInvocationContext>
 		implements TestTemplateInvocationContextProvider {
 
 	static final String DECLARATION_CONTEXT_KEY = "context";
@@ -45,7 +44,7 @@ class ParameterizedTestExtension extends ParameterizedInvocationContextProvider<
 	}
 
 	@Override
-	public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(
+	public Stream<ParameterizedTestInvocationContext> provideTestTemplateInvocationContexts(
 			ExtensionContext extensionContext) {
 
 		return provideInvocationContexts(extensionContext, getDeclarationContext(extensionContext));


### PR DESCRIPTION
For consistency with `ClassTemplateInvocationContextProvider` and to
make implementations simpler, this commit changes the return type of the
`provideTestTemplateInvocationContexts(ExtensionContext)` method of the
`TestTemplateInvocationContextProvider` interface to allow more concrete
`Streams` to be returned.

This change is source compatible, meaning implementations will still
compile when declaring `Stream<TestTemplateInvocationContext>` as method
return type. To check for binary compatibility, I used Pioneer's
`RetryingTestExtension` with a 6.0.0-SNAPSHOT that included this change.
The extension kept working. Nevertheless, I included this change as
potentially breaking in the release notes.

Resolves #3577.

<!-- Please describe your changes here and list any open questions you might have. -->

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://docs.junit.org/snapshot/user-guide/) and [Release Notes](https://docs.junit.org/snapshot/user-guide/#release-notes)
