### PR TITLE
Report warning when @SuiteDisplayName is blank or whitespace-only

### DIFF
--- a/junit-platform-suite-engine/src/main/java/org/junit/platform/suite/engine/SuiteTestDescriptor.java
+++ b/junit-platform-suite-engine/src/main/java/org/junit/platform/suite/engine/SuiteTestDescriptor.java
@@ -87,6 +87,7 @@ final class SuiteTestDescriptor extends AbstractTestDescriptor {
 		this.suiteClass = suiteClass;
 		this.lifecycleMethods = new LifecycleMethods(suiteClass, issueReporter);
 		this.discoveryRequestBuilder.listener(DiscoveryIssueForwardingListener.create(id, discoveryListener));
+		inspectSuiteDisplayName(suiteClass, issueReporter);
 	}
 
 	private static Boolean getFailIfNoTests(Class<?> suiteClass) {
@@ -147,6 +148,16 @@ final class SuiteTestDescriptor extends AbstractTestDescriptor {
 				.filter(StringUtils::isNotBlank)
 				.orElse(testClass.getSimpleName());
 		// @formatter:on
+	}
+
+	private static void inspectSuiteDisplayName(Class<?> suiteClass, DiscoveryIssueReporter issueReporter) {
+		findAnnotation(suiteClass, SuiteDisplayName.class).map(SuiteDisplayName::value).filter(
+			StringUtils::isBlank).ifPresent(__ -> {
+				String message = "@SuiteDisplayName on %s must be declared with a non-blank value.".formatted(
+					suiteClass.getName());
+				issueReporter.reportIssue(DiscoveryIssue.builder(DiscoveryIssue.Severity.WARNING, message).source(
+					ClassSource.from(suiteClass)).build());
+			});
 	}
 
 	void execute(EngineExecutionListener executionListener, NamespacedHierarchicalStore<Namespace> requestLevelStore,

--- a/platform-tests/src/test/java/org/junit/platform/suite/engine/SuiteEngineTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/suite/engine/SuiteEngineTests.java
@@ -68,6 +68,7 @@ import org.junit.platform.suite.engine.testcases.MultipleTestsTestCase;
 import org.junit.platform.suite.engine.testcases.SingleTestTestCase;
 import org.junit.platform.suite.engine.testcases.TaggedTestTestCase;
 import org.junit.platform.suite.engine.testsuites.AbstractSuite;
+import org.junit.platform.suite.engine.testsuites.BlankSuiteDisplayNameSuite;
 import org.junit.platform.suite.engine.testsuites.ConfigurationSuite;
 import org.junit.platform.suite.engine.testsuites.CyclicSuite;
 import org.junit.platform.suite.engine.testsuites.DynamicSuite;
@@ -88,6 +89,7 @@ import org.junit.platform.suite.engine.testsuites.SuiteDisplayNameSuite;
 import org.junit.platform.suite.engine.testsuites.SuiteSuite;
 import org.junit.platform.suite.engine.testsuites.SuiteWithErroneousTestSuite;
 import org.junit.platform.suite.engine.testsuites.ThreePartCyclicSuite;
+import org.junit.platform.suite.engine.testsuites.WhitespaceSuiteDisplayNameSuite;
 import org.junit.platform.testkit.engine.EngineTestKit;
 
 /**
@@ -703,6 +705,38 @@ class SuiteEngineTests {
 		finally {
 			CancellingSuite.cancellationToken = null;
 		}
+	}
+
+	@Test
+	void blankSuiteDisplayNameGeneratesWarning() {
+		var expectedMessage = "@SuiteDisplayName on %s must be declared with a non-blank value.".formatted(
+			BlankSuiteDisplayNameSuite.class.getName());
+		var expectedIssue = DiscoveryIssue.builder(Severity.WARNING, expectedMessage).source(
+			ClassSource.from(BlankSuiteDisplayNameSuite.class)).build();
+
+		var testKit = EngineTestKit.engine(ENGINE_ID).selectors(selectClass(BlankSuiteDisplayNameSuite.class));
+
+		assertThat(testKit.discover().getDiscoveryIssues()).contains(expectedIssue);
+	}
+
+	@Test
+	void whitespaceSuiteDisplayNameGeneratesWarning() {
+		var expectedMessage = "@SuiteDisplayName on %s must be declared with a non-blank value.".formatted(
+			WhitespaceSuiteDisplayNameSuite.class.getName());
+		var expectedIssue = DiscoveryIssue.builder(Severity.WARNING, expectedMessage).source(
+			ClassSource.from(WhitespaceSuiteDisplayNameSuite.class)).build();
+
+		var testKit = EngineTestKit.engine(ENGINE_ID).selectors(selectClass(WhitespaceSuiteDisplayNameSuite.class));
+
+		assertThat(testKit.discover().getDiscoveryIssues()).contains(expectedIssue);
+	}
+
+	@Test
+	void validSuiteDisplayNameGeneratesNoWarning() {
+		var testKit = EngineTestKit.engine(ENGINE_ID).selectors(selectClass(SuiteDisplayNameSuite.class));
+
+		assertThat(testKit.discover().getDiscoveryIssues()).noneMatch(
+			issue -> issue.message().contains("@SuiteDisplayName"));
 	}
 
 	// -----------------------------------------------------------------------------------------------------------------

--- a/platform-tests/src/test/java/org/junit/platform/suite/engine/testsuites/BlankSuiteDisplayNameSuite.java
+++ b/platform-tests/src/test/java/org/junit/platform/suite/engine/testsuites/BlankSuiteDisplayNameSuite.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2015-2025 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.suite.engine.testsuites;
+
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
+import org.junit.platform.suite.api.SuiteDisplayName;
+import org.junit.platform.suite.engine.testcases.SingleTestTestCase;
+
+/**
+ * Test suite with blank @SuiteDisplayName to verify validation.
+ *
+ * @since 6.0.0-RC1
+ */
+@Suite
+@SelectClasses(SingleTestTestCase.class)
+@SuiteDisplayName("")
+public class BlankSuiteDisplayNameSuite {
+}

--- a/platform-tests/src/test/java/org/junit/platform/suite/engine/testsuites/WhitespaceSuiteDisplayNameSuite.java
+++ b/platform-tests/src/test/java/org/junit/platform/suite/engine/testsuites/WhitespaceSuiteDisplayNameSuite.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2015-2025 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.suite.engine.testsuites;
+
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
+import org.junit.platform.suite.api.SuiteDisplayName;
+import org.junit.platform.suite.engine.testcases.SingleTestTestCase;
+
+/**
+ * Test suite with whitespace-only @SuiteDisplayName to verify validation.
+ *
+ * @since 6.0.0-RC1
+ */
+@Suite
+@SelectClasses(SingleTestTestCase.class)
+@SuiteDisplayName("   ")
+public class WhitespaceSuiteDisplayNameSuite {
+}


### PR DESCRIPTION
### Purpose
This PR adds a discovery-time validation for `@SuiteDisplayName` in the Suite Engine.
If the annotation value is blank or whitespace-only, the engine now reports a `DiscoveryIssue` with WARNING severity.


### Related issue
- https://github.com/junit-team/junit-framework/issues/4810

### Key Changes
- `SuiteTestDescriptor`: invoke `inspectSuiteDisplayName(...)` during construction and report a warning when needed.
  (referred to [DisplayNameUtils.validateAnnotation()](https://github.com/junit-team/junit-framework/blob/24b3c407e9a3640cf3003b7241e1e1378c7c6e89/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DisplayNameUtils.java#L83-L94).)
- I initially considered using [`Preconditions.notBlank()`](https://github.com/junit-team/junit-framework/blob/24b3c407e9a3640cf3003b7241e1e1378c7c6e89/junit-platform-commons/src/main/java/org/junit/platform/commons/util/Preconditions.java#L285-L289) to throw a `PreconditionViolationException` when the value contains only whitespace.
However, to maintain backward compatibility, I decided that reporting a **warning** would be more appropriate than throwing an exception.


### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://docs.junit.org/snapshot/user-guide/) and [Release Notes](https://docs.junit.org/snapshot/user-guide/#release-notes)
