### PR TITLE
Replace ISO control characters in display names

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-6.0.0-RC1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-6.0.0-RC1.adoc
@@ -32,6 +32,11 @@ repository on GitHub.
 * Convention-based conversion in `ConversionSupport` now supports factory methods and
   factory constructors that accept a single `CharSequence` argument in addition to the
   existing support for factories that accept a single `String` argument.
+* Non-printable control characters in display names are now replaced with alternative
+  representations. For example, `\n` is replaced with `<LF>`. This applies to all display
+  names in JUnit Jupiter, `@SuiteDisplayName`, and any other test engines that subclass
+  `AbstractTestDescriptor`. Please refer to the
+  <<../user-guide/index.adoc#writing-tests-display-names, User Guide>> for details.
 
 
 [[release-notes-6.0.0-RC1-junit-jupiter]]
@@ -64,6 +69,9 @@ repository on GitHub.
   Fallback String-to-Object Conversion>> for parameterized tests now supports factory
   methods and factory constructors that accept a single `CharSequence` argument in
   addition to the existing support for factories that accept a single `String` argument.
+* Non-printable control characters in display names are now replaced with alternative
+  representations. Please refer to the
+  <<../user-guide/index.adoc#writing-tests-display-names, User Guide>> for details.
 
 
 [[release-notes-6.0.0-RC1-junit-vintage]]

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -307,6 +307,32 @@ by test runners and IDEs.
 include::{testDir}/example/DisplayNameDemo.java[tags=user_guide]
 ----
 
+[NOTE]
+====
+Control characters in text-based arguments in display names for parameterized tests are
+escaped by default. See <<writing-tests-parameterized-tests-display-names-quoted-text>>
+for details.
+
+Any remaining ISO control characters in a display name will be replaced as follows.
+
+[cols="25%,15%,60%"]
+|===
+| Original | Replacement | Description
+
+| ```\r```
+| ```<CR>```
+| Textual representation of a carriage return
+
+| ```\n```
+| ```<LF>```
+| Textual representation of a line feed
+
+| Other control character
+| ```�```
+| Unicode replacement character (U+FFFD)
+|===
+====
+
 [[writing-tests-display-name-generator]]
 ==== Display Name Generators
 
@@ -2778,8 +2804,7 @@ is considered text. A `CharSequence` is wrapped in double quotes (`"`), and a `C
 is wrapped in single quotes (`'`).
 
 Special characters will be escaped in the quoted text. For example, carriage returns and
-line feeds will be escaped as `\\r` and `\\n`, respectively. In addition, any ISO control
-character will be represented as a question mark (`?`) in the quoted text.
+line feeds will be escaped as `\\r` and `\\n`, respectively.
 
 [TIP]
 ====

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/QuoteUtils.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/QuoteUtils.java
@@ -48,7 +48,7 @@ final class QuoteUtils {
 			case '\t' -> "\\t";
 			case '\r' -> "\\r";
 			case '\n' -> "\\n";
-			default -> Character.isISOControl(ch) ? "?" : String.valueOf(ch);
+			default -> String.valueOf(ch);
 		};
 	}
 

--- a/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedInvocationNameFormatterTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedInvocationNameFormatterTests.java
@@ -342,7 +342,7 @@ class ParameterizedInvocationNameFormatterTests {
 				'   \t   '   -> '   \\t   '
 				'\b'         -> \\b
 				'\f'         -> \\f
-				'\u0007'     -> ?
+				'\u0007'     -> '\u0007'
 				""")
 		void quotedStrings(String argument, String expected) {
 			var formatter = formatter(DEFAULT_DISPLAY_NAME, "IGNORED");
@@ -364,7 +364,7 @@ class ParameterizedInvocationNameFormatterTests {
 				"\t"     -> \\t
 				"\b"     -> \\b
 				"\f"     -> \\f
-				"\u0007" -> ?
+				"\u0007" -> "\u0007"
 				""")
 		void quotedCharacters(char argument, String expected) {
 			var formatter = formatter(DEFAULT_DISPLAY_NAME, "IGNORED");

--- a/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java
@@ -270,6 +270,30 @@ class ParameterizedTestIntegrationTests extends AbstractJupiterTestEngineTests {
 				.haveExactly(1, event(test(), displayName("[2] argument = bar"), finishedWithFailure(message("bar"))));
 	}
 
+	/**
+	 * @since 6.0
+	 */
+	@Test
+	void executesWithCsvSourceAndSpecialCharacters() {
+		// @formatter:off
+		execute("testWithCsvSourceAndSpecialCharacters", String.class)
+				.testEvents()
+				.started()
+				.assertEventsMatchExactly(
+					displayName(quoted("üñåé")),
+					displayName(quoted("\\n")),
+					displayName(quoted("\\r")),
+					displayName(quoted("\uFFFD")),
+					displayName(quoted("😱")),
+					displayName(quoted("Zero\u200BWidth\u200BSpaces"))
+				);
+		// @formatter:on
+	}
+
+	private static String quoted(String text) {
+		return '"' + text + '"';
+	}
+
 	@Test
 	void executesWithCustomName() {
 		var results = execute("testWithCustomName", String.class, int.class);
@@ -1451,6 +1475,11 @@ class ParameterizedTestIntegrationTests extends AbstractJupiterTestEngineTests {
 		@CsvSource({ "foo", "bar" })
 		void testWithCsvSource(String argument) {
 			fail(argument);
+		}
+
+		@ParameterizedTest(name = "{0}")
+		@CsvSource({ "'üñåé'", "'\n'", "'\r'", "'\u0007'", "😱", "'Zero\u200BWidth\u200BSpaces'" })
+		void testWithCsvSourceAndSpecialCharacters(String argument) {
 		}
 
 		@ParameterizedTest(quoteTextArguments = false, name = "{0} and {1}")


### PR DESCRIPTION
Prior to this commit, display names were "sanitized" before they were printed via the `ConsoleLauncher` (#1713), and text-based arguments in display names for parameterized tests were quoted and escaped (#4716). However, there was still the chance that display names could contain control characters such as CR or LF.

To address that, this commit introduces support for automatically replacing non-printable characters in any display name passed to one of the constructors for `AbstractTestDescriptor`. Doing so automatically covers all display names in Jupiter, `@SuiteDisplayName`, and any other test engines that subclass `AbstractTestDescriptor`, which should cover most common use cases.

Specifically, the following replacements are performed.

- `\r` -> `<CR>`
- `\n` -> `<LF>`
- ISO control character -> � (Unicode replacement character)

This commit also removes the special handling of ISO control characters from `QuoteUtils`, since this is now handled within `AbstractTestDescriptor`.

- See #1713
- See #4716
- Closes #4714

