### PR TITLE
Relocate `ParameterInfo` to `params` package and deprecate old interface

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-6.0.0-RC3.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-6.0.0-RC3.adoc
@@ -45,6 +45,8 @@ JUnit repository on GitHub.
 * `MediaType.APPLICATION_JSON_UTF_8` is now deprecated in favor of using
   `MediaType.APPLICATION_JSON`, since the industry considers UTF-8 to be the implicit
   default encoding for the `application/json` media type.
+* `org.junit.jupiter.params.support.ParameterInfo` is now deprecated in favor of
+  `org.junit.jupiter.params.ParameterInfo`
 
 [[release-notes-6.0.0-RC3-junit-jupiter-new-features-and-improvements]]
 ==== New Features and Improvements

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/DefaultParameterInfo.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/DefaultParameterInfo.java
@@ -13,12 +13,13 @@ package org.junit.jupiter.params;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.aggregator.ArgumentsAccessor;
 import org.junit.jupiter.params.support.ParameterDeclarations;
-import org.junit.jupiter.params.support.ParameterInfo;
 
 /**
  * @since 5.13
  */
-record DefaultParameterInfo(ParameterDeclarations declarations, ArgumentsAccessor arguments) implements ParameterInfo {
+@SuppressWarnings("removal")
+record DefaultParameterInfo(ParameterDeclarations declarations, ArgumentsAccessor arguments)
+		implements org.junit.jupiter.params.support.ParameterInfo {
 
 	@Override
 	public ParameterDeclarations getDeclarations() {
@@ -31,6 +32,10 @@ record DefaultParameterInfo(ParameterDeclarations declarations, ArgumentsAccesso
 	}
 
 	void store(ExtensionContext context) {
-		context.getStore(NAMESPACE).put(KEY, this);
+		context.getStore(org.junit.jupiter.params.ParameterInfo.NAMESPACE) //
+				.put(org.junit.jupiter.params.ParameterInfo.KEY, this);
+		context.getStore(org.junit.jupiter.params.support.ParameterInfo.NAMESPACE) //
+				.put(org.junit.jupiter.params.support.ParameterInfo.KEY, this);
 	}
+
 }

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterInfo.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterInfo.java
@@ -8,9 +8,9 @@
  * https://www.eclipse.org/legal/epl-v20.html
  */
 
-package org.junit.jupiter.params.support;
+package org.junit.jupiter.params;
 
-import static org.apiguardian.api.API.Status.DEPRECATED;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import org.apiguardian.api.API;
 import org.jspecify.annotations.Nullable;
@@ -18,8 +18,8 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.extension.Extension;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
-import org.junit.jupiter.params.ParameterizedClass;
-import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.aggregator.ArgumentsAccessor;
+import org.junit.jupiter.params.support.ParameterDeclarations;
 
 /**
  * {@code ParameterInfo} is used to provide information about the current
@@ -44,46 +44,41 @@ import org.junit.jupiter.params.ParameterizedTest;
  * retrieving the {@code ParameterInfo} instance from the
  * {@link ExtensionContext.Store Store}.
  *
- * @since 5.13
+ * @since 6.0
  * @see ParameterizedClass
  * @see ParameterizedTest
- * @deprecated Please use {@link org.junit.jupiter.params.ParameterInfo} instead
  */
-@Deprecated(since = "6.0", forRemoval = true)
-@API(status = DEPRECATED, since = "6.0")
-public interface ParameterInfo extends org.junit.jupiter.params.ParameterInfo {
+@API(status = EXPERIMENTAL, since = "6.0")
+public interface ParameterInfo {
 
 	/**
 	 * The {@link Namespace} for accessing the
 	 * {@link ExtensionContext.Store Store} for {@code ParameterInfo}.
-	 * @deprecated Please use
-	 * {@link org.junit.jupiter.params.ParameterInfo#NAMESPACE} instead
 	 */
-	@Deprecated(since = "6.0", forRemoval = true)
-	@API(status = DEPRECATED, since = "6.0")
 	Namespace NAMESPACE = Namespace.create(ParameterInfo.class);
 
 	/**
 	 * The key for retrieving the {@code ParameterInfo} instance from the
 	 * {@link ExtensionContext.Store Store}.
-	 * @deprecated Please use
-	 * {@link org.junit.jupiter.params.ParameterInfo#KEY} instead
 	 */
-	@Deprecated(since = "6.0", forRemoval = true)
-	@API(status = DEPRECATED, since = "6.0")
 	Object KEY = ParameterInfo.class;
 
 	/**
 	 * {@return the closest {@code ParameterInfo} instance for the supplied
 	 * {@code ExtensionContext}; potentially {@code null}}
-	 * @deprecated Please use
-	 * {@link org.junit.jupiter.params.ParameterInfo#get(ExtensionContext)}
-	 * instead
 	 */
-	@Deprecated(since = "6.0", forRemoval = true)
-	@API(status = DEPRECATED, since = "6.0")
 	static @Nullable ParameterInfo get(ExtensionContext context) {
 		return context.getStore(NAMESPACE).get(KEY, ParameterInfo.class);
 	}
+
+	/**
+	 * {@return the declarations of all <em>indexed</em> parameters}
+	 */
+	ParameterDeclarations getDeclarations();
+
+	/**
+	 * {@return the accessor to the arguments of the current invocation}
+	 */
+	ArgumentsAccessor getArguments();
 
 }

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ResolverFacade.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ResolverFacade.java
@@ -58,7 +58,6 @@ import org.junit.jupiter.params.support.AnnotationConsumerInitializer;
 import org.junit.jupiter.params.support.FieldContext;
 import org.junit.jupiter.params.support.ParameterDeclaration;
 import org.junit.jupiter.params.support.ParameterDeclarations;
-import org.junit.jupiter.params.support.ParameterInfo;
 import org.junit.platform.commons.JUnitException;
 import org.junit.platform.commons.PreconditionViolationException;
 import org.junit.platform.commons.function.Try;

--- a/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterInfoIntegrationTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterInfoIntegrationTests.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2015-2025 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.params;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.jspecify.annotations.NullMarked;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.BeforeClassTemplateInvocationCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.engine.AbstractJupiterTestEngineTests;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * @since 6.0
+ */
+class ParameterInfoIntegrationTests extends AbstractJupiterTestEngineTests {
+
+	@Test
+	void storesParameterInfoInExtensionContextStoreOnDifferentLevels() {
+		var results = executeTestsForClass(TestCase.class);
+
+		results.allEvents().debug().assertStatistics(stats -> stats.started(7).succeeded(7));
+	}
+
+	@ParameterizedClass
+	@ValueSource(ints = 1)
+	@ExtendWith(ParameterInfoConsumingExtension.class)
+	record TestCase(int i) {
+
+		@Nested
+		@ParameterizedClass
+		@ValueSource(ints = 2)
+		class Inner {
+
+			@Parameter
+			int j;
+
+			@ParameterizedTest
+			@ValueSource(ints = 3)
+			void test(int k) {
+				assertEquals(1, i);
+				assertEquals(2, j);
+				assertEquals(3, k);
+			}
+		}
+	}
+
+	@NullMarked
+	private static class ParameterInfoConsumingExtension
+			implements BeforeClassTemplateInvocationCallback, BeforeEachCallback {
+
+		@Override
+		public void beforeClassTemplateInvocation(ExtensionContext parameterizedClassInvocationContext) {
+			if (TestCase.Inner.class.equals(parameterizedClassInvocationContext.getRequiredTestClass())) {
+				assertParameterInfo(parameterizedClassInvocationContext, "j", 2);
+
+				var nestedParameterizedClassContext = parameterizedClassInvocationContext.getParent().orElseThrow();
+				assertParameterInfo(nestedParameterizedClassContext, "i", 1);
+
+				parameterizedClassInvocationContext = nestedParameterizedClassContext.getParent().orElseThrow();
+			}
+
+			assertParameterInfo(parameterizedClassInvocationContext, "i", 1);
+
+			var outerParameterizedClassContext = parameterizedClassInvocationContext.getParent().orElseThrow();
+			assertNull(ParameterInfo.get(outerParameterizedClassContext));
+		}
+
+		@Override
+		public void beforeEach(ExtensionContext parameterizedTestInvocationContext) {
+			assertParameterInfo(parameterizedTestInvocationContext, "k", 3);
+
+			var parameterizedTestContext = parameterizedTestInvocationContext.getParent().orElseThrow();
+			assertParameterInfo(parameterizedTestContext, "j", 2);
+
+			var nestedParameterizedClassInvocationContext = parameterizedTestContext.getParent().orElseThrow();
+			assertParameterInfo(nestedParameterizedClassInvocationContext, "j", 2);
+
+			var nestedParameterizedClassContext = nestedParameterizedClassInvocationContext.getParent().orElseThrow();
+			assertParameterInfo(nestedParameterizedClassContext, "i", 1);
+
+			var outerParameterizedClassInvocationContext = nestedParameterizedClassContext.getParent().orElseThrow();
+			assertParameterInfo(outerParameterizedClassInvocationContext, "i", 1);
+
+			var outerParameterizedClassContext = outerParameterizedClassInvocationContext.getParent().orElseThrow();
+			assertNull(ParameterInfo.get(outerParameterizedClassContext));
+		}
+
+		private static void assertParameterInfo(ExtensionContext context, String parameterName, int argumentValue) {
+			var parameterInfo = ParameterInfo.get(context);
+			assertNotNull(parameterInfo);
+			var declaration = parameterInfo.getDeclarations().get(0).orElseThrow();
+			assertEquals(parameterName, declaration.getParameterName().orElseThrow());
+			assertEquals(int.class, declaration.getParameterType());
+			assertEquals(argumentValue, parameterInfo.getArguments().getInteger(0));
+		}
+	}
+}

--- a/jupiter-tests/src/test/java/org/junit/jupiter/params/support/DeprecatedParameterInfoIntegrationTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/params/support/DeprecatedParameterInfoIntegrationTests.java
@@ -14,6 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import org.jspecify.annotations.NullMarked;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.BeforeClassTemplateInvocationCallback;
@@ -29,7 +30,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 /**
  * @since 5.13
  */
-class ParameterInfoIntegrationTests extends AbstractJupiterTestEngineTests {
+class DeprecatedParameterInfoIntegrationTests extends AbstractJupiterTestEngineTests {
 
 	@Test
 	void storesParameterInfoInExtensionContextStoreOnDifferentLevels() {
@@ -61,6 +62,8 @@ class ParameterInfoIntegrationTests extends AbstractJupiterTestEngineTests {
 		}
 	}
 
+	@SuppressWarnings("removal")
+	@NullMarked
 	private static class ParameterInfoConsumingExtension
 			implements BeforeClassTemplateInvocationCallback, BeforeEachCallback {
 

--- a/platform-tooling-support-tests/src/archUnit/java/platform/tooling/support/tests/ArchUnitTests.java
+++ b/platform-tooling-support-tests/src/archUnit/java/platform/tooling/support/tests/ArchUnitTests.java
@@ -63,8 +63,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.TestReporter;
 import org.junit.jupiter.api.extension.MediaType;
-import org.junit.jupiter.params.aggregator.ArgumentsAccessor;
-import org.junit.jupiter.params.support.ParameterInfo;
 import org.junit.platform.commons.support.Resource;
 import org.junit.platform.commons.support.scanning.ClasspathScanner;
 import org.junit.platform.commons.util.ModuleUtils;
@@ -157,6 +155,7 @@ class ArchUnitTests {
 		slices().matching("org.junit.(*)..").should().beFreeOfCycles().check(classes);
 	}
 
+	@SuppressWarnings("removal")
 	@ArchTest
 	void freeOfPackageCycles(JavaClasses classes) throws Exception {
 		slices().matching("org.junit.(**)").should().beFreeOfCycles() //
@@ -174,8 +173,9 @@ class ArchUnitTests {
 				.ignoreDependency(Class.forName("org.junit.platform.commons.util.DefaultClasspathScanner"),
 					Resource.class) //
 
-				// Needs more investigation
-				.ignoreDependency(ParameterInfo.class, ArgumentsAccessor.class)
+				// https://github.com/junit-team/junit-framework/issues/4919
+				.ignoreDependency(org.junit.jupiter.params.support.ParameterInfo.class,
+					org.junit.jupiter.params.ParameterInfo.class)
 
 				// Needs more investigation
 				.ignoreDependency(OutputDirectoryProvider.class, TestDescriptor.class) //


### PR DESCRIPTION
Resolves #4919.

<!-- Please describe your changes here and list any open questions you might have. -->

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://docs.junit.org/snapshot/user-guide/) and [Release Notes](https://docs.junit.org/snapshot/user-guide/#release-notes)
