### PR TITLE
Prune stack traces up to test or lifecycle method

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-6.0.0-RC1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-6.0.0-RC1.adoc
@@ -26,8 +26,7 @@ repository on GitHub.
 [[release-notes-6.0.0-RC1-junit-platform-new-features-and-improvements]]
 ==== New Features and Improvements
 
-* ❓
-
+* Prune stack traces up to test or lifecycle method
 
 [[release-notes-6.0.0-RC1-junit-jupiter]]
 === JUnit Jupiter

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ExceptionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ExceptionUtils.java
@@ -97,11 +97,15 @@ public final class ExceptionUtils {
 	}
 
 	/**
-	 * Prune the stack trace of the supplied {@link Throwable} by removing
-	 * {@linkplain StackTraceElement stack trace elements} from the {@code org.junit},
-	 * {@code jdk.internal.reflect}, and {@code sun.reflect} packages. If a
-	 * {@code StackTraceElement} matching one of the supplied {@code classNames}
-	 * is encountered, all subsequent elements in the stack trace will be retained.
+	 * Prune the stack trace of the supplied {@link Throwable}.
+	 *
+	 * <p>Prune all {@linkplain StackTraceElement stack trace elements} up one
+	 * of the supplied {@code classNames} are pruned. All subsequent elements
+	 * in the stack trace will be retained.
+	 *
+	 * <p>If the {@code classNames} do not match any of the stacktrace elements
+	 * then the {@code org.junit}, {@code jdk.internal.reflect}, and
+	 * {@code sun.reflect} packages are pruned.
 	 *
 	 * <p>Additionally, all elements prior to and including the first JUnit Platform
 	 * Launcher call will be removed.
@@ -128,6 +132,9 @@ public final class ExceptionUtils {
 			String className = element.getClassName();
 
 			if (classNames.contains(className)) {
+				// We found the test
+				// everything before that is not informative.
+				prunedStackTrace.clear();
 				// Include all elements called by the test
 				prunedStackTrace.addAll(stackTrace.subList(i, stackTrace.size()));
 				break;

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/StackTracePruningEngineExecutionListener.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/StackTracePruningEngineExecutionListener.java
@@ -13,6 +13,7 @@ package org.junit.platform.launcher.core;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import org.junit.platform.commons.util.ExceptionUtils;
 import org.junit.platform.engine.EngineExecutionListener;
@@ -46,8 +47,9 @@ class StackTracePruningEngineExecutionListener extends DelegatingEngineExecution
 	}
 
 	private static List<String> getTestClassNames(TestDescriptor testDescriptor) {
-		return testDescriptor.getAncestors() //
-				.stream() //
+		Stream<? extends TestDescriptor> self = Stream.of(testDescriptor);
+		Stream<? extends TestDescriptor> ancestors = testDescriptor.getAncestors().stream();
+		return Stream.concat(self, ancestors) //
 				.map(TestDescriptor::getSource) //
 				.flatMap(Optional::stream) //
 				.map(source -> {

--- a/platform-tests/src/test/java/org/junit/platform/StackTracePruningTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/StackTracePruningTests.java
@@ -115,7 +115,7 @@ class StackTracePruningTests {
 	}
 
 	@Test
-	void shouldKeepEverythingAfterTestCall() {
+	void shouldKeepExactlyEverythingAfterTestCall() {
 		EngineExecutionResults results = EngineTestKit.engine("junit-jupiter") //
 				.configurationParameter("junit.platform.stacktrace.pruning.enabled", "true") //
 				.selectors(selectMethod(FailingTestTestCase.class, "failingAssertion")) //
@@ -128,7 +128,6 @@ class StackTracePruningTests {
 					\\Qorg.junit.jupiter.api.AssertionUtils.fail(AssertionUtils.java:\\E.+
 					\\Qorg.junit.jupiter.api.Assertions.fail(Assertions.java:\\E.+
 					\\Qorg.junit.platform.StackTracePruningTests$FailingTestTestCase.failingAssertion(StackTracePruningTests.java:\\E.+
-					>>>>
 					""");
 	}
 
@@ -136,7 +135,7 @@ class StackTracePruningTests {
 	@ValueSource(strings = { "org.junit.platform.StackTracePruningTests$FailingBeforeEachTestCase",
 			"org.junit.platform.StackTracePruningTests$FailingBeforeEachTestCase$NestedTestCase",
 			"org.junit.platform.StackTracePruningTests$FailingBeforeEachTestCase$NestedTestCase$NestedNestedTestCase" })
-	void shouldKeepEverythingAfterLifecycleMethodCall(Class<?> methodClass) {
+	void shouldKeepExactlyEverythingAfterLifecycleMethodCall(Class<?> methodClass) {
 		EngineExecutionResults results = EngineTestKit.engine("junit-jupiter") //
 				.configurationParameter("junit.platform.stacktrace.pruning.enabled", "true") //
 				.selectors(selectMethod(methodClass, "test")) //
@@ -149,7 +148,6 @@ class StackTracePruningTests {
 					\\Qorg.junit.jupiter.api.AssertionUtils.fail(AssertionUtils.java:\\E.+
 					\\Qorg.junit.jupiter.api.Assertions.fail(Assertions.java:\\E.+
 					\\Qorg.junit.platform.StackTracePruningTests$FailingBeforeEachTestCase.setUp(StackTracePruningTests.java:\\E.+
-					>>>>
 					""");
 	}
 


### PR DESCRIPTION
Everything before the test method is invoked is not informative for the end user. Discarding that part of the stacktrace removes a few more uninformative frames.

Additionally, when pruning consider the source of the test descriptor not merely its ancestors.

Fixes: #4828

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://docs.junit.org/snapshot/user-guide/) and [Release Notes](https://docs.junit.org/snapshot/user-guide/#release-notes)
