### PR TITLE
Fail on classpath resource names that are blank after removing leading slash

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.13.4.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.13.4.adoc
@@ -28,6 +28,8 @@ repository on GitHub.
 
 * `ClasspathResourceSelector` no longer allows to be constructed with a resource name that
   is blank after removing the leading slash.
+* `PackageSource.from(String)` now allows to be constructed with an empty string to
+  indicate the default package.
 
 [[release-notes-5.13.4-junit-platform-deprecations-and-breaking-changes]]
 ==== Deprecations and Breaking Changes

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.13.4.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.13.4.adoc
@@ -26,7 +26,8 @@ repository on GitHub.
 [[release-notes-5.13.4-junit-platform-bug-fixes]]
 ==== Bug Fixes
 
-* ❓
+* `ClasspathResourceSelector` no longer allows to be constructed with a resource name that
+  is blank after removing the leading slash.
 
 [[release-notes-5.13.4-junit-platform-deprecations-and-breaking-changes]]
 ==== Deprecations and Breaking Changes

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/ClasspathResourceSelector.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/ClasspathResourceSelector.java
@@ -25,6 +25,7 @@ import org.jspecify.annotations.Nullable;
 import org.junit.platform.commons.PreconditionViolationException;
 import org.junit.platform.commons.function.Try;
 import org.junit.platform.commons.support.Resource;
+import org.junit.platform.commons.util.Preconditions;
 import org.junit.platform.commons.util.ReflectionUtils;
 import org.junit.platform.commons.util.StringUtils;
 import org.junit.platform.commons.util.ToStringBuilder;
@@ -64,6 +65,8 @@ public final class ClasspathResourceSelector implements DiscoverySelector {
 	ClasspathResourceSelector(String classpathResourceName, @Nullable FilePosition position) {
 		boolean startsWithSlash = classpathResourceName.startsWith("/");
 		this.classpathResourceName = (startsWithSlash ? classpathResourceName.substring(1) : classpathResourceName);
+		Preconditions.notBlank(this.classpathResourceName,
+			"classpath resource name must not be blank after removing leading slash");
 		this.position = position;
 	}
 

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/PackageSource.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/PackageSource.java
@@ -60,7 +60,10 @@ public final class PackageSource implements TestSource {
 	}
 
 	private PackageSource(String packageName) {
-		this.packageName = Preconditions.notBlank(packageName, "package name must not be null or blank");
+		Preconditions.notNull(packageName, "package name must not be null");
+		Preconditions.condition(packageName.isEmpty() || !packageName.isBlank(),
+			"package name must not contain only whitespace");
+		this.packageName = packageName;
 	}
 
 	/**

--- a/platform-tests/src/test/java/org/junit/platform/engine/discovery/DiscoverySelectorsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/discovery/DiscoverySelectorsTests.java
@@ -299,8 +299,11 @@ class DiscoverySelectorsTests {
 		void selectClasspathResourcesPreconditions() {
 			assertViolatesPrecondition(() -> selectClasspathResource((String) null));
 			assertViolatesPrecondition(() -> selectClasspathResource(""));
+			assertViolatesPrecondition(() -> selectClasspathResource("/"));
 			assertViolatesPrecondition(() -> selectClasspathResource("    "));
+			assertViolatesPrecondition(() -> selectClasspathResource("/   "));
 			assertViolatesPrecondition(() -> selectClasspathResource("\t"));
+			assertViolatesPrecondition(() -> selectClasspathResource("/\t"));
 			assertViolatesPrecondition(() -> selectClasspathResource((Set<Resource>) null));
 			assertViolatesPrecondition(() -> selectClasspathResource(Collections.emptySet()));
 			assertViolatesPrecondition(() -> selectClasspathResource(Collections.singleton(null)));

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/PackageSourceTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/PackageSourceTests.java
@@ -18,6 +18,8 @@ import java.io.Serializable;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.junit.platform.commons.PreconditionViolationException;
 
 /**
@@ -49,9 +51,11 @@ class PackageSourceTests extends AbstractTestSourceTests {
 		assertThrows(PreconditionViolationException.class, () -> PackageSource.from((Package) null));
 	}
 
-	@Test
-	void packageSourceFromPackageName() {
-		var testPackage = getClass().getPackage().getName();
+	@ParameterizedTest
+	@ValueSource(classes = PackageSourceTests.class)
+	@ValueSource(strings = "DefaultPackageTestCase")
+	void packageSourceFromPackageName(Class<?> testClass) {
+		var testPackage = testClass.getPackage().getName();
 		var source = PackageSource.from(testPackage);
 
 		assertThat(source.getPackageName()).isEqualTo(testPackage);

--- a/platform-tests/src/test/java/org/junit/platform/launcher/core/DiscoveryIssueCollectorTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/core/DiscoveryIssueCollectorTests.java
@@ -69,6 +69,7 @@ class DiscoveryIssueCollectorTests {
 			new Pair(selectClasspathResource("someResource", FilePosition.from(42, 23)),
 				ClasspathResourceSource.from("someResource",
 					org.junit.platform.engine.support.descriptor.FilePosition.from(42, 23))), //
+			new Pair(selectPackage(""), PackageSource.from("")), //
 			new Pair(selectPackage("some.package"), PackageSource.from("some.package")), //
 			new Pair(selectFile("someFile"), FileSource.from(new File("someFile"))), //
 			new Pair(selectFile("someFile", FilePosition.from(42)),


### PR DESCRIPTION
Fixes #4752.


---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://docs.junit.org/snapshot/user-guide/) and [Release Notes](https://docs.junit.org/snapshot/user-guide/#release-notes)