### PR TITLE
#4882 : Removed the TestIdentifier.SerializedForm

### DIFF
--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestIdentifier.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestIdentifier.java
@@ -17,13 +17,6 @@ import static org.apiguardian.api.API.Status.INTERNAL;
 import static org.apiguardian.api.API.Status.STABLE;
 import static org.junit.platform.commons.util.CollectionUtils.getOnlyElement;
 
-import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
-import java.io.ObjectStreamClass;
-import java.io.ObjectStreamField;
-import java.io.Serial;
-import java.io.Serializable;
 import java.util.LinkedHashSet;
 import java.util.Objects;
 import java.util.Optional;
@@ -47,14 +40,7 @@ import org.junit.platform.engine.UniqueId;
  * @see TestPlan
  */
 @API(status = STABLE, since = "1.0")
-public final class TestIdentifier implements Serializable {
-
-	@Serial
-	private static final long serialVersionUID = 1L;
-	@Serial
-	@SuppressWarnings("UnusedVariable")
-	private static final ObjectStreamField[] serialPersistentFields = ObjectStreamClass.lookup(
-		SerializedForm.class).getFields();
+public final class TestIdentifier {
 
 	// These are effectively final but not technically due to late initialization when deserializing
 	private /* final */ UniqueId uniqueId;
@@ -272,88 +258,4 @@ public final class TestIdentifier implements Serializable {
 				.toString();
 		// @formatter:on
 	}
-
-	@Serial
-	private void writeObject(ObjectOutputStream s) throws IOException {
-		SerializedForm serializedForm = new SerializedForm(this);
-		serializedForm.serialize(s);
-	}
-
-	@Serial
-	private void readObject(ObjectInputStream s) throws ClassNotFoundException, IOException {
-		SerializedForm serializedForm = SerializedForm.deserialize(s);
-		uniqueId = UniqueId.parse(serializedForm.uniqueId);
-		displayName = serializedForm.displayName;
-		source = serializedForm.source;
-		tags = serializedForm.tags;
-		type = serializedForm.type;
-		String parentId = serializedForm.parentId;
-		this.parentId = parentId == null ? null : UniqueId.parse(parentId);
-		legacyReportingName = serializedForm.legacyReportingName;
-	}
-
-	/**
-	 * Represents the serialized output of {@code TestIdentifier}. The fields on this
-	 * class match the fields that {@code TestIdentifier} had prior to 1.8.
-	 */
-	private static class SerializedForm implements Serializable {
-
-		@Serial
-		private static final long serialVersionUID = 1L;
-
-		private final String uniqueId;
-
-		@Nullable
-		private final String parentId;
-
-		private final String displayName;
-		private final String legacyReportingName;
-
-		@Nullable
-		private final TestSource source;
-
-		@SuppressWarnings({ "serial", "RedundantSuppression" }) // always used with serializable implementation (see TestIdentifier#copyOf())
-		private final Set<TestTag> tags;
-		private final Type type;
-
-		SerializedForm(TestIdentifier testIdentifier) {
-			this.uniqueId = testIdentifier.uniqueId.toString();
-			UniqueId parentId = testIdentifier.parentId;
-			this.parentId = parentId == null ? null : parentId.toString();
-			this.displayName = testIdentifier.displayName;
-			this.legacyReportingName = testIdentifier.legacyReportingName;
-			this.source = testIdentifier.source;
-			this.tags = testIdentifier.tags;
-			this.type = testIdentifier.type;
-		}
-
-		@SuppressWarnings("unchecked")
-		private SerializedForm(ObjectInputStream.GetField fields) throws IOException, ClassNotFoundException {
-			this.uniqueId = (String) fields.get("uniqueId", null);
-			this.parentId = (String) fields.get("parentId", null);
-			this.displayName = (String) fields.get("displayName", null);
-			this.legacyReportingName = (String) fields.get("legacyReportingName", null);
-			this.source = (TestSource) fields.get("source", null);
-			this.tags = (Set<TestTag>) fields.get("tags", null);
-			this.type = (Type) fields.get("type", null);
-		}
-
-		void serialize(ObjectOutputStream s) throws IOException {
-			ObjectOutputStream.PutField fields = s.putFields();
-			fields.put("uniqueId", uniqueId);
-			fields.put("parentId", parentId);
-			fields.put("displayName", displayName);
-			fields.put("legacyReportingName", legacyReportingName);
-			fields.put("source", source);
-			fields.put("tags", tags);
-			fields.put("type", type);
-			s.writeFields();
-		}
-
-		static SerializedForm deserialize(ObjectInputStream s) throws IOException, ClassNotFoundException {
-			ObjectInputStream.GetField fields = s.readFields();
-			return new SerializedForm(fields);
-		}
-	}
-
 }


### PR DESCRIPTION
**This PR removes the old, custom Java serialization support for TestIdentifier. The SerializedForm inner class has been deleted, and TestIdentifier no longer implements Serializable.**

**What changed**

1. Deleted the SerializedForm inner class from TestIdentifier.
2. Removed implements Serializable and related code.
3. Updated tests:
   - Removed old round-trip serialization tests.
   - Added behavior-based tests to check IDs, names, tags, type, and parent linkage.
   - Added a negative test to confirm that trying to serialize a TestIdentifier now fails with NotSerializableException.
   
TestIdentifier is no longer serializable. If you were persisting or sending these objects via Java serialization, you’ll need to switch to using stable identifiers (getUniqueId()) or create your own small DTO with just the fields you need.
Instead of writing out the whole TestIdentifier, do something like this:

```
// Before (JUnit 5.x) - not supported anymore in JUnit 6
// oos.writeObject(testIdentifier);

// After - recommended
String id = testIdentifier.getUniqueId();
// send/store this string instead
```

**Open questions:**
1. Should I add a short note in the Javadoc for TestIdentifier saying “not serializable”?


---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://docs.junit.org/snapshot/user-guide/) and [Release Notes](https://docs.junit.org/snapshot/user-guide/#release-notes)
