### PR TITLE
Add `computeIfAbsent` variants for non-nullable types to stores

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-6.0.0-M2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-6.0.0-M2.adoc
@@ -29,6 +29,8 @@ repository on GitHub.
 * `ConversionSupport` now converts `String` to `Locale` using the IETF BCP 47 language tag
   format supported by the `Locale.forLanguageTag(String)` factory method instead of the
   format used by the deprecated `Locale(String)` constructor.
+* Deprecate `getOrComputeIfAbsent(...)` methods in `NamespacedHierarchicalStore` in favor
+  of the new `computeIfAbsent(...)` methods.
 
 [[release-notes-6.0.0-M2-junit-platform-new-features-and-improvements]]
 ==== New Features and Improvements
@@ -51,6 +53,8 @@ repository on GitHub.
 * Provide cancellation support for the Suite and Vintage test engines
 * Introduce `TestTask.getTestDescriptor()` method for use in
   `HierarchicalTestExecutorService` implementations.
+* Introduce `computeIfAbsent(...)` methods in `NamespacedHierarchicalStore` to simplify
+  working with non-nullable types.
 
 
 [[release-notes-6.0.0-M2-junit-jupiter]]
@@ -72,12 +76,16 @@ repository on GitHub.
   configuration parameter. `Locale` conversions are now always performed using the IETF
   BCP 47 language tag format supported by the `Locale.forLanguageTag(String)` factory
   method.
+* Deprecate `getOrComputeIfAbsent(...)` methods in `ExtensionContext.Store` in favor of
+  the new `computeIfAbsent(...)` methods.
 
 [[release-notes-6.0.0-M2-junit-jupiter-new-features-and-improvements]]
 ==== New Features and Improvements
 
 * Reason strings supplied to `ConditionEvaluationResult` APIs are now officially declared
   as `@Nullable`.
+* Introduce `computeIfAbsent(...)` methods in `ExtensionContext.Store` to ease simplify
+  with non-nullable types.
 
 
 [[release-notes-6.0.0-M2-junit-vintage]]

--- a/documentation/src/test/java/example/FirstCustomEngine.java
+++ b/documentation/src/test/java/example/FirstCustomEngine.java
@@ -48,9 +48,6 @@ public class FirstCustomEngine implements TestEngine {
 		return new EngineDescriptor(uniqueId, "First Custom Test Engine");
 	}
 
-	//end::user_guide[]
-	@SuppressWarnings("NullAway")
-	//tag::user_guide[]
 	@Override
 	public void execute(ExecutionRequest request) {
 		request.getEngineExecutionListener()
@@ -58,7 +55,7 @@ public class FirstCustomEngine implements TestEngine {
 				.executionStarted(request.getRootTestDescriptor());
 
 		NamespacedHierarchicalStore<Namespace> store = request.getStore();
-		socket = store.getOrComputeIfAbsent(Namespace.GLOBAL, "serverSocket", key -> {
+		socket = store.computeIfAbsent(Namespace.GLOBAL, "serverSocket", key -> {
 			try {
 				return new ServerSocket(0, 50, getLoopbackAddress());
 			}

--- a/documentation/src/test/java/example/SecondCustomEngine.java
+++ b/documentation/src/test/java/example/SecondCustomEngine.java
@@ -48,9 +48,6 @@ public class SecondCustomEngine implements TestEngine {
 		return new EngineDescriptor(uniqueId, "Second Custom Test Engine");
 	}
 
-	//end::user_guide[]
-	@SuppressWarnings("NullAway")
-	//tag::user_guide[]
 	@Override
 	public void execute(ExecutionRequest request) {
 		request.getEngineExecutionListener()
@@ -58,7 +55,7 @@ public class SecondCustomEngine implements TestEngine {
 				.executionStarted(request.getRootTestDescriptor());
 
 		NamespacedHierarchicalStore<Namespace> store = request.getStore();
-		socket = store.getOrComputeIfAbsent(Namespace.GLOBAL, "serverSocket", key -> {
+		socket = store.computeIfAbsent(Namespace.GLOBAL, "serverSocket", key -> {
 			try {
 				return new ServerSocket(0, 50, getLoopbackAddress());
 			}

--- a/documentation/src/test/java/example/extensions/HttpServerExtension.java
+++ b/documentation/src/test/java/example/extensions/HttpServerExtension.java
@@ -28,16 +28,13 @@ public class HttpServerExtension implements ParameterResolver {
 		return HttpServer.class.equals(parameterContext.getParameter().getType());
 	}
 
-	//end::user_guide[]
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
-	//tag::user_guide[]
 	@Override
 	public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
 
 		ExtensionContext rootContext = extensionContext.getRoot();
 		ExtensionContext.Store store = rootContext.getStore(Namespace.GLOBAL);
 		Class<HttpServerResource> key = HttpServerResource.class;
-		HttpServerResource resource = store.getOrComputeIfAbsent(key, __ -> {
+		HttpServerResource resource = store.computeIfAbsent(key, __ -> {
 			try {
 				HttpServerResource serverResource = new HttpServerResource(0);
 				serverResource.start();

--- a/documentation/src/test/java/example/session/GlobalSetupTeardownListener.java
+++ b/documentation/src/test/java/example/session/GlobalSetupTeardownListener.java
@@ -43,7 +43,7 @@ public class GlobalSetupTeardownListener implements LauncherSessionListener {
 				}
 				//tag::user_guide[]
 				NamespacedHierarchicalStore<Namespace> store = session.getStore(); // <1>
-				store.getOrComputeIfAbsent(Namespace.GLOBAL, "httpServer", key -> { // <2>
+				store.computeIfAbsent(Namespace.GLOBAL, "httpServer", key -> { // <2>
 					InetSocketAddress address = new InetSocketAddress(getLoopbackAddress(), 0);
 					HttpServer server;
 					try {

--- a/junit-jupiter-api/src/testFixtures/java/org/junit/jupiter/api/fixtures/TrackLogRecords.java
+++ b/junit-jupiter-api/src/testFixtures/java/org/junit/jupiter/api/fixtures/TrackLogRecords.java
@@ -15,6 +15,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.jspecify.annotations.NullMarked;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -41,6 +42,7 @@ import org.junit.platform.commons.logging.LoggerFactory;
  * @see LoggerFactory
  * @see LogRecordListener
  */
+@NullMarked
 @Target({ ElementType.TYPE, ElementType.PARAMETER })
 @Retention(RetentionPolicy.RUNTIME)
 @ExtendWith(TrackLogRecords.Extension.class)
@@ -71,7 +73,7 @@ public @interface TrackLogRecords {
 		}
 
 		private LogRecordListener getListener(ExtensionContext context) {
-			return getStore(context).getOrComputeIfAbsent(LogRecordListener.class);
+			return getStore(context).computeIfAbsent(LogRecordListener.class);
 		}
 
 		private Store getStore(ExtensionContext context) {

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/NamespaceAwareStore.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/NamespaceAwareStore.java
@@ -42,7 +42,7 @@ public class NamespaceAwareStore implements Store {
 	public @Nullable Object get(Object key) {
 		Preconditions.notNull(key, "key must not be null");
 		Supplier<@Nullable Object> action = () -> this.valuesStore.get(this.namespace, key);
-		return accessStore(action);
+		return this.<@Nullable Object> accessStore(action);
 	}
 
 	@Override
@@ -50,9 +50,10 @@ public class NamespaceAwareStore implements Store {
 		Preconditions.notNull(key, "key must not be null");
 		Preconditions.notNull(requiredType, "requiredType must not be null");
 		Supplier<@Nullable T> action = () -> this.valuesStore.get(this.namespace, key, requiredType);
-		return accessStore(action);
+		return this.<@Nullable T> accessStore(action);
 	}
 
+	@SuppressWarnings("deprecation")
 	@Override
 	public <K, V extends @Nullable Object> @Nullable Object getOrComputeIfAbsent(K key,
 			Function<? super K, ? extends V> defaultCreator) {
@@ -60,9 +61,10 @@ public class NamespaceAwareStore implements Store {
 		Preconditions.notNull(defaultCreator, "defaultCreator function must not be null");
 		Supplier<@Nullable Object> action = () -> this.valuesStore.getOrComputeIfAbsent(this.namespace, key,
 			defaultCreator);
-		return accessStore(action);
+		return this.<@Nullable Object> accessStore(action);
 	}
 
+	@SuppressWarnings("deprecation")
 	@Override
 	public <K, V extends @Nullable Object> @Nullable V getOrComputeIfAbsent(K key,
 			Function<? super K, ? extends V> defaultCreator, Class<V> requiredType) {
@@ -71,6 +73,23 @@ public class NamespaceAwareStore implements Store {
 		Preconditions.notNull(requiredType, "requiredType must not be null");
 		Supplier<@Nullable V> action = () -> this.valuesStore.getOrComputeIfAbsent(this.namespace, key, defaultCreator,
 			requiredType);
+		return this.<@Nullable V> accessStore(action);
+	}
+
+	@Override
+	public <K, V> Object computeIfAbsent(K key, Function<? super K, ? extends V> defaultCreator) {
+		Preconditions.notNull(key, "key must not be null");
+		Preconditions.notNull(defaultCreator, "defaultCreator function must not be null");
+		Supplier<Object> action = () -> this.valuesStore.computeIfAbsent(this.namespace, key, defaultCreator);
+		return accessStore(action);
+	}
+
+	@Override
+	public <K, V> V computeIfAbsent(K key, Function<? super K, ? extends V> defaultCreator, Class<V> requiredType) {
+		Preconditions.notNull(key, "key must not be null");
+		Preconditions.notNull(defaultCreator, "defaultCreator function must not be null");
+		Preconditions.notNull(requiredType, "requiredType must not be null");
+		Supplier<V> action = () -> this.valuesStore.computeIfAbsent(this.namespace, key, defaultCreator, requiredType);
 		return accessStore(action);
 	}
 
@@ -78,14 +97,14 @@ public class NamespaceAwareStore implements Store {
 	public void put(Object key, @Nullable Object value) {
 		Preconditions.notNull(key, "key must not be null");
 		Supplier<@Nullable Object> action = () -> this.valuesStore.put(this.namespace, key, value);
-		accessStore(action);
+		this.<@Nullable Object> accessStore(action);
 	}
 
 	@Override
 	public @Nullable Object remove(Object key) {
 		Preconditions.notNull(key, "key must not be null");
 		Supplier<@Nullable Object> action = () -> this.valuesStore.remove(this.namespace, key);
-		return accessStore(action);
+		return this.<@Nullable Object> accessStore(action);
 	}
 
 	@Override
@@ -93,10 +112,10 @@ public class NamespaceAwareStore implements Store {
 		Preconditions.notNull(key, "key must not be null");
 		Preconditions.notNull(requiredType, "requiredType must not be null");
 		Supplier<@Nullable T> action = () -> this.valuesStore.remove(this.namespace, key, requiredType);
-		return accessStore(action);
+		return this.<@Nullable T> accessStore(action);
 	}
 
-	private <T> @Nullable T accessStore(Supplier<@Nullable T> action) {
+	private <T extends @Nullable Object> T accessStore(Supplier<T> action) {
 		try {
 			return action.get();
 		}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
@@ -12,7 +12,6 @@ package org.junit.jupiter.engine.extension;
 
 import static java.nio.file.FileVisitResult.CONTINUE;
 import static java.nio.file.FileVisitResult.SKIP_SUBTREE;
-import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
 import static org.junit.jupiter.api.extension.TestInstantiationAwareExtension.ExtensionContextScope.TEST_METHOD;
 import static org.junit.jupiter.api.io.CleanupMode.DEFAULT;
@@ -242,11 +241,11 @@ class TempDirectory implements BeforeAllCallback, BeforeEachCallback, ParameterR
 	private static Object getPathOrFile(Class<?> elementType, AnnotatedElementContext elementContext,
 			TempDirFactory factory, CleanupMode cleanupMode, ExtensionContext extensionContext) {
 
-		Path path = requireNonNull(extensionContext.getStore(NAMESPACE.append(elementContext)) //
-				.getOrComputeIfAbsent(KEY,
+		Path path = extensionContext.getStore(NAMESPACE.append(elementContext)) //
+				.computeIfAbsent(KEY,
 					__ -> createTempDir(factory, cleanupMode, elementType, elementContext, extensionContext),
-					CloseablePath.class)) //
-							.get();
+					CloseablePath.class) //
+				.get();
 
 		return (elementType == Path.class) ? path : path.toFile();
 	}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TimeoutExtension.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TimeoutExtension.java
@@ -10,7 +10,6 @@
 
 package org.junit.jupiter.engine.extension;
 
-import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Timeout.TIMEOUT_MODE_PROPERTY_NAME;
 import static org.junit.jupiter.api.Timeout.ThreadMode.SAME_THREAD;
 
@@ -172,8 +171,8 @@ class TimeoutExtension implements BeforeAllCallback, BeforeEachCallback, Invocat
 
 	private TimeoutConfiguration getGlobalTimeoutConfiguration(ExtensionContext extensionContext) {
 		ExtensionContext root = extensionContext.getRoot();
-		return requireNonNull(root.getStore(NAMESPACE).getOrComputeIfAbsent(GLOBAL_TIMEOUT_CONFIG_KEY,
-			key -> new TimeoutConfiguration(root), TimeoutConfiguration.class));
+		return root.getStore(NAMESPACE).computeIfAbsent(GLOBAL_TIMEOUT_CONFIG_KEY,
+			key -> new TimeoutConfiguration(root), TimeoutConfiguration.class);
 	}
 
 	private <T extends @Nullable Object> Invocation<T> decorate(Invocation<T> invocation,

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TimeoutInvocationFactory.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TimeoutInvocationFactory.java
@@ -10,8 +10,6 @@
 
 package org.junit.jupiter.engine.extension;
 
-import static java.util.Objects.requireNonNull;
-
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -50,7 +48,7 @@ class TimeoutInvocationFactory {
 	}
 
 	private ScheduledExecutorService getThreadExecutorForSameThreadInvocation() {
-		return requireNonNull(store.getOrComputeIfAbsent(SingleThreadExecutorResource.class)).get();
+		return store.computeIfAbsent(SingleThreadExecutorResource.class).get();
 	}
 
 	@SuppressWarnings({ "deprecation", "try" })

--- a/junit-jupiter-migrationsupport/src/main/java/org/junit/jupiter/migrationsupport/rules/ExpectedExceptionSupport.java
+++ b/junit-jupiter-migrationsupport/src/main/java/org/junit/jupiter/migrationsupport/rules/ExpectedExceptionSupport.java
@@ -61,8 +61,8 @@ public class ExpectedExceptionSupport implements AfterEachCallback, TestExecutio
 
 	@Override
 	public void afterEach(ExtensionContext context) throws Exception {
-		Boolean handled = getStore(context).getOrComputeIfAbsent(EXCEPTION_WAS_HANDLED, key -> false, Boolean.class);
-		if (handled != null && !handled) {
+		boolean handled = getStore(context).computeIfAbsent(EXCEPTION_WAS_HANDLED, key -> false, Boolean.class);
+		if (!handled) {
 			this.support.afterEach(context);
 		}
 	}

--- a/junit-jupiter-migrationsupport/src/main/java/org/junit/jupiter/migrationsupport/rules/TestRuleSupport.java
+++ b/junit-jupiter-migrationsupport/src/main/java/org/junit/jupiter/migrationsupport/rules/TestRuleSupport.java
@@ -11,7 +11,6 @@
 package org.junit.jupiter.migrationsupport.rules;
 
 import static java.util.Collections.unmodifiableList;
-import static java.util.Objects.requireNonNull;
 import static org.junit.platform.commons.support.AnnotationSupport.findPublicAnnotatedFields;
 import static org.junit.platform.commons.support.AnnotationSupport.isAnnotated;
 import static org.junit.platform.commons.support.HierarchyTraversalMode.TOP_DOWN;
@@ -147,8 +146,8 @@ class TestRuleSupport implements BeforeEachCallback, TestExecutionExceptionHandl
 		Object testInstance = context.getRequiredTestInstance();
 		Namespace namespace = Namespace.create(TestRuleSupport.class, context.getRequiredTestClass());
 		// @formatter:off
-		return new ArrayList<>(requireNonNull(context.getStore(namespace)
-				.getOrComputeIfAbsent("rule-annotated-members", key -> findRuleAnnotatedMembers(testInstance), List.class)));
+		return new ArrayList<>(context.getStore(namespace)
+				.computeIfAbsent("rule-annotated-members", key -> findRuleAnnotatedMembers(testInstance), List.class));
 		// @formatter:on
 	}
 

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ArgumentCountValidator.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ArgumentCountValidator.java
@@ -10,8 +10,6 @@
 
 package org.junit.jupiter.params;
 
-import static java.util.Objects.requireNonNull;
-
 import java.util.Arrays;
 import java.util.Optional;
 
@@ -72,7 +70,7 @@ class ArgumentCountValidator {
 		String key = ARGUMENT_COUNT_VALIDATION_KEY;
 		ArgumentCountValidationMode fallback = ArgumentCountValidationMode.NONE;
 		ExtensionContext.Store store = getStore(extensionContext);
-		return requireNonNull(store.getOrComputeIfAbsent(key, __ -> {
+		return store.computeIfAbsent(key, __ -> {
 			Optional<String> optionalConfigValue = extensionContext.getConfigurationParameter(key);
 			if (optionalConfigValue.isPresent()) {
 				String configValue = optionalConfigValue.get();
@@ -95,7 +93,7 @@ class ArgumentCountValidator {
 			else {
 				return fallback;
 			}
-		}, ArgumentCountValidationMode.class));
+		}, ArgumentCountValidationMode.class);
 	}
 
 	private static String pluralize(int count, String singular, String plural) {

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/extension/Heavyweight.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/extension/Heavyweight.java
@@ -10,7 +10,6 @@
 
 package org.junit.jupiter.api.extension;
 
-import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -33,7 +32,7 @@ class Heavyweight implements ParameterResolver, BeforeEachCallback {
 	public Object resolveParameter(ParameterContext parameterContext, ExtensionContext context) {
 		var engineContext = context.getRoot();
 		var store = engineContext.getStore(ExtensionContext.Namespace.GLOBAL);
-		var resource = requireNonNull(store.getOrComputeIfAbsent(ResourceValue.class));
+		var resource = store.computeIfAbsent(ResourceValue.class);
 		resource.usages.incrementAndGet();
 		return resource;
 	}

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/descriptor/ExtensionContextTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/descriptor/ExtensionContextTests.java
@@ -409,7 +409,7 @@ public class ExtensionContextTests {
 	}
 
 	@Test
-	@SuppressWarnings("resource")
+	@SuppressWarnings({ "resource", "deprecation" })
 	void usingStore() {
 		var methodTestDescriptor = methodDescriptor();
 		var classTestDescriptor = outerClassDescriptor(methodTestDescriptor);
@@ -436,14 +436,17 @@ public class ExtensionContextTests {
 
 		final Object key2 = "key 2";
 		final var value2 = "other value";
-		assertEquals(value2, childStore.getOrComputeIfAbsent(key2, key -> value2));
-		assertEquals(value2, childStore.getOrComputeIfAbsent(key2, key -> value2, String.class));
+		assertEquals(value2, childStore.computeIfAbsent(key2, key -> value2));
+		assertEquals(value2, childStore.computeIfAbsent(key2, key -> "a different value", String.class));
+		assertEquals(value2, childStore.getOrComputeIfAbsent(key2, key -> "a different value"));
+		assertEquals(value2, childStore.getOrComputeIfAbsent(key2, key -> "a different value", String.class));
 		assertEquals(value2, childStore.get(key2));
 		assertEquals(value2, childStore.get(key2, String.class));
 
 		final Object parentKey = "parent key";
 		final var parentValue = "parent value";
 		parentStore.put(parentKey, parentValue);
+		assertEquals(parentValue, childStore.computeIfAbsent(parentKey, k -> "a different value"));
 		assertEquals(parentValue, childStore.getOrComputeIfAbsent(parentKey, k -> "a different value"));
 		assertEquals(parentValue, childStore.get(parentKey));
 	}

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/execution/ExtensionContextStoreConcurrencyTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/execution/ExtensionContextStoreConcurrencyTests.java
@@ -35,7 +35,7 @@ class ExtensionContextStoreConcurrencyTests {
 		IntStream.range(1, 100).forEach(i -> {
 			Store store = reset();
 			// Simulate 100 extensions interacting concurrently with the Store.
-			IntStream.range(1, 100).parallel().forEach(j -> store.getOrComputeIfAbsent("key", this::newValue));
+			IntStream.range(1, 100).parallel().forEach(j -> store.computeIfAbsent("key", this::newValue));
 			assertEquals(1, count.get(), () -> "number of times newValue() was invoked in run #" + i);
 		});
 	}

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/execution/ExtensionContextStoreTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/execution/ExtensionContextStoreTests.java
@@ -12,6 +12,7 @@ package org.junit.jupiter.engine.execution;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -77,6 +78,7 @@ class ExtensionContextStoreTests {
 		assertThat(store.getOrDefault(KEY, String.class, VALUE)).isEqualTo(VALUE);
 	}
 
+	@SuppressWarnings("deprecation")
 	@Test
 	void getOrComputeIfAbsentWithFailingCreator() {
 		var invocations = new AtomicInteger();
@@ -90,6 +92,15 @@ class ExtensionContextStoreTests {
 
 		assertDoesNotThrow(localStore::close);
 		assertThat(invocations).hasValue(1);
+	}
+
+	@Test
+	void computeIfAbsentWithFailingCreator() {
+		assertThrows(RuntimeException.class, () -> store.computeIfAbsent(KEY, __ -> {
+			throw new RuntimeException();
+		}));
+		assertNull(store.get(KEY));
+		assertDoesNotThrow(localStore::close);
 	}
 
 }

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/ExtensionContextExecutionTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/ExtensionContextExecutionTests.java
@@ -73,7 +73,7 @@ class ExtensionContextExecutionTests extends AbstractJupiterTestEngineTests {
 		@Override
 		public void beforeAll(ExtensionContext context) {
 			ExtensionContext.Store store = getRoot(context).getStore(ExtensionContext.Namespace.GLOBAL);
-			store.getOrComputeIfAbsent("counter", key -> Parent.counter.incrementAndGet());
+			store.computeIfAbsent("counter", key -> Parent.counter.incrementAndGet());
 		}
 
 		private ExtensionContext getRoot(ExtensionContext context) {

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/TimeoutInvocationFactoryTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/TimeoutInvocationFactoryTests.java
@@ -85,12 +85,13 @@ class TimeoutInvocationFactoryTests {
 				.hasMessage("timeout invocation parameters must not be null");
 	}
 
+	@SuppressWarnings("resource")
 	@Test
 	@DisplayName("creates timeout invocation for SAME_THREAD thread mode")
 	void shouldCreateTimeoutInvocationForSameThreadTimeoutThreadMode() {
 		var invocation = timeoutInvocationFactory.create(ThreadMode.SAME_THREAD, parameters);
 		assertThat(invocation).isInstanceOf(SameThreadTimeoutInvocation.class);
-		verify(store).getOrComputeIfAbsent(SingleThreadExecutorResource.class);
+		verify(store).computeIfAbsent(SingleThreadExecutorResource.class);
 	}
 
 	@Test

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/LocalMavenRepo.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/LocalMavenRepo.java
@@ -32,7 +32,7 @@ public class LocalMavenRepo implements AutoCloseable {
 		@Override
 		public ManagedResource.Scope determineScope(ExtensionContext extensionContext) {
 			var store = extensionContext.getRoot().getStore(NAMESPACE);
-			var fileSystemType = store.getOrComputeIfAbsent("tempFileSystemType", key -> {
+			var fileSystemType = store.computeIfAbsent("tempFileSystemType", key -> {
 				var type = getFileSystemType(Path.of(System.getProperty("java.io.tmpdir")));
 				extensionContext.getRoot().publishReportEntry("tempFileSystemType", type);
 				return type;

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/ManagedResource.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/ManagedResource.java
@@ -95,7 +95,7 @@ public @interface ManagedResource {
 				case PER_CONTEXT -> extensionContext;
 			};
 			return storingContext.getStore(Namespace.GLOBAL) //
-					.getOrComputeIfAbsent(type, Resource::new, Resource.class);
+					.computeIfAbsent(type, Resource::new, Resource.class);
 		}
 	}
 

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/OutputAttachingExtension.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/OutputAttachingExtension.java
@@ -40,7 +40,7 @@ class OutputAttachingExtension implements ParameterResolver, AfterTestExecutionC
 	@Override
 	public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
 			throws ParameterResolutionException {
-		var outputDir = extensionContext.getStore(NAMESPACE).getOrComputeIfAbsent("outputDir", __ -> {
+		var outputDir = extensionContext.getStore(NAMESPACE).computeIfAbsent("outputDir", __ -> {
 			try {
 				return new OutputDir(Files.createTempDirectory("output"));
 			}


### PR DESCRIPTION
Since both `ExtensionContext.Store` and its backing
`NamespaceAwareStore` implementation allow storing `null` values, the
`getOrComputeIfAbsent` methods potentially returned `null`, even if
documented otherwise (in case of `getOrComputeIfAbsent(Class)` in
`ExtensionContext.Store`). Now that the API uses JSpecify's nullability
annotations, this became more apparent and also caused
Jupiter `Extension` implementations to have to deal with values being
potentially `null` despite their best intentions to only use
`getOrComputeIfAbsent` to access a certain `key` with a function that
never returned `null`. Therefore, this commit introduces null-safe
variants called `computeIfAbsent` that treat `null` as absent in
addition to the key not being present in the backing `Map`.

<!-- Please describe your changes here and list any open questions you might have. -->

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://docs.junit.org/snapshot/user-guide/) and [Release Notes](https://docs.junit.org/snapshot/user-guide/#release-notes)
