### PR TITLE
Reliably support `JRE.OTHER` with `@EnabledOnJre` and `@DisabledOnJre`

### DIFF
--- a/junit-jupiter-api/src/templates/resources/main/org/junit/jupiter/api/condition/JRE.java.jte
+++ b/junit-jupiter-api/src/templates/resources/main/org/junit/jupiter/api/condition/JRE.java.jte
@@ -169,17 +169,28 @@ public enum JRE {
 	}
 
 	/**
-	 * {@return {@code true} if the supplied version number is known to be the
-	 * Java Runtime Environment version for the currently executing JVM or if
-	 * the supplied version number is {@code -1} and the current JVM version
-	 * could not be determined}
+	 * Determine if the supplied version number is considered to be the current
+	 * JRE version.
 	 *
+	 * <p>Returns {@code true} if either of the following is {@code true}.
+	 *
+	 * <ul>
+	 * <li>The supplied version number is known to be the Java Runtime Environment
+	 * version for the currently executing JVM.</li>
+	 * <li>The supplied version number is {@link Integer#MAX_VALUE} and the current
+	 * {@code JRE} is {@link JRE#OTHER OTHER}.</li>
+	 * </ul>
+	 *
+	 * @return {@code true} if the supplied version number is considered to be
+	 * the current JRE version
 	 * @since 5.12
 	 * @see Runtime.Version#feature()
+	 * @see #isCurrentVersion()
+	 * @see #currentJre()
 	 */
 	@API(status = MAINTAINED, since = "5.13.3")
 	public static boolean isCurrentVersion(int version) {
-		return version == CURRENT_VERSION;
+		return (version == CURRENT_VERSION) || (version == JRE.currentJre().version);
 	}
 
 	static boolean isCurrentVersionWithinRange(int min, int max) {

--- a/junit-jupiter-api/src/templates/resources/testFixtures/org/junit/jupiter/api/condition/JavaVersionPredicates.java.jte
+++ b/junit-jupiter-api/src/templates/resources/testFixtures/org/junit/jupiter/api/condition/JavaVersionPredicates.java.jte
@@ -19,4 +19,9 @@ public class JavaVersionPredicates {
 		return @for(var jre : ForSupport.of(supportedJres))onJava${jre.get().getVersion()}()@if(!jre.isLast()) //
 				|| @endif@endfor;
 	}
+
+	static boolean onOtherVersion() {
+		return JRE.OTHER.isCurrentVersion();
+	}
+
 }

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/condition/DisabledForJreRangeConditionTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/condition/DisabledForJreRangeConditionTests.java
@@ -14,6 +14,7 @@ import static org.junit.jupiter.api.condition.JavaVersionPredicates.onJava17;
 import static org.junit.jupiter.api.condition.JavaVersionPredicates.onJava18;
 import static org.junit.jupiter.api.condition.JavaVersionPredicates.onJava19;
 import static org.junit.jupiter.api.condition.JavaVersionPredicates.onKnownVersion;
+import static org.junit.jupiter.api.condition.JavaVersionPredicates.onOtherVersion;
 import static org.junit.platform.commons.test.PreconditionAssertions.assertPreconditionViolationFor;
 
 import org.junit.jupiter.api.Test;
@@ -257,7 +258,7 @@ class DisabledForJreRangeConditionTests extends AbstractExecutionConditionTests 
 	@Test
 	void minOtherMaxOther() {
 		evaluateCondition();
-		assertDisabledOnCurrentJreIf(!onKnownVersion());
+		assertDisabledOnCurrentJreIf(!(onKnownVersion() || onOtherVersion()));
 	}
 
 	/**

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/condition/DisabledForJreRangeIntegrationTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/condition/DisabledForJreRangeIntegrationTests.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.condition.JavaVersionPredicates.onJava17;
 import static org.junit.jupiter.api.condition.JavaVersionPredicates.onJava18;
 import static org.junit.jupiter.api.condition.JavaVersionPredicates.onJava19;
 import static org.junit.jupiter.api.condition.JavaVersionPredicates.onKnownVersion;
+import static org.junit.jupiter.api.condition.JavaVersionPredicates.onOtherVersion;
 
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -194,7 +195,7 @@ class DisabledForJreRangeIntegrationTests {
 	@Test
 	@DisabledForJreRange(min = OTHER, max = OTHER)
 	void minOtherMaxOther() {
-		assertTrue(onKnownVersion());
+		assertTrue(onKnownVersion() || onOtherVersion());
 	}
 
 	@Test

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/condition/EnabledForJreRangeConditionTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/condition/EnabledForJreRangeConditionTests.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.condition.JavaVersionPredicates.onJava25;
 import static org.junit.jupiter.api.condition.JavaVersionPredicates.onJava26;
 import static org.junit.jupiter.api.condition.JavaVersionPredicates.onJava27;
 import static org.junit.jupiter.api.condition.JavaVersionPredicates.onKnownVersion;
+import static org.junit.jupiter.api.condition.JavaVersionPredicates.onOtherVersion;
 import static org.junit.platform.commons.test.PreconditionAssertions.assertPreconditionViolationFor;
 
 import org.junit.jupiter.api.Test;
@@ -197,7 +198,7 @@ class EnabledForJreRangeConditionTests extends AbstractExecutionConditionTests {
 	void min20() {
 		evaluateCondition();
 		assertEnabledOnCurrentJreIf(onJava20() || onJava21() || onJava22() || onJava23() || onJava24() || onJava25()
-				|| onJava26() || onJava27());
+				|| onJava26() || onJava27() || onOtherVersion());
 	}
 
 	/**
@@ -305,8 +306,8 @@ class EnabledForJreRangeConditionTests extends AbstractExecutionConditionTests {
 	@Test
 	void minVersion21MaxVersionMaxInteger() {
 		evaluateCondition();
-		assertEnabledOnCurrentJreIf(
-			onJava21() || onJava22() || onJava23() || onJava24() || onJava25() || onJava26() || onJava27());
+		assertEnabledOnCurrentJreIf(onJava21() || onJava22() || onJava23() || onJava24() || onJava25() || onJava26()
+				|| onJava27() || onOtherVersion());
 	}
 
 	/**
@@ -315,7 +316,7 @@ class EnabledForJreRangeConditionTests extends AbstractExecutionConditionTests {
 	@Test
 	void minOtherMaxOther() {
 		evaluateCondition();
-		assertEnabledOnCurrentJreIf(!onKnownVersion());
+		assertEnabledOnCurrentJreIf(!(onKnownVersion() || onOtherVersion()));
 	}
 
 	/**

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/condition/EnabledForJreRangeIntegrationTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/condition/EnabledForJreRangeIntegrationTests.java
@@ -26,6 +26,7 @@ import static org.junit.jupiter.api.condition.JavaVersionPredicates.onJava21;
 import static org.junit.jupiter.api.condition.JavaVersionPredicates.onJava22;
 import static org.junit.jupiter.api.condition.JavaVersionPredicates.onJava23;
 import static org.junit.jupiter.api.condition.JavaVersionPredicates.onKnownVersion;
+import static org.junit.jupiter.api.condition.JavaVersionPredicates.onOtherVersion;
 
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -152,7 +153,7 @@ class EnabledForJreRangeIntegrationTests {
 	@Test
 	@EnabledForJreRange(min = JAVA_20)
 	void min20() {
-		assertTrue(onKnownVersion());
+		assertTrue(onKnownVersion() || onOtherVersion());
 		assertTrue(JRE.currentVersionNumber() >= 20);
 		assertTrue(CURRENT_JRE.compareTo(JAVA_20) >= 0);
 		assertTrue(CURRENT_JRE.version() >= 20);
@@ -241,7 +242,7 @@ class EnabledForJreRangeIntegrationTests {
 	@Test
 	@EnabledForJreRange(minVersion = 21, maxVersion = Integer.MAX_VALUE)
 	void minVersion21MaxVersionMaxInteger() {
-		assertTrue(onKnownVersion());
+		assertTrue(onKnownVersion() || onOtherVersion());
 		assertTrue(JRE.currentVersionNumber() >= 21);
 	}
 


### PR DESCRIPTION
## Overview

In JUnit Jupiter 5.12, I added support for arbitrary Java versions with JRE conditions; however, I accidentally introduced a regression regarding `JRE.OTHER`. Specifically, prior to this commit, `JRE.OTHER` no longer worked reliably when used with `@EnabledOnJre` and `@DisabledOnJre`.

To address that, this commit revises the logic in `JRE.isCurrentVersion(int)` to account for situations where the supplied version value is `Integer.MAX_VALUE` (representing `@EnabledOnJre(OTHER)` or `@DisabledOnJre(OTHER)`), and the current version of the JVM is greater than the version of the last `JRE.JAVA_*` enum constant — for example, when running on Java 27 and the last JRE enum constant is `JAVA_26`.

## Related Issues

- #3930
- #5341
- #5364

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] Change is documented in the [Release Notes](https://docs.junit.org/snapshot/release-notes.html)
