### PR TITLE
Fix 'invalid references' in single-module Javadoc output

### DIFF
--- a/gradle/plugins/common/src/main/kotlin/junitbuild.java-library-conventions.gradle.kts
+++ b/gradle/plugins/common/src/main/kotlin/junitbuild.java-library-conventions.gradle.kts
@@ -64,40 +64,13 @@ java {
 
 if (project in mavenizedProjects) {
 
+	apply(plugin = "junitbuild.javadoc-conventions")
 	apply(plugin = "junitbuild.publishing-conventions")
 	apply(plugin = "junitbuild.osgi-conventions")
 	apply(plugin = "junitbuild.japicmp")
 
 	java {
-		withJavadocJar()
 		withSourcesJar()
-	}
-
-	tasks.javadoc {
-		options {
-			memberLevel = JavadocMemberLevel.PROTECTED
-			header = project.name
-			encoding = "UTF-8"
-			locale = "en"
-			(this as StandardJavadocDocletOptions).apply {
-				addBooleanOption("Xdoclint:all,-missing,-reference", true)
-				addBooleanOption("XD-Xlint:none", true)
-				addBooleanOption("html5", true)
-				addMultilineStringsOption("tag").value = listOf(
-						"apiNote:a:API Note:",
-						"implNote:a:Implementation Note:"
-				)
-				use(true)
-				noTimestamp(true)
-			}
-		}
-	}
-
-	tasks.named<Jar>("javadocJar").configure {
-		from(tasks.javadoc.map { File(it.destinationDir, "element-list") }) {
-			// For compatibility with older tools, e.g. NetBeans 11
-			rename { "package-list" }
-		}
 	}
 
 	tasks.named<Jar>("sourcesJar").configure {

--- a/gradle/plugins/common/src/main/kotlin/junitbuild.javadoc-conventions.gradle.kts
+++ b/gradle/plugins/common/src/main/kotlin/junitbuild.javadoc-conventions.gradle.kts
@@ -1,0 +1,34 @@
+plugins {
+	`java-library`
+}
+
+java {
+	withJavadocJar()
+}
+
+tasks.javadoc {
+	options {
+		memberLevel = JavadocMemberLevel.PROTECTED
+		header = project.name
+		encoding = "UTF-8"
+		locale = "en"
+		(this as StandardJavadocDocletOptions).apply {
+			addBooleanOption("Xdoclint:all,-missing,-reference", true)
+			addBooleanOption("XD-Xlint:none", true)
+			addBooleanOption("html5", true)
+			addMultilineStringsOption("tag").value = listOf(
+				"apiNote:a:API Note:",
+				"implNote:a:Implementation Note:"
+			)
+			use(true)
+			noTimestamp(true)
+		}
+	}
+}
+
+tasks.named<Jar>("javadocJar").configure {
+	from(tasks.javadoc.map { File(it.destinationDir, "element-list") }) {
+		// For compatibility with older tools, e.g. NetBeans 11
+		rename { "package-list" }
+	}
+}

--- a/gradle/plugins/common/src/main/kotlin/junitbuild.javadoc-conventions.gradle.kts
+++ b/gradle/plugins/common/src/main/kotlin/junitbuild.javadoc-conventions.gradle.kts
@@ -14,16 +14,15 @@ tasks.javadoc {
 		locale = "en"
 		(this as StandardJavadocDocletOptions).apply {
 			addBooleanOption("Xdoclint:all,-missing,-reference", true)
-			addBooleanOption("XD-Xlint:none", true)
 			addBooleanOption("html5", true)
-			addMultilineStringsOption("tag").value = listOf(
-				"apiNote:a:API Note:",
-				"implNote:a:Implementation Note:"
-			)
-			use(true)
-			noTimestamp(true)
-		}
-	}
+            addMultilineStringsOption("tag").value = listOf(
+                "apiNote:a:API Note:",
+                "implNote:a:Implementation Note:"
+            )
+            use(true)
+            noTimestamp(true)
+        }
+    }
 }
 
 tasks.named<Jar>("javadocJar").configure {

--- a/gradle/plugins/common/src/main/kotlin/junitbuild.javadoc-conventions.gradle.kts
+++ b/gradle/plugins/common/src/main/kotlin/junitbuild.javadoc-conventions.gradle.kts
@@ -1,3 +1,5 @@
+import junitbuild.javadoc.JavadocConventionsExtension
+
 plugins {
 	`java-library`
 }
@@ -6,23 +8,34 @@ java {
 	withJavadocJar()
 }
 
+val javadocReference = configurations.dependencyScope("javadocReference")
+
+val extension = JavadocConventionsExtension(project, javadocReference.get(), tasks.javadoc)
+project.extensions.add("javadocConventions", extension)
+
+val javadocClasspath = configurations.resolvable("javadocClasspath") {
+	extendsFrom(configurations.compileClasspath.get())
+	extendsFrom(javadocReference.get())
+}
+
 tasks.javadoc {
+	classpath = javadocClasspath.get()
 	options {
 		memberLevel = JavadocMemberLevel.PROTECTED
 		header = project.name
 		encoding = "UTF-8"
 		locale = "en"
 		(this as StandardJavadocDocletOptions).apply {
-			addBooleanOption("Xdoclint:all,-missing,-reference", true)
+			addBooleanOption("Xdoclint:all,-missing", true)
 			addBooleanOption("html5", true)
-            addMultilineStringsOption("tag").value = listOf(
-                "apiNote:a:API Note:",
-                "implNote:a:Implementation Note:"
-            )
-            use(true)
-            noTimestamp(true)
-        }
-    }
+			addMultilineStringsOption("tag").value = listOf(
+				"apiNote:a:API Note:",
+				"implNote:a:Implementation Note:"
+			)
+			use(true)
+			noTimestamp(true)
+		}
+	}
 }
 
 tasks.named<Jar>("javadocJar").configure {

--- a/gradle/plugins/common/src/main/kotlin/junitbuild/javadoc/JavadocConventionsExtension.kt
+++ b/gradle/plugins/common/src/main/kotlin/junitbuild/javadoc/JavadocConventionsExtension.kt
@@ -1,0 +1,29 @@
+package junitbuild.javadoc
+
+import junitbuild.extensions.javaModuleName
+import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.ProjectDependency
+import org.gradle.api.tasks.TaskProvider
+import org.gradle.api.tasks.javadoc.Javadoc
+import org.gradle.external.javadoc.StandardJavadocDocletOptions
+import org.gradle.kotlin.dsl.dependencies
+
+class JavadocConventionsExtension(val project: Project, val dependencyScope: Configuration, val task: TaskProvider<Javadoc>) {
+
+    fun addExtraModuleReferences(vararg projectDependencies: ProjectDependency) {
+        project.dependencies {
+            projectDependencies.forEach { dependencyScope(it) }
+        }
+        task.configure {
+            options {
+                (this as StandardJavadocDocletOptions).apply {
+                    val referencedModuleNames = projectDependencies.joinToString(",") { it.javaModuleName }
+                    addStringOption("-add-modules", referencedModuleNames)
+                    addStringOption("-add-reads", "${project.javaModuleName}=$referencedModuleNames")
+                }
+            }
+        }
+    }
+
+}

--- a/junit-jupiter-api/junit-jupiter-api.gradle.kts
+++ b/junit-jupiter-api/junit-jupiter-api.gradle.kts
@@ -24,6 +24,10 @@ dependencies {
 	osgiVerification(projects.junitPlatformLauncher)
 }
 
+javadocConventions {
+	addExtraModuleReferences(projects.junitPlatformEngine, projects.junitPlatformLauncher, projects.junitJupiterParams)
+}
+
 tasks {
 	compileJava {
 		options.compilerArgs.add("-Xlint:-module") // due to qualified exports

--- a/junit-platform-commons/junit-platform-commons.gradle.kts
+++ b/junit-platform-commons/junit-platform-commons.gradle.kts
@@ -21,6 +21,10 @@ dependencies {
 	testFixturesImplementation(libs.assertj)
 }
 
+javadocConventions {
+	addExtraModuleReferences(projects.junitPlatformEngine)
+}
+
 tasks.compileJava {
 	options.compilerArgs.add("-Xlint:-module") // due to qualified exports
 	val moduleName = javaModuleName

--- a/junit-platform-engine/junit-platform-engine.gradle.kts
+++ b/junit-platform-engine/junit-platform-engine.gradle.kts
@@ -19,3 +19,7 @@ dependencies {
 	osgiVerification(projects.junitJupiterEngine)
 	osgiVerification(projects.junitPlatformLauncher)
 }
+
+javadocConventions {
+	addExtraModuleReferences(projects.junitPlatformLauncher)
+}

--- a/junit-platform-launcher/junit-platform-launcher.gradle.kts
+++ b/junit-platform-launcher/junit-platform-launcher.gradle.kts
@@ -16,6 +16,10 @@ dependencies {
 	osgiVerification(projects.junitJupiterEngine)
 }
 
+javadocConventions {
+	addExtraModuleReferences(projects.junitPlatformReporting)
+}
+
 tasks {
 	jar {
 		bundle {

--- a/junit-platform-suite-api/junit-platform-suite-api.gradle.kts
+++ b/junit-platform-suite-api/junit-platform-suite-api.gradle.kts
@@ -15,3 +15,7 @@ dependencies {
 	osgiVerification(projects.junitJupiterEngine)
 	osgiVerification(projects.junitPlatformLauncher)
 }
+
+javadocConventions {
+	addExtraModuleReferences(projects.junitPlatformEngine, projects.junitPlatformLauncher)
+}


### PR DESCRIPTION
- **Extract javadoc-conventions plugin**
- **Remove defunct option**
- **Add referenced modules to Javadoc classpath**

<!-- Please describe your changes here and list any open questions you might have. -->

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://docs.junit.org/snapshot/user-guide/) and [Release Notes](https://docs.junit.org/snapshot/user-guide/#release-notes)
