### PR TITLE
Introduce `commentCharacter` property in `@Csv{File}Source`

### DIFF
--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvFileSource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvFileSource.java
@@ -10,6 +10,7 @@
 
 package org.junit.jupiter.params.provider;
 
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.lang.annotation.Documented;
@@ -234,5 +235,18 @@ public @interface CsvFileSource {
 	 */
 	@API(status = STABLE, since = "5.10")
 	boolean ignoreLeadingAndTrailingWhitespace() default true;
+
+	/**
+	 * The character used to denote comments when reading the CSV files.
+	 *
+	 * <p>Any line that begins with this character will be treated as a comment and ignored
+	 * during parsing.
+	 *
+	 * <p>Defaults to a hash tag {@code #}.
+	 *
+	 * @since 6.0.1
+	 */
+	@API(status = EXPERIMENTAL, since = "6.0.1")
+	char commentCharacter() default '#';
 
 }

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvSource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvSource.java
@@ -10,6 +10,7 @@
 
 package org.junit.jupiter.params.provider;
 
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.lang.annotation.Documented;
@@ -295,5 +296,18 @@ public @interface CsvSource {
 	 */
 	@API(status = STABLE, since = "5.10")
 	boolean ignoreLeadingAndTrailingWhitespace() default true;
+
+	/**
+	 * The character used to denote comments in a {@linkplain #textBlock text block}.
+	 *
+	 * <p>Any line that begins with this character will be treated as a comment and ignored
+	 * during parsing.
+	 *
+	 * <p>Defaults to a hash tag {@code #}.
+	 *
+	 * @since 6.0.1
+	 */
+	@API(status = EXPERIMENTAL, since = "6.0.1")
+	char commentCharacter() default '#';
 
 }

--- a/jupiter-tests/src/test/java/org/junit/jupiter/params/provider/MockCsvAnnotationBuilder.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/params/provider/MockCsvAnnotationBuilder.java
@@ -42,6 +42,7 @@ abstract class MockCsvAnnotationBuilder<A extends Annotation, B extends MockCsvA
 	protected String[] nullValues = new String[0];
 	protected int maxCharsPerColumn = 4096;
 	protected boolean ignoreLeadingAndTrailingWhitespace = true;
+	private char commentCharacter = '#';
 
 	private MockCsvAnnotationBuilder() {
 	}
@@ -88,6 +89,11 @@ abstract class MockCsvAnnotationBuilder<A extends Annotation, B extends MockCsvA
 		return getSelf();
 	}
 
+	B commentCharacter(char commentCharacter) {
+		this.commentCharacter = commentCharacter;
+		return getSelf();
+	}
+
 	abstract A build();
 
 	// -------------------------------------------------------------------------
@@ -129,6 +135,7 @@ abstract class MockCsvAnnotationBuilder<A extends Annotation, B extends MockCsvA
 			when(annotation.nullValues()).thenReturn(super.nullValues);
 			when(annotation.maxCharsPerColumn()).thenReturn(super.maxCharsPerColumn);
 			when(annotation.ignoreLeadingAndTrailingWhitespace()).thenReturn(super.ignoreLeadingAndTrailingWhitespace);
+			when(annotation.commentCharacter()).thenReturn(super.commentCharacter);
 
 			// @CsvSource
 			when(annotation.value()).thenReturn(this.lines);
@@ -188,6 +195,7 @@ abstract class MockCsvAnnotationBuilder<A extends Annotation, B extends MockCsvA
 			when(annotation.nullValues()).thenReturn(super.nullValues);
 			when(annotation.maxCharsPerColumn()).thenReturn(super.maxCharsPerColumn);
 			when(annotation.ignoreLeadingAndTrailingWhitespace()).thenReturn(super.ignoreLeadingAndTrailingWhitespace);
+			when(annotation.commentCharacter()).thenReturn(super.commentCharacter);
 
 			// @CsvFileSource
 			when(annotation.resources()).thenReturn(this.resources);


### PR DESCRIPTION
<!-- Please describe your changes here and list any open questions you might have. -->

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://docs.junit.org/snapshot/user-guide/) and [Release Notes](https://docs.junit.org/snapshot/user-guide/#release-notes)
