### PR TITLE
Make artifacts built by JitPack consumable in Gradle or Maven projects

### DIFF
--- a/.jitpack.yml
+++ b/.jitpack.yml
@@ -3,4 +3,11 @@ before_install:
   - sdk install java 24-open
   - sdk use java 24-open
 install:
-  - ./gradlew --show-version javaToolchains publishToMavenLocal
+  - |
+    ./gradlew \
+      --show-version \
+      -Pjitpack.version=$VERSION \
+      -Ppublishing.group=$GROUP.$ARTIFACT \
+      -Ppublishing.signArtifacts=false \
+      javaToolchains \
+      publishToMavenLocal

--- a/gradle/plugins/build-parameters/build.gradle.kts
+++ b/gradle/plugins/build-parameters/build.gradle.kts
@@ -93,6 +93,14 @@ buildParameters {
 		bool("signArtifacts") {
 			description = "Sign artifacts before publishing them to Maven repos"
 		}
+		string("group") {
+			description = "Group ID for published Maven artifacts"
+		}
+	}
+	group("jitpack") {
+		string("version") {
+			description = "The version computed by Jitpack"
+		}
 	}
 	group("manifest") {
 		string("buildTimestamp") {

--- a/gradle/plugins/common/src/main/kotlin/junitbuild.java-library-conventions.gradle.kts
+++ b/gradle/plugins/common/src/main/kotlin/junitbuild.java-library-conventions.gradle.kts
@@ -113,9 +113,11 @@ if (project in mavenizedProjects) {
 		publications {
 			named<MavenPublication>("maven") {
 				from(components["java"])
-				versionMapping {
-					allVariants {
-						fromResolutionResult()
+				if (!buildParameters.jitpack.version.isPresent) {
+					versionMapping {
+						allVariants {
+							fromResolutionResult()
+						}
 					}
 				}
 				pom {

--- a/gradle/plugins/common/src/main/kotlin/junitbuild.publishing-conventions.gradle.kts
+++ b/gradle/plugins/common/src/main/kotlin/junitbuild.publishing-conventions.gradle.kts
@@ -11,12 +11,13 @@ val jupiterProjects: List<Project> by rootProject
 val platformProjects: List<Project> by rootProject
 val vintageProjects: List<Project> by rootProject
 
-group = when (project) {
-	in jupiterProjects -> "org.junit.jupiter"
-	in platformProjects -> "org.junit.platform"
-	in vintageProjects -> "org.junit.vintage"
-	else -> "org.junit"
-}
+group = buildParameters.publishing.group
+	.getOrElse(when (project) {
+		in jupiterProjects -> "org.junit.jupiter"
+		in platformProjects -> "org.junit.platform"
+		in vintageProjects -> "org.junit.vintage"
+		else -> "org.junit"
+	})
 
 val signArtifacts = buildParameters.publishing.signArtifacts.getOrElse(!(project.version.isSnapshot() || buildParameters.ci))
 
@@ -33,6 +34,9 @@ tasks.withType<Sign>().configureEach {
 publishing {
 	publications {
 		create<MavenPublication>("maven") {
+			version = buildParameters.jitpack.version
+				.map { value -> "(.+)-[0-9a-f]+-\\d+".toRegex().matchEntire(value)!!.groupValues[1] + "-SNAPSHOT" }
+				.getOrElse(project.version.toString())
 			pom {
 				name.set(provider {
 					project.description ?: "${project.group}:${project.name}"

--- a/junit-bom/junit-bom.gradle.kts
+++ b/junit-bom/junit-bom.gradle.kts
@@ -10,7 +10,12 @@ dependencies {
 		val mavenizedProjects: List<Project> by rootProject.extra
 		mavenizedProjects.sorted()
 				.filter { it.name != "junit-platform-console-standalone" }
-				.forEach { api("${it.group}:${it.name}:${it.version}") }
+				.forEach {
+					val version = buildParameters.jitpack.version
+						.map { value -> "(.+)-[0-9a-f]+-\\d+".toRegex().matchEntire(value)!!.groupValues[1] + "-SNAPSHOT" }
+						.getOrElse(it.version.toString())
+					api("${it.group}:${it.name}:${version}")
+				}
 	}
 }
 


### PR DESCRIPTION
* Use JitPack's version but replace commit sha and counter with SNAPSHOT
* Use JitPack's group and artifact ID
* Disable artifact signing

<!-- Please describe your changes here and list any open questions you might have. -->

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://docs.junit.org/snapshot/user-guide/) and [Release Notes](https://docs.junit.org/snapshot/user-guide/#release-notes)
