### PR TITLE
Fail for invalid enum constants supplied as configuration parameters

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-6.0.0-M2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-6.0.0-M2.adoc
@@ -31,6 +31,10 @@ repository on GitHub.
   format used by the deprecated `Locale(String)` constructor.
 * Deprecate `getOrComputeIfAbsent(...)` methods in `NamespacedHierarchicalStore` in favor
   of the new `computeIfAbsent(...)` methods.
+* Setting an invalid value for one of the following enum-based configuration parameters
+  now causes test discovery to fail:
+  - `junit.platform.discovery.issue.failure.phase`
+  - `junit.platform.discovery.issue.severity.critical`
 
 [[release-notes-6.0.0-M2-junit-platform-new-features-and-improvements]]
 ==== New Features and Improvements
@@ -78,6 +82,15 @@ repository on GitHub.
   method.
 * Deprecate `getOrComputeIfAbsent(...)` methods in `ExtensionContext.Store` in favor of
   the new `computeIfAbsent(...)` methods.
+* Setting an invalid value for one of the following enum-based configuration parameters
+  now causes test discovery or execution to fail:
+  - `junit.jupiter.execution.parallel.mode.default`
+  - `junit.jupiter.execution.parallel.mode.classes.default`
+  - `junit.jupiter.execution.timeout.mode`
+  - `junit.jupiter.execution.timeout.thread.mode.default`
+  - `junit.jupiter.extensions.testinstantiation.extensioncontextscope.default`
+  - `junit.jupiter.tempdir.cleanup.mode.default`
+  - `junit.jupiter.testinstance.lifecycle.default`
 
 [[release-notes-6.0.0-M2-junit-jupiter-new-features-and-improvements]]
 ==== New Features and Improvements

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/config/DefaultJupiterConfiguration.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/config/DefaultJupiterConfiguration.java
@@ -149,19 +149,19 @@ public class DefaultJupiterConfiguration implements JupiterConfiguration {
 
 	@Override
 	public ExecutionMode getDefaultExecutionMode() {
-		return executionModeConverter.get(configurationParameters, DEFAULT_EXECUTION_MODE_PROPERTY_NAME,
+		return executionModeConverter.getOrDefault(configurationParameters, DEFAULT_EXECUTION_MODE_PROPERTY_NAME,
 			ExecutionMode.SAME_THREAD);
 	}
 
 	@Override
 	public ExecutionMode getDefaultClassesExecutionMode() {
-		return executionModeConverter.get(configurationParameters, DEFAULT_CLASSES_EXECUTION_MODE_PROPERTY_NAME,
-			getDefaultExecutionMode());
+		return executionModeConverter.getOrDefault(configurationParameters,
+			DEFAULT_CLASSES_EXECUTION_MODE_PROPERTY_NAME, getDefaultExecutionMode());
 	}
 
 	@Override
 	public Lifecycle getDefaultTestInstanceLifecycle() {
-		return lifecycleConverter.get(configurationParameters, DEFAULT_TEST_INSTANCE_LIFECYCLE_PROPERTY_NAME,
+		return lifecycleConverter.getOrDefault(configurationParameters, DEFAULT_TEST_INSTANCE_LIFECYCLE_PROPERTY_NAME,
 			Lifecycle.PER_METHOD);
 	}
 
@@ -189,7 +189,7 @@ public class DefaultJupiterConfiguration implements JupiterConfiguration {
 
 	@Override
 	public CleanupMode getDefaultTempDirCleanupMode() {
-		return cleanupModeConverter.get(configurationParameters, DEFAULT_CLEANUP_MODE_PROPERTY_NAME, ALWAYS);
+		return cleanupModeConverter.getOrDefault(configurationParameters, DEFAULT_CLEANUP_MODE_PROPERTY_NAME, ALWAYS);
 	}
 
 	@Override
@@ -202,7 +202,7 @@ public class DefaultJupiterConfiguration implements JupiterConfiguration {
 	@SuppressWarnings("deprecation")
 	@Override
 	public ExtensionContextScope getDefaultTestInstantiationExtensionContextScope() {
-		return extensionContextScopeConverter.get(configurationParameters,
+		return extensionContextScopeConverter.getOrDefault(configurationParameters,
 			DEFAULT_TEST_INSTANTIATION_EXTENSION_CONTEXT_SCOPE_PROPERTY_NAME, ExtensionContextScope.DEFAULT);
 	}
 

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/EngineDiscoveryOrchestrator.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/EngineDiscoveryOrchestrator.java
@@ -133,8 +133,8 @@ public class EngineDiscoveryOrchestrator {
 	private static boolean shouldReportDiscoveryIssues(LauncherDiscoveryRequest request,
 			Optional<LauncherPhase> phase) {
 		ConfigurationParameters configurationParameters = request.getConfigurationParameters();
-		return getDiscoveryIssueFailurePhase(configurationParameters).orElse(
-			phase.orElse(null)) == LauncherPhase.DISCOVERY;
+		return getDiscoveryIssueFailurePhase(configurationParameters) //
+				.orElse(phase.orElse(null)) == LauncherPhase.DISCOVERY;
 	}
 
 	private static void reportDiscoveryIssues(LauncherDiscoveryResult discoveryResult) {

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/EngineExecutionOrchestrator.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/EngineExecutionOrchestrator.java
@@ -223,8 +223,8 @@ public class EngineExecutionOrchestrator {
 
 	private static boolean shouldReportDiscoveryIssues(LauncherDiscoveryResult discoveryResult) {
 		ConfigurationParameters configurationParameters = discoveryResult.getConfigurationParameters();
-		return getDiscoveryIssueFailurePhase(configurationParameters).orElse(
-			LauncherPhase.EXECUTION) == LauncherPhase.EXECUTION;
+		return getDiscoveryIssueFailurePhase(configurationParameters) //
+				.orElse(LauncherPhase.EXECUTION) == LauncherPhase.EXECUTION;
 	}
 
 	private ListenerRegistry<TestExecutionListener> buildListenerRegistryForExecution(

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherPhase.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherPhase.java
@@ -17,8 +17,7 @@ import java.util.Optional;
 import java.util.function.Function;
 
 import org.jspecify.annotations.Nullable;
-import org.junit.platform.commons.logging.Logger;
-import org.junit.platform.commons.logging.LoggerFactory;
+import org.junit.platform.commons.JUnitException;
 import org.junit.platform.engine.ConfigurationParameters;
 
 /**
@@ -30,18 +29,15 @@ enum LauncherPhase {
 
 	DISCOVERY, EXECUTION;
 
-	private static final Logger logger = LoggerFactory.getLogger(LauncherPhase.class);
-
 	static Optional<LauncherPhase> getDiscoveryIssueFailurePhase(ConfigurationParameters configurationParameters) {
 		Function<String, @Nullable LauncherPhase> stringLauncherPhaseFunction = value -> {
 			try {
 				return LauncherPhase.valueOf(value.toUpperCase(Locale.ROOT));
 			}
 			catch (Exception e) {
-				logger.warn(
-					() -> "Ignoring invalid LauncherPhase '%s' set via the '%s' configuration parameter.".formatted(
-						value, DISCOVERY_ISSUE_FAILURE_PHASE_PROPERTY_NAME));
-				return null;
+				throw new JUnitException(
+					"Invalid LauncherPhase '%s' set via the '%s' configuration parameter.".formatted(value,
+						DISCOVERY_ISSUE_FAILURE_PHASE_PROPERTY_NAME));
 			}
 		};
 		return configurationParameters.get(DISCOVERY_ISSUE_FAILURE_PHASE_PROPERTY_NAME, stringLauncherPhaseFunction);

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/config/DefaultJupiterConfigurationTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/config/DefaultJupiterConfigurationTests.java
@@ -11,6 +11,7 @@
 package org.junit.jupiter.engine.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
@@ -71,8 +72,13 @@ class DefaultJupiterConfigurationTests {
 	void getDefaultTestInstanceLifecycleWithConfigParamSet() {
 		assertAll(//
 			() -> assertDefaultConfigParam(null, PER_METHOD), //
-			() -> assertDefaultConfigParam("", PER_METHOD), //
-			() -> assertDefaultConfigParam("bogus", PER_METHOD), //
+			() -> assertThatThrownBy(() -> getDefaultTestInstanceLifecycleConfigParam("")) //
+					.hasMessage("Invalid test instance lifecycle mode '' set via the '%s' configuration parameter.",
+						DEFAULT_TEST_INSTANCE_LIFECYCLE_PROPERTY_NAME), //
+			() -> assertThatThrownBy(() -> getDefaultTestInstanceLifecycleConfigParam("bogus")) //
+					.hasMessage(
+						"Invalid test instance lifecycle mode 'BOGUS' set via the '%s' configuration parameter.",
+						DEFAULT_TEST_INSTANCE_LIFECYCLE_PROPERTY_NAME), //
 			() -> assertDefaultConfigParam(PER_METHOD.name(), PER_METHOD), //
 			() -> assertDefaultConfigParam(PER_METHOD.name().toLowerCase(), PER_METHOD), //
 			() -> assertDefaultConfigParam("  " + PER_METHOD.name() + "  ", PER_METHOD), //
@@ -156,11 +162,15 @@ class DefaultJupiterConfigurationTests {
 	}
 
 	private void assertDefaultConfigParam(@Nullable String configValue, Lifecycle expected) {
+		var lifecycle = getDefaultTestInstanceLifecycleConfigParam(configValue);
+		assertThat(lifecycle).isEqualTo(expected);
+	}
+
+	private static Lifecycle getDefaultTestInstanceLifecycleConfigParam(@Nullable String configValue) {
 		ConfigurationParameters configParams = mock();
 		when(configParams.get(KEY)).thenReturn(Optional.ofNullable(configValue));
-		Lifecycle lifecycle = new DefaultJupiterConfiguration(configParams, dummyOutputDirectoryProvider(),
+		return new DefaultJupiterConfiguration(configParams, dummyOutputDirectoryProvider(),
 			mock()).getDefaultTestInstanceLifecycle();
-		assertThat(lifecycle).isEqualTo(expected);
 	}
 
 }

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/descriptor/ExtensionContextTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/descriptor/ExtensionContextTests.java
@@ -34,7 +34,6 @@ import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.function.Function;
 
 import org.jspecify.annotations.Nullable;
@@ -454,10 +453,14 @@ public class ExtensionContextTests {
 	@ParameterizedTest
 	@MethodSource("extensionContextFactories")
 	void configurationParameter(Function<JupiterConfiguration, ? extends ExtensionContext> extensionContextFactory) {
-		JupiterConfiguration echo = new DefaultJupiterConfiguration(new EchoParameters(),
-			dummyOutputDirectoryProvider(), mock());
+
 		var key = "123";
 		var expected = Optional.of(key);
+
+		ConfigurationParameters configurationParameters = mock();
+		when(configurationParameters.get("123")).thenReturn(expected);
+		JupiterConfiguration echo = new DefaultJupiterConfiguration(configurationParameters,
+			dummyOutputDirectoryProvider(), mock());
 
 		var context = extensionContextFactory.apply(echo);
 
@@ -552,25 +555,6 @@ public class ExtensionContextTests {
 
 		@Tag("method-tag")
 		void aMethod() {
-		}
-	}
-
-	private static class EchoParameters implements ConfigurationParameters {
-
-		@Override
-		public Optional<String> get(String key) {
-			return Optional.of(key);
-		}
-
-		@Override
-		public Optional<Boolean> getBoolean(String key) {
-			throw new UnsupportedOperationException("getBoolean(String) should not be called");
-		}
-
-		@Override
-		public Set<String> keySet() {
-			throw new UnsupportedOperationException("keySet() should not be called");
-
 		}
 	}
 


### PR DESCRIPTION
Resolves #4617.

<!-- Please describe your changes here and list any open questions you might have. -->

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://docs.junit.org/snapshot/user-guide/) and [Release Notes](https://docs.junit.org/snapshot/user-guide/#release-notes)
