### PR TITLE
Order nested classes declared in same enclosing type deterministically

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-6.0.0-RC1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-6.0.0-RC1.adoc
@@ -21,7 +21,9 @@ repository on GitHub.
 [[release-notes-6.0.0-RC1-junit-platform-deprecations-and-breaking-changes]]
 ==== Deprecations and Breaking Changes
 
-* ❓
+* The methods `findNestedClasses` and `streamNestedClasses` in `ReflectionSupport` now
+  return nested classes declared in the same enclosing class or interface ordered in a
+  deterministic but intentionally nonobvious way.
 
 [[release-notes-6.0.0-RC1-junit-platform-new-features-and-improvements]]
 ==== New Features and Improvements
@@ -47,7 +49,9 @@ repository on GitHub.
 [[release-notes-6.0.0-RC1-junit-jupiter-deprecations-and-breaking-changes]]
 ==== Deprecations and Breaking Changes
 
-* ❓
+* For consistency with test methods, `@Nested` classes declared in the same enclosing
+  class or interface are now ordered in a deterministic but intentionally nonobvious
+  way.
 
 [[release-notes-6.0.0-RC1-junit-jupiter-new-features-and-improvements]]
 ==== New Features and Improvements

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/ReflectionSupport.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/ReflectionSupport.java
@@ -632,6 +632,10 @@ public final class ReflectionSupport {
 	 * <p>This method does <strong>not</strong> search for nested classes
 	 * recursively.
 	 *
+	 * <p>Nested classes declared in the same enclosing class or interface will
+	 * be ordered using an algorithm that is deterministic but intentionally
+	 * nonobvious.
+	 *
 	 * <p>As of JUnit Platform 1.6, this method detects cycles in <em>inner</em>
 	 * class hierarchies &mdash; from the supplied class up to the outermost
 	 * enclosing class &mdash; and throws a {@link JUnitException} if such a cycle
@@ -657,6 +661,10 @@ public final class ReflectionSupport {
 	 *
 	 * <p>This method does <strong>not</strong> search for nested classes
 	 * recursively.
+	 *
+	 * <p>Nested classes declared in the same enclosing class or interface will
+	 * be ordered using an algorithm that is deterministic but intentionally
+	 * nonobvious.
 	 *
 	 * <p>As of JUnit Platform 1.6, this method detects cycles in <em>inner</em>
 	 * class hierarchies &mdash; from the supplied class up to the outermost

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
@@ -1182,7 +1182,7 @@ public final class ReflectionUtils {
 
 		try {
 			// Candidates in current class
-			for (Class<?> nestedClass : clazz.getDeclaredClasses()) {
+			for (Class<?> nestedClass : toSortedMutableList(clazz.getDeclaredClasses())) {
 				if (predicate.test(nestedClass)) {
 					consumer.accept(nestedClass);
 					if (detectInnerClassCycle(nestedClass, errorHandling)) {
@@ -1698,6 +1698,10 @@ public final class ReflectionUtils {
 		return toSortedMutableList(methods, ReflectionUtils::defaultMethodSorter);
 	}
 
+	private static List<Class<?>> toSortedMutableList(Class<?>[] fields) {
+		return toSortedMutableList(fields, ReflectionUtils::defaultClassSorter);
+	}
+
 	private static <T> List<T> toSortedMutableList(T[] items, Comparator<? super T> comparator) {
 		List<T> result = new ArrayList<>(items.length);
 		Collections.addAll(result, items);
@@ -1726,6 +1730,19 @@ public final class ReflectionUtils {
 			if (comparison == 0) {
 				comparison = method1.toString().compareTo(method2.toString());
 			}
+		}
+		return comparison;
+	}
+
+	/**
+	 * Class comparator to achieve deterministic but nonobvious order.
+	 */
+	private static int defaultClassSorter(Class<?> class1, Class<?> class2) {
+		String name1 = class1.getName();
+		String name2 = class2.getName();
+		int comparison = Integer.compare(name1.hashCode(), name2.hashCode());
+		if (comparison == 0) {
+			comparison = name1.compareTo(name2);
 		}
 		return comparison;
 	}

--- a/platform-tests/src/test/java/org/junit/platform/commons/util/ReflectionUtilsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/util/ReflectionUtilsTests.java
@@ -1152,6 +1152,15 @@ class ReflectionUtilsTests {
 				runnable4, runnable4, runnable4, runnable5, runnable5, runnable5).parallel().forEach(Runnable::run);
 		}
 
+		@Test
+		void findNestedClassesWithMultipleNestedClasses() {
+			var nestedClasses = findNestedClasses(OuterClassWithMultipleNestedClasses.class);
+
+			assertThat(nestedClasses) //
+					.map(Class::getSimpleName) //
+					.containsExactly("Beta", "Zeta", "Eta", "Alpha", "Delta", "Gamma", "Theta", "Epsilon");
+		}
+
 		private static List<Class<?>> findNestedClasses(Class<?> clazz) {
 			return ReflectionUtils.findNestedClasses(clazz, c -> true);
 		}
@@ -2323,6 +2332,25 @@ class ReflectionUtilsTests {
 	static class OuterClassImplementingInterface implements InterfaceWithNestedClass {
 
 		class InnerClassImplementingInterface implements InterfaceWithNestedClass {
+		}
+	}
+
+	static class OuterClassWithMultipleNestedClasses {
+		class Alpha {
+		}
+		class Beta {
+		}
+		class Gamma {
+		}
+		class Delta {
+		}
+		class Epsilon {
+		}
+		class Zeta {
+		}
+		class Eta {
+		}
+		class Theta {
 		}
 	}
 


### PR DESCRIPTION
* The methods `findNestedClasses` and `streamNestedClasses` in
  `ReflectionSupport` now return nested classes declared in the same
  enclosing class or interface ordered in a deterministic but
  intentionally nonobvious way.
* For consistency with test methods, `@Nested` classes declared in the
  same enclosing class or interface are now ordered in a deterministic
  but intentionally nonobvious way.

<!-- Please describe your changes here and list any open questions you might have. -->

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://docs.junit.org/snapshot/user-guide/) and [Release Notes](https://docs.junit.org/snapshot/user-guide/#release-notes)
