### PR TITLE
Use `DataFlowIssue` as suppression name alias for `NullAway`

### DIFF
--- a/documentation/src/test/java/example/session/HttpTests.java
+++ b/documentation/src/test/java/example/session/HttpTests.java
@@ -50,7 +50,7 @@ class HttpServerParameterResolver implements ParameterResolver {
 	}
 
 	//end::user_guide[]
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	//tag::user_guide[]
 	@Override
 	public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {

--- a/documentation/src/test/java/example/sharedresources/SharedResourceDemo.java
+++ b/documentation/src/test/java/example/sharedresources/SharedResourceDemo.java
@@ -24,7 +24,7 @@ import org.junit.platform.launcher.core.LauncherFactory;
 
 class SharedResourceDemo {
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	//tag::user_guide[]
 	@Test
 	void runBothCustomEnginesTest() {

--- a/documentation/src/test/java/example/timing/TimingExtension.java
+++ b/documentation/src/test/java/example/timing/TimingExtension.java
@@ -41,7 +41,7 @@ public class TimingExtension implements BeforeTestExecutionCallback, AfterTestEx
 	}
 
 	//end::user_guide[]
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	//tag::user_guide[]
 	@Override
 	public void afterTestExecution(ExtensionContext context) {

--- a/gradle/plugins/common/src/main/kotlin/junitbuild.java-nullability-conventions.gradle.kts
+++ b/gradle/plugins/common/src/main/kotlin/junitbuild.java-nullability-conventions.gradle.kts
@@ -64,6 +64,8 @@ tasks.withType<JavaCompile>().configureEach {
 			isJSpecifyMode = true
 			customContractAnnotations.add("org.junit.platform.commons.annotation.Contract")
 			checkContracts = true
+			// FIXME a new gradle-nullaway-plugin version is needed for a proper DSL
+			checkOptions.put("NullAway:SuppressionNameAliases", "DataFlowIssue")
 		}
 	}
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/MethodBasedCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/MethodBasedCondition.java
@@ -88,7 +88,7 @@ abstract class MethodBasedCondition<A extends Annotation> implements ExecutionCo
 		return invokeMethod(method, context, testInstance);
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	private static boolean invokeMethod(Method method, ExtensionContext context, @Nullable Object testInstance) {
 		if (method.getParameterCount() == 0) {
 			return (boolean) ReflectionSupport.invokeMethod(method, testInstance);

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/AssertAllAssertionsTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/AssertAllAssertionsTests.java
@@ -37,25 +37,25 @@ import org.opentest4j.MultipleFailuresError;
  */
 class AssertAllAssertionsTests {
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void assertAllWithNullExecutableArray() {
 		assertPrecondition("executables array must not be null or empty", () -> assertAll((Executable[]) null));
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void assertAllWithNullExecutableCollection() {
 		assertPrecondition("executables collection must not be null", () -> assertAll((Collection<Executable>) null));
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void assertAllWithNullExecutableStream() {
 		assertPrecondition("executables stream must not be null", () -> assertAll((Stream<Executable>) null));
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void assertAllWithNullInExecutableArray() {
 		assertPrecondition("individual executables must not be null", () -> assertAll((Executable) null));

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/AssertLinesMatchAssertionsTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/AssertLinesMatchAssertionsTests.java
@@ -95,7 +95,7 @@ class AssertLinesMatchAssertionsTests {
 	}
 
 	@Test
-	@SuppressWarnings({ "unchecked", "rawtypes", "DataFlowIssue", "NullAway" })
+	@SuppressWarnings({ "unchecked", "rawtypes", "DataFlowIssue" })
 	void assertLinesMatchWithNullFails() {
 		assertThrows(PreconditionViolationException.class, () -> assertLinesMatch(null, (List) null));
 		assertThrows(PreconditionViolationException.class, () -> assertLinesMatch(null, Collections.emptyList()));

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/DynamicTestTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/DynamicTestTests.java
@@ -43,7 +43,7 @@ class DynamicTestTests {
 
 	private final List<@Nullable String> assertedValues = new ArrayList<>();
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void streamFromStreamPreconditions() {
 		ThrowingConsumer<Object> testExecutor = input -> {
@@ -58,7 +58,7 @@ class DynamicTestTests {
 			() -> DynamicTest.stream(Stream.empty(), displayNameGenerator, null));
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void streamFromIteratorPreconditions() {
 		ThrowingConsumer<Object> testExecutor = input -> {
@@ -73,7 +73,7 @@ class DynamicTestTests {
 			() -> DynamicTest.stream(emptyIterator(), displayNameGenerator, null));
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void streamFromStreamWithNamesPreconditions() {
 		ThrowingConsumer<Object> testExecutor = input -> {
@@ -84,7 +84,7 @@ class DynamicTestTests {
 		assertThrows(PreconditionViolationException.class, () -> DynamicTest.stream(Stream.empty(), null));
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void streamFromIteratorWithNamesPreconditions() {
 		ThrowingConsumer<Object> testExecutor = input -> {
@@ -95,14 +95,14 @@ class DynamicTestTests {
 		assertThrows(PreconditionViolationException.class, () -> DynamicTest.stream(emptyIterator(), null));
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void streamFromStreamWithNamedExecutablesPreconditions() {
 		assertThrows(PreconditionViolationException.class,
 			() -> DynamicTest.stream((Stream<DummyNamedExecutableForTests>) null));
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void streamFromIteratorWithNamedExecutablesPreconditions() {
 		assertThrows(PreconditionViolationException.class,

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/FailAssertionsTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/FailAssertionsTests.java
@@ -74,7 +74,7 @@ class FailAssertionsTests {
 		}
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void failWithNullMessageSupplier() {
 		try {

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/extension/MediaTypeTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/extension/MediaTypeTests.java
@@ -45,7 +45,7 @@ class MediaTypeTests {
 		assertEquals("Invalid media type: 'invalid'", exception.getMessage());
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void parseWithNullMediaType() {
 		var exception = assertThrows(PreconditionViolationException.class, () -> MediaType.parse(null));

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/ReportingTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/ReportingTests.java
@@ -115,7 +115,7 @@ class ReportingTests extends AbstractJupiterTestEngineTests {
 				file -> Files.writeString(file, "succeedingTest"));
 		}
 
-		@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+		@SuppressWarnings("DataFlowIssue")
 		@Test
 		void invalidReportData(TestReporter reporter) {
 

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/config/DefaultJupiterConfigurationTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/config/DefaultJupiterConfigurationTests.java
@@ -44,7 +44,7 @@ class DefaultJupiterConfigurationTests {
 
 	private static final String KEY = DEFAULT_TEST_INSTANCE_LIFECYCLE_PROPERTY_NAME;
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void getDefaultTestInstanceLifecyclePreconditions() {
 		PreconditionViolationException exception = assertThrows(PreconditionViolationException.class,

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/descriptor/DisplayNameUtilsTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/descriptor/DisplayNameUtilsTests.java
@@ -218,7 +218,7 @@ class DisplayNameUtilsTests {
 
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	static class NullDisplayNameGenerator implements DisplayNameGenerator {
 
 		@Override

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/descriptor/LauncherStoreFacadeTest.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/descriptor/LauncherStoreFacadeTest.java
@@ -79,7 +79,7 @@ class LauncherStoreFacadeTest {
 		assertNotNull(adapter);
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void throwsExceptionWhenNamespaceIsNull() {
 		LauncherStoreFacade facade = new LauncherStoreFacade(requestLevelStore);

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/descriptor/TestInstanceLifecycleUtilsTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/descriptor/TestInstanceLifecycleUtilsTests.java
@@ -48,7 +48,7 @@ class TestInstanceLifecycleUtilsTests {
 
 	private static final String KEY = DEFAULT_TEST_INSTANCE_LIFECYCLE_PROPERTY_NAME;
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void getTestInstanceLifecyclePreconditions() {
 		PreconditionViolationException exception = assertThrows(PreconditionViolationException.class,

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/execution/ParameterResolutionUtilsTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/execution/ParameterResolutionUtilsTests.java
@@ -149,7 +149,7 @@ class ParameterResolutionUtilsTests {
 		assertThat(arguments).containsExactly("something");
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void passContextInformationToParameterResolverMethods() {
 		anyTestMethodWithAtLeastOneParameter();

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/CloseablePathTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/CloseablePathTests.java
@@ -167,7 +167,7 @@ class CloseablePathTests extends AbstractJupiterTestEngineTests {
 			delete(closeablePath.get());
 		}
 
-		@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+		@SuppressWarnings("DataFlowIssue")
 		@DisplayName("fails if the factory returns null")
 		@ParameterizedTest
 		@ElementTypeSource

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/OrderedMethodTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/OrderedMethodTests.java
@@ -744,7 +744,7 @@ class OrderedMethodTests {
 			context.getMethodDescriptors().set(1, createMethodDescriptorImpersonator(method2));
 		}
 
-		@SuppressWarnings({ "unchecked", "DataFlowIssue" })
+		@SuppressWarnings("unchecked")
 		static <T> T createMethodDescriptorImpersonator(MethodDescriptor method) {
 			MethodDescriptor stub = new MethodDescriptor() {
 				@Override

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/TempDirectoryTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/TempDirectoryTests.java
@@ -357,7 +357,7 @@ class TempDirectoryTests extends AbstractJupiterTestEngineTests {
 
 		private static class FactoryNotReturningDirectory implements TempDirFactory {
 
-			@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+			@SuppressWarnings("DataFlowIssue")
 			@Override
 			public Path createTempDirectory(AnnotatedElementContext elementContext, ExtensionContext extensionContext) {
 				return null;
@@ -1475,7 +1475,7 @@ class TempDirectoryTests extends AbstractJupiterTestEngineTests {
 			// never called
 		}
 
-		@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+		@SuppressWarnings("DataFlowIssue")
 		private static class Factory implements TempDirFactory {
 
 			@Override

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/TestInstanceFactoryTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/TestInstanceFactoryTests.java
@@ -775,7 +775,7 @@ class TestInstanceFactoryTests extends AbstractJupiterTestEngineTests {
 	 */
 	private static class NullTestInstanceFactory implements TestInstanceFactory {
 
-		@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+		@SuppressWarnings("DataFlowIssue")
 		@Override
 		public Object createTestInstance(TestInstanceFactoryContext factoryContext, ExtensionContext extensionContext) {
 			return null;

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/TestReporterParameterResolverTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/TestReporterParameterResolverTests.java
@@ -31,7 +31,7 @@ class TestReporterParameterResolverTests {
 
 	TestReporterParameterResolver resolver = new TestReporterParameterResolver();
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void supports() {
 		Parameter parameter1 = findParameterOfMethod("methodWithTestReporterParameter", TestReporter.class);

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/TimeoutExceptionFactoryTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/TimeoutExceptionFactoryTests.java
@@ -51,7 +51,7 @@ class TimeoutExceptionFactoryTests {
 				.hasSuppressedException(suppressedException);
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway", "ThrowableNotThrown" })
+	@SuppressWarnings({ "DataFlowIssue", "ThrowableNotThrown" })
 	@Nested
 	@DisplayName("throws exception when")
 	class ThrowException {

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/TimeoutInvocationFactoryTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/TimeoutInvocationFactoryTests.java
@@ -61,7 +61,7 @@ class TimeoutInvocationFactoryTests {
 		timeoutInvocationFactory = new TimeoutInvocationFactory(store);
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	@DisplayName("throws exception when null store is provided on create")
 	void shouldThrowExceptionWhenInstantiatingWithNullStore() {
@@ -69,7 +69,7 @@ class TimeoutInvocationFactoryTests {
 				.hasMessage("store must not be null");
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	@DisplayName("throws exception when null timeout thread mode is provided on create")
 	void shouldThrowExceptionWhenNullTimeoutThreadModeIsProvidedWhenCreate() {
@@ -77,7 +77,7 @@ class TimeoutInvocationFactoryTests {
 				.hasMessage("thread mode must not be null");
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	@DisplayName("throws exception when null timeout invocation parameters is provided on create")
 	void shouldThrowExceptionWhenNullTimeoutInvocationParametersIsProvidedWhenCreate() {

--- a/jupiter-tests/src/test/java/org/junit/jupiter/params/aggregator/DefaultArgumentsAccessorTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/params/aggregator/DefaultArgumentsAccessorTests.java
@@ -30,7 +30,7 @@ import org.junit.platform.commons.PreconditionViolationException;
  */
 class DefaultArgumentsAccessorTests {
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void argumentsMustNotBeNull() {
 		assertThrows(PreconditionViolationException.class, () -> defaultArgumentsAccessor(1, (Object[]) null));

--- a/jupiter-tests/src/test/java/org/junit/jupiter/params/converter/TypedArgumentConverterTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/params/converter/TypedArgumentConverterTests.java
@@ -48,7 +48,7 @@ class TypedArgumentConverterTests {
 		/**
 		 * @since 5.8
 		 */
-		@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+		@SuppressWarnings("DataFlowIssue")
 		@Test
 		void preconditions() {
 			assertThatExceptionOfType(PreconditionViolationException.class)//

--- a/jupiter-tests/src/test/java/org/junit/jupiter/params/provider/AnnotationBasedArgumentsProviderTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/params/provider/AnnotationBasedArgumentsProviderTests.java
@@ -38,7 +38,7 @@ class AnnotationBasedArgumentsProviderTests {
 		}
 	};
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	@DisplayName("should throw exception when null annotation is provided to accept method")
 	void shouldThrowExceptionWhenNullAnnotationIsProvidedToAccept() {

--- a/jupiter-tests/src/test/java/org/junit/jupiter/params/provider/MethodArgumentsProviderTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/params/provider/MethodArgumentsProviderTests.java
@@ -773,7 +773,7 @@ class MethodArgumentsProviderTests {
 		return provider.provideArguments(mock(), extensionContext).map(Arguments::get);
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	private DefaultExecutableInvoker getExecutableInvoker(ExtensionContext extensionContext) {
 		return new DefaultExecutableInvoker(extensionContext, extensionRegistry);
 	}

--- a/platform-tests/src/test/java/org/junit/platform/commons/function/TryTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/function/TryTests.java
@@ -72,7 +72,7 @@ public class TryTests {
 		assertThat(exception.get()).isSameAs(cause);
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void successfulTriesCanStoreNull() throws Exception {
 		var success = Try.success(null);
@@ -101,7 +101,7 @@ public class TryTests {
 		assertThat(failure).isEqualTo(Try.failure(cause));
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void methodPreconditionsAreChecked() {
 		assertThrows(JUnitException.class, () -> Try.call(null));

--- a/platform-tests/src/test/java/org/junit/platform/commons/support/AnnotationSupportTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/support/AnnotationSupportTests.java
@@ -35,7 +35,7 @@ import org.junit.platform.commons.util.ReflectionUtils;
  */
 class AnnotationSupportTests {
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void isAnnotatedPreconditions() {
 		var optional = Optional.of(Probe.class);
@@ -59,7 +59,7 @@ class AnnotationSupportTests {
 			AnnotationSupport.isAnnotated(element, Override.class));
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void findAnnotationOnElementPreconditions() {
 		var optional = Optional.of(Probe.class);
@@ -84,7 +84,7 @@ class AnnotationSupportTests {
 			AnnotationSupport.findAnnotation(element, Override.class));
 	}
 
-	@SuppressWarnings({ "deprecation", "DataFlowIssue", "NullAway" })
+	@SuppressWarnings({ "deprecation", "DataFlowIssue" })
 	@Test
 	void findAnnotationOnClassWithSearchModePreconditions() {
 		assertPreconditionViolationException("annotationType",
@@ -93,7 +93,7 @@ class AnnotationSupportTests {
 			() -> AnnotationSupport.findAnnotation(Probe.class, Override.class, (SearchOption) null));
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void findAnnotationOnClassWithEnclosingInstanceTypesPreconditions() {
 		assertPreconditionViolationException("enclosingInstanceTypes",
@@ -135,7 +135,7 @@ class AnnotationSupportTests {
 				.contains(Probe.class.getDeclaredAnnotation(Tag.class));
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void findPublicAnnotatedFieldsPreconditions() {
 		assertPreconditionViolationException("Class",
@@ -154,7 +154,7 @@ class AnnotationSupportTests {
 			AnnotationSupport.findPublicAnnotatedFields(Probe.class, Throwable.class, Override.class));
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void findAnnotatedMethodsPreconditions() {
 		assertPreconditionViolationException("Class",
@@ -199,7 +199,7 @@ class AnnotationSupportTests {
 		assertEquals(expected.toString(), actual.toString(), "expected equal exception toString representation");
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void findRepeatableAnnotationsPreconditions() {
 		assertPreconditionViolationException("annotationType",
@@ -225,7 +225,7 @@ class AnnotationSupportTests {
 				HierarchyTraversalMode.TOP_DOWN));
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void findAnnotatedFieldsPreconditions() {
 		assertPreconditionViolationException("Class",
@@ -277,7 +277,7 @@ class AnnotationSupportTests {
 				.containsExactlyInAnyOrder("s1", "s2");
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void findAnnotatedFieldValuesPreconditions() {
 		assertPreconditionViolationException("instance",

--- a/platform-tests/src/test/java/org/junit/platform/commons/support/ClassSupportTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/support/ClassSupportTests.java
@@ -24,7 +24,7 @@ import org.junit.platform.commons.util.ClassUtils;
  */
 class ClassSupportTests {
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void nullSafeToStringPreconditions() {
 		Function<? super Class<?>, ? extends String> mapper = null;

--- a/platform-tests/src/test/java/org/junit/platform/commons/support/ModifierSupportTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/support/ModifierSupportTests.java
@@ -34,7 +34,7 @@ import org.junit.platform.commons.util.ReflectionUtils;
  */
 class ModifierSupportTests {
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void isPublicPreconditions() {
 		assertPreconditionViolationException("Class", () -> ModifierSupport.isPublic((Class<?>) null));
@@ -52,7 +52,7 @@ class ModifierSupportTests {
 		assertEquals(ReflectionUtils.isPublic(method), ModifierSupport.isPublic(method));
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void isPrivatePreconditions() {
 		assertPreconditionViolationException("Class", () -> ModifierSupport.isPrivate((Class<?>) null));
@@ -70,7 +70,7 @@ class ModifierSupportTests {
 		assertEquals(ReflectionUtils.isPrivate(method), ModifierSupport.isPrivate(method));
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void isNotPrivatePreconditions() {
 		assertPreconditionViolationException("Class", () -> ModifierSupport.isNotPrivate((Class<?>) null));
@@ -88,7 +88,7 @@ class ModifierSupportTests {
 		assertEquals(ReflectionUtils.isNotPrivate(method), ModifierSupport.isNotPrivate(method));
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void isAbstractPreconditions() {
 		assertPreconditionViolationException("Class", () -> ModifierSupport.isAbstract((Class<?>) null));
@@ -106,7 +106,7 @@ class ModifierSupportTests {
 		assertEquals(ReflectionUtils.isAbstract(method), ModifierSupport.isAbstract(method));
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void isNotAbstractPreconditions() {
 		assertPreconditionViolationException("Class", () -> ModifierSupport.isNotAbstract((Class<?>) null));
@@ -124,7 +124,7 @@ class ModifierSupportTests {
 		assertEquals(ReflectionUtils.isNotAbstract(method), ModifierSupport.isNotAbstract(method));
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void isStaticPreconditions() {
 		assertPreconditionViolationException("Class", () -> ModifierSupport.isStatic((Class<?>) null));
@@ -142,7 +142,7 @@ class ModifierSupportTests {
 		assertEquals(ReflectionUtils.isStatic(method), ModifierSupport.isStatic(method));
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void isNotStaticPreconditions() {
 		assertPreconditionViolationException("Class", () -> ModifierSupport.isNotStatic((Class<?>) null));
@@ -160,7 +160,7 @@ class ModifierSupportTests {
 		assertEquals(ReflectionUtils.isNotStatic(method), ModifierSupport.isNotStatic(method));
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void isFinalPreconditions() {
 		assertPreconditionViolationException("Class", () -> ModifierSupport.isFinal((Class<?>) null));
@@ -178,7 +178,7 @@ class ModifierSupportTests {
 		assertEquals(ReflectionUtils.isFinal(method), ModifierSupport.isFinal(method));
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void isNotFinalPreconditions() {
 		assertPreconditionViolationException("Class", () -> ModifierSupport.isNotFinal((Class<?>) null));

--- a/platform-tests/src/test/java/org/junit/platform/commons/support/ReflectionSupportTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/support/ReflectionSupportTests.java
@@ -56,7 +56,7 @@ class ReflectionSupportTests {
 			ReflectionSupport.tryToLoadClass("java.nio.Bits"));
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void tryToLoadClassPreconditions() {
 		assertPreconditionViolationExceptionForString("Class name", () -> ReflectionSupport.tryToLoadClass(null));
@@ -81,7 +81,7 @@ class ReflectionSupportTests {
 	/**
 	 * @since 1.10
 	 */
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void tryToLoadClassWithExplicitClassLoaderPreconditions() {
 		var cl = getClass().getClassLoader();
@@ -110,7 +110,7 @@ class ReflectionSupportTests {
 	/**
 	 * @since 1.12
 	 */
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void tryToGetResourcesPreconditions() {
 		assertPreconditionViolationExceptionForString("Resource name", () -> ReflectionSupport.tryToGetResources(null));
@@ -133,7 +133,7 @@ class ReflectionSupportTests {
 			ReflectionSupport.tryToGetResources("default-package.resource", getDefaultClassLoader()).toOptional());
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void findAllClassesInClasspathRootPreconditions() {
 		var path = Path.of(".").toUri();
@@ -167,7 +167,7 @@ class ReflectionSupportTests {
 	/**
 	 * @since 1.11
 	 */
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void findAllResourcesInClasspathRootPreconditions() {
 		var path = Path.of(".").toUri();
@@ -199,7 +199,7 @@ class ReflectionSupportTests {
 	/**
 	 * @since 1.11
 	 */
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void streamAllResourcesInClasspathRootPreconditions() {
 		var path = Path.of(".").toUri();
@@ -216,7 +216,7 @@ class ReflectionSupportTests {
 			ReflectionSupport.findAllClassesInPackage("org.junit", allTypes, allNames));
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void findAllClassesInPackagePreconditions() {
 		assertPreconditionViolationExceptionForString("basePackageName",
@@ -241,7 +241,7 @@ class ReflectionSupportTests {
 	/**
 	 * @since 1.11
 	 */
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void findAllResourcesInPackagePreconditions() {
 		assertPreconditionViolationExceptionForString("basePackageName",
@@ -264,7 +264,7 @@ class ReflectionSupportTests {
 	/**
 	 * @since 1.11
 	 */
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void streamAllResourcesInPackagePreconditions() {
 		assertPreconditionViolationExceptionForString("basePackageName",
@@ -279,7 +279,7 @@ class ReflectionSupportTests {
 			ReflectionSupport.findAllClassesInModule("org.junit.platform.commons", allTypes, allNames));
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void findAllClassesInModulePreconditions() {
 		var exception = assertThrows(PreconditionViolationException.class,
@@ -303,7 +303,7 @@ class ReflectionSupportTests {
 	/**
 	 * @since 1.11
 	 */
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void findAllResourcesInModulePreconditions() {
 		var exception = assertThrows(PreconditionViolationException.class,
@@ -325,7 +325,7 @@ class ReflectionSupportTests {
 	/**
 	 * @since 1.11
 	 */
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void streamAllResourcesInModulePreconditions() {
 		var exception = assertThrows(PreconditionViolationException.class,
@@ -341,7 +341,7 @@ class ReflectionSupportTests {
 			ReflectionSupport.newInstance(String.class, "foo"));
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void newInstancePreconditions() {
 		assertPreconditionViolationException("Class", () -> ReflectionSupport.newInstance(null));
@@ -358,7 +358,7 @@ class ReflectionSupportTests {
 			ReflectionSupport.invokeMethod(method, null, "true"));
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void invokeMethodPreconditions() throws Exception {
 		assertPreconditionViolationException("Method", () -> ReflectionSupport.invokeMethod(null, null, "true"));
@@ -382,7 +382,7 @@ class ReflectionSupportTests {
 			ReflectionSupport.findFields(ReflectionSupportTests.class, allFields, HierarchyTraversalMode.TOP_DOWN));
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void findFieldsPreconditions() {
 		assertPreconditionViolationException("Class",
@@ -408,7 +408,7 @@ class ReflectionSupportTests {
 			ReflectionSupport.tryToReadFieldValue(instanceField, this));
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void tryToReadFieldValuePreconditions() throws Exception {
 		assertPreconditionViolationException("Field", () -> ReflectionSupport.tryToReadFieldValue(null, this));
@@ -430,7 +430,7 @@ class ReflectionSupportTests {
 			ReflectionSupport.findMethod(Boolean.class, "valueOf", String.class));
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void findMethodPreconditions() {
 		assertPreconditionViolationException("Class",
@@ -464,7 +464,7 @@ class ReflectionSupportTests {
 			ReflectionSupport.findMethods(ReflectionSupportTests.class, allMethods, HierarchyTraversalMode.TOP_DOWN));
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void findMethodsPreconditions() {
 		assertPreconditionViolationException("Class",
@@ -485,7 +485,7 @@ class ReflectionSupportTests {
 			ReflectionSupport.findNestedClasses(ClassWithNestedClasses.class, ReflectionUtils::isStatic));
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void findNestedClassesPreconditions() {
 		assertPreconditionViolationException("Class",

--- a/platform-tests/src/test/java/org/junit/platform/commons/support/scanning/DefaultClasspathScannerTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/support/scanning/DefaultClasspathScannerTests.java
@@ -441,14 +441,14 @@ class DefaultClasspathScannerTests {
 		}
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void scanForClassesInPackageForNullBasePackage() {
 		assertThrows(PreconditionViolationException.class,
 			() -> classpathScanner.scanForClassesInPackage(null, allClasses));
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void scanForResourcesInPackageForNullBasePackage() {
 		assertThrows(PreconditionViolationException.class,
@@ -467,7 +467,7 @@ class DefaultClasspathScannerTests {
 			() -> classpathScanner.scanForResourcesInPackage("    ", allResources));
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void scanForClassesInPackageForNullClassFilter() {
 		assertThrows(PreconditionViolationException.class,
@@ -551,7 +551,7 @@ class DefaultClasspathScannerTests {
 		assertTrue(classes.contains(DefaultClasspathScannerTests.class));
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void findAllClassesInClasspathRootForNullRoot() {
 		assertThrows(PreconditionViolationException.class,
@@ -564,7 +564,7 @@ class DefaultClasspathScannerTests {
 			() -> classpathScanner.scanForClassesInClasspathRoot(Path.of("does_not_exist").toUri(), allClasses));
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void findAllClassesInClasspathRootForNullClassFilter() {
 		assertThrows(PreconditionViolationException.class,

--- a/platform-tests/src/test/java/org/junit/platform/commons/util/AnnotationUtilsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/util/AnnotationUtilsTests.java
@@ -335,14 +335,14 @@ class AnnotationUtilsTests {
 			() -> "Extensions found for class " + clazz.getName());
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void findAnnotatedMethodsForNullClass() {
 		assertThrows(PreconditionViolationException.class,
 			() -> findAnnotatedMethods(null, Annotation1.class, TOP_DOWN));
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void findAnnotatedMethodsForNullAnnotationType() {
 		assertThrows(PreconditionViolationException.class,
@@ -423,21 +423,21 @@ class AnnotationUtilsTests {
 
 	// === findAnnotatedFields() ===============================================
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void findAnnotatedFieldsForNullClass() {
 		assertThrows(PreconditionViolationException.class,
 			() -> findAnnotatedFields(null, Annotation1.class, isStringField, TOP_DOWN));
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void findAnnotatedFieldsForNullAnnotationType() {
 		assertThrows(PreconditionViolationException.class,
 			() -> findAnnotatedFields(ClassWithAnnotatedFields.class, null, isStringField, TOP_DOWN));
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void findAnnotatedFieldsForNullPredicate() {
 		assertThrows(PreconditionViolationException.class,
@@ -534,21 +534,21 @@ class AnnotationUtilsTests {
 
 	// === findPublicAnnotatedFields() =========================================
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void findPublicAnnotatedFieldsForNullClass() {
 		assertThrows(PreconditionViolationException.class,
 			() -> findPublicAnnotatedFields(null, String.class, Annotation1.class));
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void findPublicAnnotatedFieldsForNullFieldType() {
 		assertThrows(PreconditionViolationException.class,
 			() -> findPublicAnnotatedFields(getClass(), null, Annotation1.class));
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void findPublicAnnotatedFieldsForNullAnnotationType() {
 		assertThrows(PreconditionViolationException.class,

--- a/platform-tests/src/test/java/org/junit/platform/commons/util/ClassLoaderUtilsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/util/ClassLoaderUtilsTests.java
@@ -29,7 +29,7 @@ import org.junit.platform.commons.test.TestClassLoader;
  */
 class ClassLoaderUtilsTests {
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void getClassLoaderPreconditions() {
 		assertThatExceptionOfType(PreconditionViolationException.class)//
@@ -101,7 +101,7 @@ class ClassLoaderUtilsTests {
 		}
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void getLocationFromNullFails() {
 		var exception = assertThrows(PreconditionViolationException.class, () -> ClassLoaderUtils.getLocation(null));

--- a/platform-tests/src/test/java/org/junit/platform/commons/util/CollectionUtilsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/util/CollectionUtilsTests.java
@@ -57,7 +57,7 @@ class CollectionUtilsTests {
 	@Nested
 	class OnlyElement {
 
-		@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+		@SuppressWarnings("DataFlowIssue")
 		@Test
 		void nullCollection() {
 			var exception = assertThrows(PreconditionViolationException.class,
@@ -90,7 +90,7 @@ class CollectionUtilsTests {
 	@Nested
 	class FirstElement {
 
-		@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+		@SuppressWarnings("DataFlowIssue")
 		@Test
 		void nullCollection() {
 			var exception = assertThrows(PreconditionViolationException.class,
@@ -183,7 +183,7 @@ class CollectionUtilsTests {
 			assertThat(CollectionUtils.isConvertibleToStream(null)).isFalse();
 		}
 
-		@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+		@SuppressWarnings("DataFlowIssue")
 		@Test
 		void toStreamWithNull() {
 			Exception exception = assertThrows(PreconditionViolationException.class,

--- a/platform-tests/src/test/java/org/junit/platform/commons/util/ExceptionUtilsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/util/ExceptionUtilsTests.java
@@ -34,7 +34,7 @@ import org.junit.platform.commons.PreconditionViolationException;
 @SuppressWarnings("ThrowableNotThrown")
 class ExceptionUtilsTests {
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void throwAsUncheckedExceptionWithNullException() {
 		assertThrows(PreconditionViolationException.class, () -> throwAsUncheckedException(null));
@@ -50,7 +50,7 @@ class ExceptionUtilsTests {
 		assertThrows(RuntimeException.class, () -> throwAsUncheckedException(new NumberFormatException()));
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void readStackTraceForNullThrowable() {
 		assertThrows(PreconditionViolationException.class, () -> readStackTrace(null));

--- a/platform-tests/src/test/java/org/junit/platform/commons/util/FunctionUtilsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/util/FunctionUtilsTests.java
@@ -26,14 +26,14 @@ import org.junit.platform.commons.PreconditionViolationException;
  */
 class FunctionUtilsTests {
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void whereWithNullFunction() {
 		var exception = assertThrows(PreconditionViolationException.class, () -> FunctionUtils.where(null, o -> true));
 		assertEquals("function must not be null", exception.getMessage());
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void whereWithNullPredicate() {
 		var exception = assertThrows(PreconditionViolationException.class, () -> FunctionUtils.where(o -> o, null));

--- a/platform-tests/src/test/java/org/junit/platform/commons/util/PackageUtilsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/util/PackageUtilsTests.java
@@ -33,7 +33,7 @@ import org.opentest4j.ValueWrapper;
  */
 class PackageUtilsTests {
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void getAttributeWithNullType() {
 		var exception = assertThrows(PreconditionViolationException.class,
@@ -41,7 +41,7 @@ class PackageUtilsTests {
 		assertEquals("type must not be null", exception.getMessage());
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void getAttributeWithNullFunction() {
 		var exception = assertThrows(PreconditionViolationException.class,
@@ -49,7 +49,7 @@ class PackageUtilsTests {
 		assertEquals("function must not be null", exception.getMessage());
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void getAttributeWithFunctionReturningNullIsEmpty() {
 		assertFalse(PackageUtils.getAttribute(ValueWrapper.class, p -> null).isPresent());
@@ -78,7 +78,7 @@ class PackageUtilsTests {
 		return () -> assertTrue(PackageUtils.getAttribute(ValueWrapper.class, function).isPresent());
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void getAttributeWithNullTypeAndName() {
 		var exception = assertThrows(PreconditionViolationException.class,
@@ -86,7 +86,7 @@ class PackageUtilsTests {
 		assertEquals("type must not be null", exception.getMessage());
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void getAttributeWithNullName() {
 		var exception = assertThrows(PreconditionViolationException.class,

--- a/platform-tests/src/test/java/org/junit/platform/commons/util/ReflectionUtilsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/util/ReflectionUtilsTests.java
@@ -117,7 +117,7 @@ class ReflectionUtilsTests {
 			assertFalse(ReflectionUtils.returnsPrimitiveVoid(clazz.getDeclaredMethod("methodReturningPrimitive")));
 		}
 
-		@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+		@SuppressWarnings("DataFlowIssue")
 		@Test
 		void getAllAssignmentCompatibleClassesWithNullClass() {
 			assertThrows(PreconditionViolationException.class,
@@ -132,7 +132,7 @@ class ReflectionUtilsTests {
 			assertTrue(superclasses.stream().allMatch(clazz -> clazz.isAssignableFrom(B.class)));
 		}
 
-		@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+		@SuppressWarnings("DataFlowIssue")
 		@Test
 		void newInstance() {
 			// @formatter:off
@@ -252,7 +252,7 @@ class ReflectionUtilsTests {
 			}
 		}
 
-		@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+		@SuppressWarnings("DataFlowIssue")
 		@Test
 		void getDeclaredConstructorPreconditions() {
 			// @formatter:off
@@ -551,7 +551,7 @@ class ReflectionUtilsTests {
 	@Nested
 	class IsClassAssignableToClassTests {
 
-		@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+		@SuppressWarnings("DataFlowIssue")
 		@Test
 		void isAssignableToForNullSourceType() {
 			assertThatExceptionOfType(PreconditionViolationException.class)//
@@ -566,7 +566,7 @@ class ReflectionUtilsTests {
 					.withMessage("source type must not be a primitive type");
 		}
 
-		@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+		@SuppressWarnings("DataFlowIssue")
 		@Test
 		void isAssignableToForNullTargetType() {
 			assertThatExceptionOfType(PreconditionViolationException.class)//
@@ -623,7 +623,7 @@ class ReflectionUtilsTests {
 	@Nested
 	class IsObjectAssignableToClassTests {
 
-		@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+		@SuppressWarnings("DataFlowIssue")
 		@Test
 		void isAssignableToForNullClass() {
 			assertThrows(PreconditionViolationException.class,
@@ -689,7 +689,7 @@ class ReflectionUtilsTests {
 	@Nested
 	class MethodInvocationTests {
 
-		@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+		@SuppressWarnings("DataFlowIssue")
 		@Test
 		void invokeMethodPreconditions() {
 			// @formatter:off
@@ -756,7 +756,7 @@ class ReflectionUtilsTests {
 	@Nested
 	class ResourceLoadingTests {
 
-		@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+		@SuppressWarnings("DataFlowIssue")
 		@Test
 		void tryToGetResourcePreconditions() {
 			assertThrows(PreconditionViolationException.class, () -> ReflectionUtils.tryToGetResources(""));
@@ -798,7 +798,7 @@ class ReflectionUtilsTests {
 	@Nested
 	class ClassLoadingTests {
 
-		@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+		@SuppressWarnings("DataFlowIssue")
 		@Test
 		void tryToLoadClassPreconditions() {
 			assertThrows(PreconditionViolationException.class, () -> ReflectionUtils.tryToLoadClass(null));
@@ -965,7 +965,7 @@ class ReflectionUtilsTests {
 	@Nested
 	class FullyQualifiedMethodNameTests {
 
-		@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+		@SuppressWarnings("DataFlowIssue")
 		@Test
 		void getFullyQualifiedMethodNamePreconditions() {
 			// @formatter:off
@@ -1001,7 +1001,7 @@ class ReflectionUtilsTests {
 			// @formatter:on
 		}
 
-		@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+		@SuppressWarnings("DataFlowIssue")
 		@Test
 		void parseFullyQualifiedMethodNamePreconditions() {
 			// @formatter:off
@@ -1041,7 +1041,7 @@ class ReflectionUtilsTests {
 	@Nested
 	class NestedClassTests {
 
-		@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+		@SuppressWarnings("DataFlowIssue")
 		@Test
 		void findNestedClassesPreconditions() {
 			// @formatter:off
@@ -1051,7 +1051,7 @@ class ReflectionUtilsTests {
 			// @formatter:on
 		}
 
-		@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+		@SuppressWarnings("DataFlowIssue")
 		@Test
 		void isNestedClassPresentPreconditions() {
 			// @formatter:off
@@ -1232,7 +1232,7 @@ class ReflectionUtilsTests {
 	@Nested
 	class MethodUtilitiesTests {
 
-		@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+		@SuppressWarnings("DataFlowIssue")
 		@Test
 		void tryToGetMethodPreconditions() {
 			assertThrows(PreconditionViolationException.class, () -> ReflectionUtils.tryToGetMethod(null, null));
@@ -1257,7 +1257,7 @@ class ReflectionUtilsTests {
 			assertThat(ReflectionUtils.tryToGetMethod(Object.class, "clone", int.class).toOptional()).isEmpty();
 		}
 
-		@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+		@SuppressWarnings("DataFlowIssue")
 		@Test
 		void isMethodPresentPreconditions() {
 			assertThrows(PreconditionViolationException.class, () -> ReflectionUtils.isMethodPresent(null, m -> true));
@@ -1279,7 +1279,7 @@ class ReflectionUtilsTests {
 	@Nested
 	class FindMethodTests {
 
-		@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+		@SuppressWarnings("DataFlowIssue")
 		@Test
 		void findMethodByParameterTypesPreconditions() {
 			// @formatter:off
@@ -1468,7 +1468,7 @@ class ReflectionUtilsTests {
 	@Nested
 	class FindMethodsTests {
 
-		@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+		@SuppressWarnings("DataFlowIssue")
 		@Test
 		void findMethodsPreconditions() {
 			// @formatter:off
@@ -1890,7 +1890,7 @@ class ReflectionUtilsTests {
 				() -> tryToReadFieldValue(MyClass.class, "doesNotExist", new MySubClass(42)).get());
 		}
 
-		@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+		@SuppressWarnings("DataFlowIssue")
 		@Test
 		void tryToReadFieldValueOfExistingStaticField() throws Exception {
 			assertThat(tryToReadFieldValue(MyClass.class, "staticField", null).get()).isEqualTo(42);
@@ -1942,7 +1942,7 @@ class ReflectionUtilsTests {
 			assertThat(fields).containsExactly(nonStaticField);
 		}
 
-		@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+		@SuppressWarnings("DataFlowIssue")
 		@Test
 		void readFieldValuesPreconditions() {
 			List<Field> fields = new ArrayList<>();

--- a/platform-tests/src/test/java/org/junit/platform/commons/util/StringUtilsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/util/StringUtilsTests.java
@@ -50,7 +50,7 @@ class StringUtilsTests {
 		// @formatter:on
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void whitespace() {
 		// @formatter:off
@@ -74,7 +74,7 @@ class StringUtilsTests {
 		// @formatter:on
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void controlCharacters() {
 		// @formatter:off
@@ -98,7 +98,7 @@ class StringUtilsTests {
 		// @formatter:on
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void replaceControlCharacters() {
 		assertNull(replaceIsoControlCharacters(null, ""));
@@ -112,7 +112,7 @@ class StringUtilsTests {
 		assertThrows(PreconditionViolationException.class, () -> replaceIsoControlCharacters("", null));
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void replaceWhitespaces() {
 		assertNull(replaceWhitespaceCharacters(null, ""));

--- a/platform-tests/src/test/java/org/junit/platform/commons/util/ToStringBuilderTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/util/ToStringBuilderTests.java
@@ -27,19 +27,19 @@ import org.junit.platform.commons.PreconditionViolationException;
  */
 class ToStringBuilderTests {
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void withNullObject() {
 		assertThrows(PreconditionViolationException.class, () -> new ToStringBuilder((Object) null));
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void withNullClass() {
 		assertThrows(PreconditionViolationException.class, () -> new ToStringBuilder((Class<?>) null));
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void appendWithIllegalName() {
 		var builder = new ToStringBuilder("");

--- a/platform-tests/src/test/java/org/junit/platform/engine/CompositeTestDescriptorVisitorTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/CompositeTestDescriptorVisitorTests.java
@@ -22,7 +22,7 @@ import org.mockito.InOrder;
 
 class CompositeTestDescriptorVisitorTests {
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void checksPreconditions() {
 		assertThrows(PreconditionViolationException.class, Visitor::composite);

--- a/platform-tests/src/test/java/org/junit/platform/engine/TestTagTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/TestTagTests.java
@@ -28,7 +28,7 @@ import org.junit.platform.commons.PreconditionViolationException;
  */
 class TestTagTests {
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void validSyntax() {
 		// @formatter:off
@@ -66,7 +66,7 @@ class TestTagTests {
 		assertEquals("foo-tag", TestTag.create("\t  foo-tag  \n").getName());
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void factoryPreconditions() {
 		assertSyntaxViolation(null);

--- a/platform-tests/src/test/java/org/junit/platform/engine/UniqueIdTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/UniqueIdTests.java
@@ -123,7 +123,7 @@ class UniqueIdTests {
 			assertSegment(uniqueId.getSegments().get(2), "t2", "v2");
 		}
 
-		@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+		@SuppressWarnings("DataFlowIssue")
 		@Test
 		void appendingNullIsNotAllowed() {
 			var uniqueId = UniqueId.forEngine(ENGINE_ID);
@@ -230,7 +230,7 @@ class UniqueIdTests {
 	@Nested
 	class Prefixing {
 
-		@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+		@SuppressWarnings("DataFlowIssue")
 		@Test
 		void nullIsNotAPrefix() {
 			var id = UniqueId.forEngine(ENGINE_ID);

--- a/platform-tests/src/test/java/org/junit/platform/engine/discovery/ClassNameFilterTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/discovery/ClassNameFilterTests.java
@@ -23,7 +23,7 @@ import org.junit.platform.commons.PreconditionViolationException;
  */
 class ClassNameFilterTests {
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void includeClassNamePatternsChecksPreconditions() {
 		assertThatThrownBy(() -> ClassNameFilter.includeClassNamePatterns((String[]) null)) //
@@ -86,7 +86,7 @@ class ClassNameFilterTests {
 					+ secondRegex + "'");
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void excludeClassNamePatternsChecksPreconditions() {
 		assertThatThrownBy(() -> ClassNameFilter.excludeClassNamePatterns((String[]) null)) //

--- a/platform-tests/src/test/java/org/junit/platform/engine/discovery/DiscoverySelectorsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/discovery/DiscoverySelectorsTests.java
@@ -69,7 +69,7 @@ class DiscoverySelectorsTests {
 	@Nested
 	class SelectUriTests {
 
-		@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+		@SuppressWarnings("DataFlowIssue")
 		@Test
 		void selectUriByName() {
 			assertViolatesPrecondition(() -> selectUri((String) null));
@@ -82,7 +82,7 @@ class DiscoverySelectorsTests {
 			assertEquals(uri, selector.getUri().toString());
 		}
 
-		@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+		@SuppressWarnings("DataFlowIssue")
 		@Test
 		void selectUriByURI() {
 			assertViolatesPrecondition(() -> selectUri((URI) null));
@@ -108,7 +108,7 @@ class DiscoverySelectorsTests {
 					.isEqualTo(URI.create("https://junit.org"));
 		}
 
-		@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+		@SuppressWarnings("DataFlowIssue")
 		@Test
 		void selectFileByName() {
 			assertViolatesPrecondition(() -> selectFile((String) null));
@@ -122,7 +122,7 @@ class DiscoverySelectorsTests {
 			assertEquals(Path.of(path), selector.getPath());
 		}
 
-		@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+		@SuppressWarnings("DataFlowIssue")
 		@Test
 		void selectFileByNameAndPosition() {
 			var filePosition = FilePosition.from(12, 34);
@@ -138,7 +138,7 @@ class DiscoverySelectorsTests {
 			assertEquals(filePosition, selector.getPosition().orElseThrow());
 		}
 
-		@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+		@SuppressWarnings("DataFlowIssue")
 		@Test
 		void selectFileByFileReference() throws Exception {
 			assertViolatesPrecondition(() -> selectFile((File) null));
@@ -155,7 +155,7 @@ class DiscoverySelectorsTests {
 			assertEquals(Path.of(path), selector.getPath());
 		}
 
-		@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+		@SuppressWarnings("DataFlowIssue")
 		@Test
 		void selectFileByFileReferenceAndPosition() throws Exception {
 			var filePosition = FilePosition.from(12, 34);
@@ -232,7 +232,7 @@ class DiscoverySelectorsTests {
 						Optional.of(filePosition));
 		}
 
-		@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+		@SuppressWarnings("DataFlowIssue")
 		@Test
 		void selectDirectoryByName() {
 			assertViolatesPrecondition(() -> selectDirectory((String) null));
@@ -246,7 +246,7 @@ class DiscoverySelectorsTests {
 			assertEquals(Path.of(path), selector.getPath());
 		}
 
-		@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+		@SuppressWarnings("DataFlowIssue")
 		@Test
 		void selectDirectoryByFileReference() throws Exception {
 			assertViolatesPrecondition(() -> selectDirectory((File) null));
@@ -294,7 +294,7 @@ class DiscoverySelectorsTests {
 					.containsExactly(path, new File(path), Path.of(path));
 		}
 
-		@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+		@SuppressWarnings("DataFlowIssue")
 		@Test
 		void selectClasspathResourcesPreconditions() {
 			assertViolatesPrecondition(() -> selectClasspathResource((String) null));
@@ -341,7 +341,7 @@ class DiscoverySelectorsTests {
 			assertViolatesPrecondition(selector::getClasspathResources);
 		}
 
-		@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+		@SuppressWarnings("DataFlowIssue")
 		@Test
 		void selectClasspathResourcesWithFilePosition() {
 			var filePosition = FilePosition.from(12, 34);
@@ -432,7 +432,7 @@ class DiscoverySelectorsTests {
 					.isEqualTo("java.base");
 		}
 
-		@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+		@SuppressWarnings("DataFlowIssue")
 		@Test
 		void selectModuleByNamePreconditions() {
 			assertViolatesPrecondition(() -> selectModule(null));
@@ -447,7 +447,7 @@ class DiscoverySelectorsTests {
 			assertThat(names).containsExactlyInAnyOrder("b", "a");
 		}
 
-		@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+		@SuppressWarnings("DataFlowIssue")
 		@Test
 		void selectModulesByNamesPreconditions() {
 			assertViolatesPrecondition(() -> selectModules(null));
@@ -547,7 +547,7 @@ class DiscoverySelectorsTests {
 	@Nested
 	class SelectMethodTests {
 
-		@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+		@SuppressWarnings("DataFlowIssue")
 		@Test
 		@DisplayName("Preconditions: selectMethod(className, methodName)")
 		void selectMethodByClassNameAndMethodNamePreconditions() {
@@ -559,7 +559,7 @@ class DiscoverySelectorsTests {
 			assertViolatesPrecondition(() -> selectMethod("   ", "method"));
 		}
 
-		@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+		@SuppressWarnings("DataFlowIssue")
 		@Test
 		@DisplayName("Preconditions: selectMethod(className, methodName, parameterTypeNames)")
 		void selectMethodByClassNameMethodNameAndParameterTypeNamesPreconditions() {
@@ -572,7 +572,7 @@ class DiscoverySelectorsTests {
 			assertViolatesPrecondition(() -> selectMethod("TestClass", "method", (String) null));
 		}
 
-		@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+		@SuppressWarnings("DataFlowIssue")
 		@Test
 		@DisplayName("Preconditions: selectMethod(className, methodName, parameterTypes)")
 		void selectMethodByClassNameMethodNameAndParameterTypesPreconditions() {
@@ -586,7 +586,7 @@ class DiscoverySelectorsTests {
 			assertViolatesPrecondition(() -> selectMethod("TestClass", "method", new Class<?>[] { int.class, null }));
 		}
 
-		@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+		@SuppressWarnings("DataFlowIssue")
 		@Test
 		@DisplayName("Preconditions: selectMethod(class, methodName)")
 		void selectMethodByClassAndMethodNamePreconditions() {
@@ -596,7 +596,7 @@ class DiscoverySelectorsTests {
 			assertViolatesPrecondition(() -> selectMethod((Class<?>) null, "method"));
 		}
 
-		@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+		@SuppressWarnings("DataFlowIssue")
 		@Test
 		@DisplayName("Preconditions: selectMethod(class, methodName, parameterTypeNames)")
 		void selectMethodByClassMethodNameAndParameterTypeNamesPreconditions() {
@@ -607,7 +607,7 @@ class DiscoverySelectorsTests {
 			assertViolatesPrecondition(() -> selectMethod(testClass(), "method", (String) null));
 		}
 
-		@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+		@SuppressWarnings("DataFlowIssue")
 		@Test
 		@DisplayName("Preconditions: selectMethod(class, method)")
 		void selectMethodByClassAndMethodPreconditions() {
@@ -1151,7 +1151,7 @@ class DiscoverySelectorsTests {
 			assertThat(parseIdentifier(selector)).isEqualTo(selector);
 		}
 
-		@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+		@SuppressWarnings("DataFlowIssue")
 		@Test
 		void selectNestedClassPreconditions() {
 			assertViolatesPrecondition(() -> selectNestedClass(null, "ClassName"));
@@ -1319,7 +1319,7 @@ class DiscoverySelectorsTests {
 			assertThat(parseIdentifier(selector)).isEqualTo(selector);
 		}
 
-		@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+		@SuppressWarnings("DataFlowIssue")
 		@Test
 		@DisplayName("Preconditions: selectNestedMethod(enclosingClassNames, nestedClassName, methodName)")
 		void selectNestedMethodByEnclosingClassNamesAndMethodNamePreconditions() {
@@ -1331,7 +1331,7 @@ class DiscoverySelectorsTests {
 			assertViolatesPrecondition(() -> selectNestedMethod(List.of("ClassName"), "ClassName", " "));
 		}
 
-		@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+		@SuppressWarnings("DataFlowIssue")
 		@Test
 		@DisplayName("Preconditions: selectNestedMethod(enclosingClassNames, nestedClassName, methodName, parameterTypeNames)")
 		void selectNestedMethodByEnclosingClassNamesMethodNameAndParameterTypeNamesPreconditions() {
@@ -1348,7 +1348,7 @@ class DiscoverySelectorsTests {
 		/**
 		 * @since 1.10
 		 */
-		@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+		@SuppressWarnings("DataFlowIssue")
 		@Test
 		@DisplayName("Preconditions: selectNestedMethod(enclosingClassNames, nestedClassName, methodName, parameterTypes)")
 		void selectNestedMethodByEnclosingClassNamesMethodNameAndParameterTypesPreconditions() {
@@ -1367,7 +1367,7 @@ class DiscoverySelectorsTests {
 		/**
 		 * @since 1.10
 		 */
-		@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+		@SuppressWarnings("DataFlowIssue")
 		@Test
 		@DisplayName("Preconditions: selectNestedMethod(enclosingClasses, nestedClass, methodName, parameterTypes)")
 		void selectNestedMethodByEnclosingClassesClassMethodNameAndParameterTypesPreconditions() {

--- a/platform-tests/src/test/java/org/junit/platform/engine/discovery/PackageNameFilterTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/discovery/PackageNameFilterTests.java
@@ -23,7 +23,7 @@ import org.junit.platform.commons.PreconditionViolationException;
  */
 class PackageNameFilterTests {
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void includePackageChecksPreconditions() {
 		assertThatThrownBy(() -> PackageNameFilter.includePackageNames((String[]) null)) //
@@ -75,7 +75,7 @@ class PackageNameFilterTests {
 					+ includedPackage2 + "'");
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void excludePackageChecksPreconditions() {
 		assertThatThrownBy(() -> PackageNameFilter.excludePackageNames((String[]) null)) //

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/config/PrefixedConfigurationParametersTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/config/PrefixedConfigurationParametersTests.java
@@ -37,7 +37,7 @@ class PrefixedConfigurationParametersTests {
 	@Mock
 	private ConfigurationParameters delegate;
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void preconditions() {
 		assertThrows(PreconditionViolationException.class, () -> new PrefixedConfigurationParameters(null, "example."));

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/ClassSourceTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/ClassSourceTests.java
@@ -39,7 +39,7 @@ class ClassSourceTests extends AbstractTestSourceTests {
 		);
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void preconditions() {
 		assertThrows(PreconditionViolationException.class, () -> ClassSource.from((String) null));

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/ClasspathResourceSourceTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/ClasspathResourceSourceTests.java
@@ -38,7 +38,7 @@ class ClasspathResourceSourceTests extends AbstractTestSourceTests {
 		return Stream.of(ClasspathResourceSource.from(FOO_RESOURCE));
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void preconditions() {
 		assertThrows(PreconditionViolationException.class, () -> ClasspathResourceSource.from((String) null));

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/CompositeTestSourceTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/CompositeTestSourceTests.java
@@ -37,7 +37,7 @@ class CompositeTestSourceTests extends AbstractTestSourceTests {
 		return Stream.of(CompositeTestSource.from(sources));
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void createCompositeTestSourceFromNullList() {
 		assertThrows(PreconditionViolationException.class, () -> CompositeTestSource.from(null));

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/DefaultUriSourceTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/DefaultUriSourceTests.java
@@ -33,7 +33,7 @@ class DefaultUriSourceTests extends AbstractTestSourceTests {
 		return Stream.of(new DefaultUriSource(URI.create("sample://instance")));
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void nullSourceUriYieldsException() {
 		assertThrows(PreconditionViolationException.class, () -> new DefaultUriSource(null));

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/FileSystemSourceTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/FileSystemSourceTests.java
@@ -34,7 +34,7 @@ class FileSystemSourceTests extends AbstractTestSourceTests {
 			FileSource.from(new File("file.and.position"), FilePosition.from(42, 23)));
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void nullSourceFileOrDirectoryYieldsException() {
 		assertThrows(PreconditionViolationException.class, () -> FileSource.from(null));

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/MethodSourceTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/MethodSourceTests.java
@@ -57,7 +57,7 @@ class MethodSourceTests extends AbstractTestSourceTests {
 		assertEqualsAndHashCode(MethodSource.from(method1), MethodSource.from(method1), MethodSource.from(method2));
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void instantiatingWithNullNamesShouldThrowPreconditionViolationException() {
 		assertThrows(PreconditionViolationException.class, () -> MethodSource.from("foo", null));
@@ -76,13 +76,13 @@ class MethodSourceTests extends AbstractTestSourceTests {
 		assertThrows(PreconditionViolationException.class, () -> MethodSource.from("  ", "foo"));
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void instantiationWithNullMethodShouldThrowPreconditionViolationException() {
 		assertThrows(PreconditionViolationException.class, () -> MethodSource.from(null));
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void instantiationWithNullClassOrMethodShouldThrowPreconditionViolationException() {
 		assertThrows(PreconditionViolationException.class,

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/PackageSourceTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/PackageSourceTests.java
@@ -34,7 +34,7 @@ class PackageSourceTests extends AbstractTestSourceTests {
 		return Stream.of(PackageSource.from("package.source"));
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void packageSourceFromNullPackageName() {
 		assertThrows(PreconditionViolationException.class, () -> PackageSource.from((String) null));
@@ -45,7 +45,7 @@ class PackageSourceTests extends AbstractTestSourceTests {
 		assertThrows(PreconditionViolationException.class, () -> PackageSource.from("  "));
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void packageSourceFromNullPackageReference() {
 		assertThrows(PreconditionViolationException.class, () -> PackageSource.from((Package) null));

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/TestDescriptorOrderChildrenTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/TestDescriptorOrderChildrenTests.java
@@ -116,7 +116,7 @@ public interface TestDescriptorOrderChildrenTests {
 		assertThat(exception).hasMessage("orderer may not add or remove test descriptors");
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	default void orderChildrenOrdererReturnsNull() {
 		var testDescriptor = createTestDescriptorWithChildren();

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ForkJoinPoolHierarchicalTestExecutorServiceTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ForkJoinPoolHierarchicalTestExecutorServiceTests.java
@@ -168,7 +168,7 @@ class ForkJoinPoolHierarchicalTestExecutorServiceTests {
 		);
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@ParameterizedTest
 	@MethodSource("compatibleLockCombinations")
 	void canWorkStealTaskWithCompatibleLocks(Set<ExclusiveResource> initialResources,

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/store/NamespacedHierarchicalStoreTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/store/NamespacedHierarchicalStoreTests.java
@@ -207,7 +207,7 @@ public class NamespacedHierarchicalStoreTests {
 			assertEquals(value, requiredTypeValue);
 		}
 
-		@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+		@SuppressWarnings("DataFlowIssue")
 		@Test
 		void getWithTypeSafetyAndPrimitiveValueType() {
 			String key = "enigma";
@@ -288,7 +288,7 @@ public class NamespacedHierarchicalStoreTests {
 			assertEquals(value, computedValue);
 		}
 
-		@SuppressWarnings({ "DataFlowIssue", "NullAway", "deprecation" })
+		@SuppressWarnings({ "DataFlowIssue", "deprecation" })
 		@Test
 		void getOrComputeIfAbsentWithTypeSafetyAndPrimitiveValueType() {
 			String key = "enigma";
@@ -357,7 +357,7 @@ public class NamespacedHierarchicalStoreTests {
 			assertNull(store.get(namespace, key));
 		}
 
-		@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+		@SuppressWarnings("DataFlowIssue")
 		@Test
 		void removeWithTypeSafetyAndPrimitiveValueType() {
 			String key = "enigma";

--- a/platform-tests/src/test/java/org/junit/platform/launcher/MethodFilterTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/MethodFilterTests.java
@@ -39,7 +39,7 @@ class MethodFilterTests {
 	private static final TestDescriptor CLASS2_TEST1 = methodTestDescriptor("class2", Class2.class, "test1");
 	private static final TestDescriptor CLASS2_TEST2 = methodTestDescriptor("class2", Class2.class, "test2");
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void includeMethodNamePatternsChecksPreconditions() {
 		assertThatThrownBy(() -> includeMethodNamePatterns((String[]) null)) //
@@ -87,7 +87,7 @@ class MethodFilterTests {
 				firstRegex, secondRegex));
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void excludeMethodNamePatternsChecksPreconditions() {
 		assertThatThrownBy(() -> excludeMethodNamePatterns((String[]) null)) //

--- a/platform-tests/src/test/java/org/junit/platform/launcher/TagFilterTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/TagFilterTests.java
@@ -61,7 +61,7 @@ class TagFilterTests {
 		// @formatter:on
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	private void assertSyntaxViolationForIncludes(@Nullable String tag) {
 		var exception = assertThrows(PreconditionViolationException.class, () -> includeTags(tag));
 		assertThat(exception).hasMessageStartingWith("Unable to parse tag expression");
@@ -79,7 +79,7 @@ class TagFilterTests {
 		// @formatter:on
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	private void assertSyntaxViolationForExcludes(@Nullable String tag) {
 		var exception = assertThrows(PreconditionViolationException.class, () -> excludeTags(tag));
 		assertThat(exception).hasMessageStartingWith("Unable to parse tag expression");

--- a/platform-tests/src/test/java/org/junit/platform/launcher/core/DefaultLauncherTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/core/DefaultLauncherTests.java
@@ -134,7 +134,7 @@ class DefaultLauncherTests {
 	void discoverTestPlanForEngineThatReturnsNullForItsRootDescriptor() {
 		TestEngine engine = new TestEngineStub("some-engine-id") {
 
-			@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+			@SuppressWarnings("DataFlowIssue")
 			@Override
 			public TestDescriptor discover(EngineDiscoveryRequest discoveryRequest, UniqueId uniqueId) {
 				return null;
@@ -155,7 +155,7 @@ class DefaultLauncherTests {
 	void discoverErrorTestDescriptorForEngineThatThrowsInDiscoveryPhase(Class<? extends Throwable> throwableClass) {
 		TestEngine engine = new TestEngineStub("my-engine-id") {
 
-			@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+			@SuppressWarnings("DataFlowIssue")
 			@Override
 			public TestDescriptor discover(EngineDiscoveryRequest discoveryRequest, UniqueId uniqueId) {
 				try {

--- a/platform-tests/src/test/java/org/junit/platform/launcher/core/LauncherConfigTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/core/LauncherConfigTests.java
@@ -30,7 +30,7 @@ import org.junit.platform.launcher.TestExecutionListener;
  */
 class LauncherConfigTests {
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void preconditions() {
 		assertThrows(PreconditionViolationException.class,

--- a/platform-tests/src/test/java/org/junit/platform/launcher/core/LauncherConfigurationParametersTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/core/LauncherConfigurationParametersTests.java
@@ -60,7 +60,7 @@ class LauncherConfigurationParametersTests {
 		System.clearProperty(KEY);
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void constructorPreconditions() {
 		assertThrows(PreconditionViolationException.class, () -> fromMap(null));
@@ -69,7 +69,7 @@ class LauncherConfigurationParametersTests {
 		assertThrows(PreconditionViolationException.class, () -> fromMapAndFile(Map.of(), "  "));
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void getPreconditions() {
 		ConfigurationParameters configParams = fromMap(Map.of());

--- a/platform-tests/src/test/java/org/junit/platform/launcher/core/LauncherFactoryTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/core/LauncherFactoryTests.java
@@ -63,7 +63,7 @@ import org.junit.platform.launcher.listeners.UnusedTestExecutionListener;
  */
 class LauncherFactoryTests {
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void preconditions() {
 		assertThrows(PreconditionViolationException.class, () -> LauncherFactory.create(null));

--- a/platform-tests/src/test/java/org/junit/platform/launcher/core/ListenerRegistryTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/core/ListenerRegistryTests.java
@@ -20,7 +20,7 @@ import org.junit.platform.commons.PreconditionViolationException;
 
 public class ListenerRegistryTests {
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void registerWithNullArray() {
 		var registry = ListenerRegistry.create(List::getFirst);
@@ -39,7 +39,7 @@ public class ListenerRegistryTests {
 		assertThat(exception).hasMessageContaining("listeners array must not be null or empty");
 	}
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void registerWithArrayContainingNullElements() {
 		var registry = ListenerRegistry.create(List::getFirst);

--- a/platform-tests/src/test/java/org/junit/platform/testkit/engine/NestedContainerEventConditionTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/testkit/engine/NestedContainerEventConditionTests.java
@@ -41,7 +41,7 @@ import org.junit.platform.testkit.engine.NestedContainerEventConditionTests.ATes
  */
 class NestedContainerEventConditionTests {
 
-	@SuppressWarnings({ "DataFlowIssue", "NullAway" })
+	@SuppressWarnings("DataFlowIssue")
 	@Test
 	void preconditions() {
 		assertThatExceptionOfType(PreconditionViolationException.class)//

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,7 +16,6 @@ plugins {
 dependencyResolutionManagement {
 	repositories {
 		mavenCentral()
-		mavenLocal() // FIXME delete
 	}
 	repositoriesMode = FAIL_ON_PROJECT_REPOS
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,6 +16,7 @@ plugins {
 dependencyResolutionManagement {
 	repositories {
 		mavenCentral()
+		mavenLocal() // FIXME delete
 	}
 	repositoriesMode = FAIL_ON_PROJECT_REPOS
 }


### PR DESCRIPTION
I am working on a [NullAway enhancement](https://github.com/uber/NullAway/pull/1231) that allows setting suppression name aliases, like the JetBrains [`DataFlowIssue`](https://www.jetbrains.com/help/inspectopedia/DataFlowIssue.html) inspection.

As I'm also testing my changes against the JUnit codebase, I'm opening this PR as a draft to showcase the idea, and I'd be happy to finalize it if the team agrees.

### Prerequisites

- [x] NullAway 0.12.8 for the new `SuppressionNameAliases` config option
- [ ] New release of [`gradle-nullaway-plugin`](https://github.com/tbroyer/gradle-nullaway-plugin) for the corresponding DSL (workaround demonstrated in the PR)

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [x] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://docs.junit.org/snapshot/user-guide/) and [Release Notes](https://docs.junit.org/snapshot/user-guide/#release-notes)
