### PR TITLE
[openrewrite] add `SanityCheck` featuring `tech.picnic.errorprone.refasterrules`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,6 +49,11 @@ jobs:
       uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+    - name: rewriteDryRun
+      uses: ./.github/actions/main-build
+      with:
+        encryptionKey: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+        arguments: rewriteDryRun
 
   Windows:
     runs-on: windows-latest

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
 	id("junitbuild.jacoco-aggregation-conventions")
 	id("junitbuild.maven-central-publishing")
 	id("junitbuild.temp-maven-repo")
+	id("org.openrewrite.rewrite") version "7.17.0" apply false
 }
 
 description = "JUnit"
@@ -54,3 +55,5 @@ dependencies {
 	jacocoAggregation(projects.jupiterTests)
 	jacocoAggregation(projects.platformTests)
 }
+
+apply(from = "$rootDir/gradle/rewrite.gradle")

--- a/gradle/rewrite.gradle
+++ b/gradle/rewrite.gradle
@@ -1,0 +1,16 @@
+apply plugin: "org.openrewrite.rewrite"
+
+rewrite {
+	activeRecipe("org.junit.jupiter.openrewrite.SanityCheck")
+	exportDatatables = true
+	failOnDryRunResults = true
+}
+
+dependencies {
+	rewrite(platform("org.openrewrite.recipe:rewrite-recipe-bom:3.15.0"))
+	rewrite("org.openrewrite.recipe:rewrite-java-security:3.19.0")
+	rewrite("org.openrewrite.recipe:rewrite-migrate-java:3.18.0")
+	rewrite("org.openrewrite.recipe:rewrite-rewrite:0.13.0")
+	rewrite("org.openrewrite.recipe:rewrite-static-analysis:2.18.0")
+	rewrite("org.openrewrite.recipe:rewrite-third-party:0.28.0")
+}

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/UniqueId.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/UniqueId.java
@@ -110,7 +110,7 @@ public final class UniqueId implements Cloneable, Serializable {
 	}
 
 	Optional<Segment> getRoot() {
-		return this.segments.isEmpty() ? Optional.empty() : Optional.of(this.segments.get(0));
+		return this.segments.stream().findFirst();
 	}
 
 	/**

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/DefaultParallelExecutionConfigurationStrategy.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/DefaultParallelExecutionConfigurationStrategy.java
@@ -66,7 +66,7 @@ public enum DefaultParallelExecutionConfigurationStrategy implements ParallelExe
 			BigDecimal factor = configurationParameters.get(CONFIG_DYNAMIC_FACTOR_PROPERTY_NAME,
 				BigDecimal::new).orElse(BigDecimal.ONE);
 
-			Preconditions.condition(factor.compareTo(BigDecimal.ZERO) > 0,
+			Preconditions.condition(factor.signum() == 1,
 				() -> "Factor '%s' specified via configuration parameter '%s' must be greater than 0".formatted(factor,
 					CONFIG_DYNAMIC_FACTOR_PROPERTY_NAME));
 

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/EngineFilter.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/EngineFilter.java
@@ -126,7 +126,7 @@ public class EngineFilter implements Filter<TestEngine> {
 		Preconditions.notBlank(engineId, "TestEngine ID must not be null or blank");
 
 		if (this.type == Type.INCLUDE) {
-			return includedIf(this.engineIds.stream().anyMatch(engineId::equals), //
+			return includedIf(this.engineIds.contains(engineId), //
 				() -> "Engine ID [%s] is in included list [%s]".formatted(engineId, this.engineIds), //
 				() -> "Engine ID [%s] is not in included list [%s]".formatted(engineId, this.engineIds));
 		}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/OutputDir.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/OutputDir.java
@@ -140,7 +140,7 @@ public class OutputDir {
 			return false;
 		};
 		try (Stream<Path> pathStream = Files.find(dir, 1, matcher)) {
-			return pathStream.findFirst().isPresent();
+			return pathStream.findAny().isPresent();
 		}
 	}
 }

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/discovery/predicates/IsTestFactoryMethodTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/discovery/predicates/IsTestFactoryMethodTests.java
@@ -174,7 +174,7 @@ class IsTestFactoryMethodTests {
 
 		@TestFactory
 		Stream<?> unboundStreamFactory() {
-			return Stream.of();
+			return Stream.empty();
 		}
 
 	}

--- a/platform-tests/src/test/java/org/junit/platform/commons/support/conversion/ConversionSupportTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/support/conversion/ConversionSupportTests.java
@@ -268,7 +268,7 @@ class ConversionSupportTests {
 	@Test
 	void convertsStringsToJavaTimeInstances() {
 		assertConverts("PT1234.5678S", Duration.class, Duration.ofSeconds(1234, 567800000));
-		assertConverts("1970-01-01T00:00:00Z", Instant.class, Instant.ofEpochMilli(0));
+		assertConverts("1970-01-01T00:00:00Z", Instant.class, Instant.EPOCH);
 		assertConverts("2017-03-14", LocalDate.class, LocalDate.of(2017, 3, 14));
 		assertConverts("2017-03-14T12:34:56.789", LocalDateTime.class,
 			LocalDateTime.of(2017, 3, 14, 12, 34, 56, 789_000_000));

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/AbstractTestSourceTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/AbstractTestSourceTests.java
@@ -60,7 +60,7 @@ abstract class AbstractTestSourceTests {
 			var serialized = serialize(instance);
 			var deserialized = deserialize(serialized);
 
-			assertTrue(type.isAssignableFrom(deserialized.getClass()));
+			assertTrue(type.isInstance(deserialized));
 			assertEquals(instance, deserialized);
 		}
 		catch (Exception e) {

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/LocalMavenRepo.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/LocalMavenRepo.java
@@ -69,7 +69,7 @@ public class LocalMavenRepo implements AutoCloseable {
 	@Override
 	public void close() throws IOException {
 		try (var files = Files.walk(tempDir)) {
-			files.sorted(Comparator.<Path> naturalOrder().reversed()) //
+			files.sorted(Comparator.reverseOrder()) //
 					.forEach(path -> {
 						try {
 							Files.delete(path);

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/ModularUserGuideTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/ModularUserGuideTests.java
@@ -181,7 +181,7 @@ class ModularUserGuideTests {
 		try (var stream = Files.walk(root)) {
 			stream.map(root::relativize) //
 					.map(path -> path.toString().replace('\\', '/')) //
-					.sorted().filter(Predicate.not(String::isEmpty)) //
+					.filter(Predicate.not(String::isEmpty)).sorted() //
 					.forEach(out);
 		}
 		catch (Exception e) {

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/OutputAttachingExtension.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/OutputAttachingExtension.java
@@ -82,7 +82,7 @@ class OutputAttachingExtension implements ParameterResolver, AfterTestExecutionC
 
 		@Override
 		public void close() throws Exception {
-			try (var stream = Files.walk(root).sorted(Comparator.<Path> naturalOrder().reversed())) {
+			try (var stream = Files.walk(root).sorted(Comparator.reverseOrder())) {
 				stream.forEach(path -> {
 					try {
 						Files.delete(path);

--- a/rewrite.yml
+++ b/rewrite.yml
@@ -1,0 +1,50 @@
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.junit.jupiter.openrewrite.SanityCheck
+displayName: Apply all Java & Gradle best practices
+description: Comprehensive code quality recipe combining modernization, security, and best practices.
+tags:
+  - java
+  - gradle
+  - static-analysis
+  - cleanup
+recipeList:
+  - org.openrewrite.java.security.JavaSecurityBestPractices
+  - org.openrewrite.staticanalysis.NoFinalizer
+  - org.openrewrite.staticanalysis.RemoveUnusedPrivateMethods
+  - tech.picnic.errorprone.refasterrules.BigDecimalRulesRecipes
+  - tech.picnic.errorprone.refasterrules.CharSequenceRulesRecipes
+  - tech.picnic.errorprone.refasterrules.ClassRulesRecipes
+  - tech.picnic.errorprone.refasterrules.CollectionRulesRecipes
+  - tech.picnic.errorprone.refasterrules.ComparatorRulesRecipes
+  - tech.picnic.errorprone.refasterrules.FileRulesRecipes
+  - tech.picnic.errorprone.refasterrules.MicrometerRulesRecipes
+  - tech.picnic.errorprone.refasterrules.PatternRulesRecipes
+  - tech.picnic.errorprone.refasterrules.PreconditionsRulesRecipes
+  - tech.picnic.errorprone.refasterrules.PrimitiveRulesRecipes
+  - tech.picnic.errorprone.refasterrules.StreamRulesRecipes
+  - tech.picnic.errorprone.refasterrules.TimeRulesRecipes
+  # - org.openrewrite.staticanalysis.EqualsAvoidsNull
+  # - org.openrewrite.staticanalysis.ModifierOrder
+  # - org.checkstyle.CheckstyleAutoFix # await release
+  # - org.openrewrite.gradle.GradleBestPractices
+  # - org.openrewrite.java.RemoveUnusedImports
+  # - org.openrewrite.java.format.RemoveTrailingWhitespace
+  # - org.openrewrite.java.migrate.UpgradeToJava17
+  # - org.openrewrite.java.recipes.JavaRecipeBestPractices
+  # - org.openrewrite.java.recipes.RecipeTestingBestPractices
+  # - org.openrewrite.staticanalysis.CodeCleanup # bug
+  # - org.openrewrite.staticanalysis.CommonStaticAnalysis
+  # - org.openrewrite.staticanalysis.JavaApiBestPractices
+  # - org.openrewrite.staticanalysis.LowercasePackage
+  # - org.openrewrite.staticanalysis.MissingOverrideAnnotation
+  # - org.openrewrite.staticanalysis.NoToStringOnStringType
+  # - org.openrewrite.staticanalysis.NoValueOfOnStringType
+  # - org.openrewrite.staticanalysis.RemoveUnusedLocalVariables
+  # - org.openrewrite.staticanalysis.RemoveUnusedPrivateFields
+  # - org.openrewrite.staticanalysis.UnnecessaryCloseInTryWithResources
+  # - org.openrewrite.staticanalysis.UnnecessaryExplicitTypeArguments
+  # - org.openrewrite.staticanalysis.UnnecessaryParentheses
+  # - org.openrewrite.staticanalysis.UnnecessaryReturnAsLastStatement
+  # - org.openrewrite.staticanalysis.UnnecessaryThrows # bug
+---


### PR DESCRIPTION

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://docs.junit.org/snapshot/user-guide/) and [Release Notes](https://docs.junit.org/snapshot/user-guide/#release-notes)



relates to:

- https://github.com/junit-team/junit-framework/issues/5002
- https://github.com/diffplug/spotless/pull/2651


```
> Task :rewriteRun
Changes have been made to junit-platform-engine/src/main/java/org/junit/platform/engine/UniqueId.java by:
    tech.picnic.errorprone.refasterrules.CollectionRulesRecipes
        tech.picnic.errorprone.refasterrules.CollectionRulesRecipes$OptionalFirstCollectionElementRecipe
Changes have been made to junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/DefaultParallelExecutionConfigurationStrategy.java by:
    tech.picnic.errorprone.refasterrules.BigDecimalRulesRecipes
        tech.picnic.errorprone.refasterrules.BigDecimalRulesRecipes$BigDecimalSignumIsPositiveRecipe
Changes have been made to junit-platform-launcher/src/main/java/org/junit/platform/launcher/EngineFilter.java by:
    tech.picnic.errorprone.refasterrules.CollectionRulesRecipes
        tech.picnic.errorprone.refasterrules.CollectionRulesRecipes$CollectionContainsRecipe
Changes have been made to junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/OutputDir.java by:
    tech.picnic.errorprone.refasterrules.StreamRulesRecipes
        tech.picnic.errorprone.refasterrules.StreamRulesRecipes$StreamFindAnyIsPresentRecipe
Changes have been made to jupiter-tests/src/test/java/org/junit/jupiter/engine/discovery/predicates/IsTestFactoryMethodTests.java by:
    tech.picnic.errorprone.refasterrules.StreamRulesRecipes
        tech.picnic.errorprone.refasterrules.StreamRulesRecipes$EmptyStreamRecipe
Changes have been made to platform-tests/src/test/java/org/junit/platform/commons/support/conversion/ConversionSupportTests.java by:
    tech.picnic.errorprone.refasterrules.TimeRulesRecipes
        tech.picnic.errorprone.refasterrules.TimeRulesRecipes$EpochInstantRecipe
Changes have been made to platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/AbstractTestSourceTests.java by:
    tech.picnic.errorprone.refasterrules.ClassRulesRecipes
        tech.picnic.errorprone.refasterrules.ClassRulesRecipes$ClassIsInstanceRecipe
Changes have been made to platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/OutputAttachingExtension.java by:
    tech.picnic.errorprone.refasterrules.ComparatorRulesRecipes
        tech.picnic.errorprone.refasterrules.ComparatorRulesRecipes$ReverseOrderRecipe
Changes have been made to platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/ModularUserGuideTests.java by:
    tech.picnic.errorprone.refasterrules.StreamRulesRecipes
        tech.picnic.errorprone.refasterrules.StreamRulesRecipes$StreamFilterSortedRecipe
Changes have been made to platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/LocalMavenRepo.java by:
    tech.picnic.errorprone.refasterrules.ComparatorRulesRecipes
        tech.picnic.errorprone.refasterrules.ComparatorRulesRecipes$ReverseOrderRecipe
Please review and commit the results.
Estimate time saved: 50m
```