### PR TITLE
Log only once per implementation type for `CloseableResource` types

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.13.4.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.13.4.adoc
@@ -58,7 +58,8 @@ repository on GitHub.
 [[release-notes-5.13.4-junit-jupiter-new-features-and-improvements]]
 ==== New Features and Improvements
 
-* ❓
+* Log only once per implementation type for `CloseableResource` implementations that do
+  not implement `AutoCloseable` to avoid flooding console output with this warning.
 
 
 [[release-notes-5.13.4-junit-vintage]]

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/AbstractExtensionContext.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/AbstractExtensionContext.java
@@ -54,6 +54,8 @@ import org.junit.platform.engine.support.store.NamespacedHierarchicalStore;
 abstract class AbstractExtensionContext<T extends TestDescriptor> implements ExtensionContextInternal, AutoCloseable {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(AbstractExtensionContext.class);
+	private static final Namespace CLOSEABLE_RESOURCE_LOGGING_NAMESPACE = Namespace.create(
+		AbstractExtensionContext.class, "CloseableResourceLogging");
 
 	private final @Nullable ExtensionContext parent;
 	private final EngineExecutionListener engineExecutionListener;
@@ -86,40 +88,37 @@ abstract class AbstractExtensionContext<T extends TestDescriptor> implements Ext
 				.collect(collectingAndThen(toCollection(LinkedHashSet::new), Collections::unmodifiableSet));
 		// @formatter:on
 
-		this.valuesStore = createStore(parent, launcherStoreFacade, createCloseAction());
+		this.valuesStore = new NamespacedHierarchicalStore<>(getParentStore(parent), createCloseAction());
+	}
+
+	private NamespacedHierarchicalStore<org.junit.platform.engine.support.store.Namespace> getParentStore(
+			@Nullable ExtensionContext parent) {
+		return parent == null //
+				? this.launcherStoreFacade.getRequestLevelStore() //
+				: ((AbstractExtensionContext<?>) parent).valuesStore;
 	}
 
 	@SuppressWarnings("deprecation")
-	private NamespacedHierarchicalStore.CloseAction<org.junit.platform.engine.support.store.Namespace> createCloseAction() {
+	private <N> NamespacedHierarchicalStore.CloseAction<N> createCloseAction() {
+		var store = this.launcherStoreFacade.getSessionLevelStore(CLOSEABLE_RESOURCE_LOGGING_NAMESPACE);
 		return (__, ___, value) -> {
 			boolean isAutoCloseEnabled = this.configuration.isClosingStoredAutoCloseablesEnabled();
 
-			if (value instanceof @SuppressWarnings("resource") AutoCloseable closeable && isAutoCloseEnabled) {
+			if (isAutoCloseEnabled && value instanceof @SuppressWarnings("resource") AutoCloseable closeable) {
 				closeable.close();
 				return;
 			}
 
 			if (value instanceof Store.CloseableResource resource) {
 				if (isAutoCloseEnabled) {
-					LOGGER.warn(
-						() -> "Type implements CloseableResource but not AutoCloseable: " + value.getClass().getName());
+					store.computeIfAbsent(value.getClass(), type -> {
+						LOGGER.warn(() -> "Type implements CloseableResource but not AutoCloseable: " + type.getName());
+						return true;
+					});
 				}
 				resource.close();
 			}
 		};
-	}
-
-	private static NamespacedHierarchicalStore<org.junit.platform.engine.support.store.Namespace> createStore(
-			@Nullable ExtensionContext parent, LauncherStoreFacade launcherStoreFacade,
-			NamespacedHierarchicalStore.CloseAction<org.junit.platform.engine.support.store.Namespace> closeAction) {
-		NamespacedHierarchicalStore<org.junit.platform.engine.support.store.Namespace> parentStore;
-		if (parent == null) {
-			parentStore = launcherStoreFacade.getRequestLevelStore();
-		}
-		else {
-			parentStore = ((AbstractExtensionContext<?>) parent).valuesStore;
-		}
-		return new NamespacedHierarchicalStore<>(parentStore, closeAction);
 	}
 
 	@Override

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/descriptor/ResourceAutoClosingTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/descriptor/ResourceAutoClosingTests.java
@@ -71,19 +71,28 @@ class ResourceAutoClosingTests {
 	void shouldLogWarningWhenResourceImplementsCloseableResourceButNotAutoCloseableAndConfigIsTrue(
 			@TrackLogRecords LogRecordListener listener) throws Exception {
 		ExecutionRecorder executionRecorder = new ExecutionRecorder();
-		CloseableResource resource = new CloseableResource();
-		String msg = "Type implements CloseableResource but not AutoCloseable: " + resource.getClass().getName();
+		CloseableResource resource1 = new CloseableResource();
+		CloseableResource resource2 = new CloseableResource();
+		CloseableResource resource3 = new CloseableResource() {
+		};
 		when(configuration.isClosingStoredAutoCloseablesEnabled()).thenReturn(true);
 
 		ExtensionContext extensionContext = new JupiterEngineExtensionContext(executionRecorder, testDescriptor,
 			configuration, extensionRegistry, launcherStoreFacade);
 		ExtensionContext.Store store = extensionContext.getStore(ExtensionContext.Namespace.GLOBAL);
-		store.put("resource", resource);
+		store.put("resource1", resource1);
+		store.put("resource2", resource2);
+		store.put("resource3", resource3);
 
 		((AutoCloseable) extensionContext).close();
 
-		assertThat(listener.stream(Level.WARNING)).map(LogRecord::getMessage).contains(msg);
-		assertThat(resource.closed).isTrue();
+		assertThat(listener.stream(Level.WARNING)).map(LogRecord::getMessage) //
+				.containsExactlyInAnyOrder(
+					"Type implements CloseableResource but not AutoCloseable: " + resource1.getClass().getName(),
+					"Type implements CloseableResource but not AutoCloseable: " + resource3.getClass().getName());
+		assertThat(resource1.closed).isTrue();
+		assertThat(resource2.closed).isTrue();
+		assertThat(resource3.closed).isTrue();
 	}
 
 	@Test


### PR DESCRIPTION
To avoid flooding console output with warnings.

Resolves #4776.

<!-- Please describe your changes here and list any open questions you might have. -->

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://docs.junit.org/snapshot/user-guide/) and [Release Notes](https://docs.junit.org/snapshot/user-guide/#release-notes)
