### PR TITLE
Include full display name in legacy XML reports

### DIFF
--- a/documentation/modules/ROOT/partials/release-notes/release-notes-6.1.0-M2.adoc
+++ b/documentation/modules/ROOT/partials/release-notes/release-notes-6.1.0-M2.adoc
@@ -47,8 +47,10 @@ repository on GitHub.
 * Recursive updates are now supported when using `computeIfAbsent(K, Function, Class)` in
   the `ExtensionContext.Store`, providing parity with the deprecated
   `getOrComputeIfAbsent(K, Function, Class)` method.
-* Include index of `@ClassTemplate`/`@ParameterizedClass` invocations in test names in
-  legacy XML reports to make them unique
+* Legacy XML reports now include the index of `@ClassTemplate`/`@ParameterizedClass`
+  invocations in test names in legacy XML reports to make them unique
+* Legacy XML reports now include parent display names to make it easier to distinguish
+  between invocations for different parameters
 
 [[v6.1.0-M2-junit-jupiter-deprecations-and-breaking-changes]]
 ==== Deprecations and Breaking Changes

--- a/junit-platform-reporting/src/main/java/org/junit/platform/reporting/legacy/xml/XmlReportWriter.java
+++ b/junit-platform-reporting/src/main/java/org/junit/platform/reporting/legacy/xml/XmlReportWriter.java
@@ -18,6 +18,7 @@ import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.counting;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.mapping;
+import static java.util.stream.Collectors.toCollection;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 import static org.junit.platform.commons.util.ExceptionUtils.readStackTrace;
@@ -36,6 +37,7 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.text.NumberFormat;
 import java.time.LocalDateTime;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumSet;
@@ -44,10 +46,12 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.TreeSet;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
@@ -111,8 +115,8 @@ class XmlReportWriter {
 	private void writeXmlReport(TestIdentifier testIdentifier, Map<TestIdentifier, AggregatedTestResult> tests,
 			Writer out) throws XMLStreamException {
 
-		try (XmlReport report = new XmlReport(out)) {
-			report.write(testIdentifier, tests);
+		try (var report = new XmlReport(out)) {
+			report.write(testIdentifier, tests, this.reportData.getTestPlan());
 		}
 	}
 
@@ -127,16 +131,16 @@ class XmlReportWriter {
 			this.xml = factory.createXMLStreamWriter(this.out);
 		}
 
-		void write(TestIdentifier testIdentifier, Map<TestIdentifier, AggregatedTestResult> tests)
+		void write(TestIdentifier testIdentifier, Map<TestIdentifier, AggregatedTestResult> tests, TestPlan testPlan)
 				throws XMLStreamException {
 			xml.writeStartDocument("UTF-8", "1.0");
 			newLine();
-			writeTestsuite(testIdentifier, tests);
+			writeTestsuite(testIdentifier, tests, testPlan);
 			xml.writeEndDocument();
 		}
 
-		private void writeTestsuite(TestIdentifier testIdentifier, Map<TestIdentifier, AggregatedTestResult> tests)
-				throws XMLStreamException {
+		private void writeTestsuite(TestIdentifier testIdentifier, Map<TestIdentifier, AggregatedTestResult> tests,
+				TestPlan testPlan) throws XMLStreamException {
 
 			// NumberFormat is not thread-safe. Thus, we instantiate it here and pass it to
 			// writeTestcase instead of using a constant
@@ -150,10 +154,10 @@ class XmlReportWriter {
 			writeSystemProperties();
 
 			for (Entry<TestIdentifier, AggregatedTestResult> entry : tests.entrySet()) {
-				writeTestcase(entry.getKey(), entry.getValue(), numberFormat);
+				writeTestcase(entry.getKey(), entry.getValue(), numberFormat, testPlan);
 			}
 
-			writeOutputElement("system-out", formatNonStandardAttributesAsString(testIdentifier));
+			writeOutputElement("system-out", formatNonStandardAttributesAsString(testIdentifier, testPlan));
 
 			xml.writeEndElement();
 			newLine();
@@ -194,7 +198,7 @@ class XmlReportWriter {
 		}
 
 		private void writeTestcase(TestIdentifier testIdentifier, AggregatedTestResult testResult,
-				NumberFormat numberFormat) throws XMLStreamException {
+				NumberFormat numberFormat, TestPlan testPlan) throws XMLStreamException {
 
 			xml.writeStartElement("testcase");
 
@@ -207,7 +211,7 @@ class XmlReportWriter {
 
 			List<String> systemOutElements = new ArrayList<>();
 			List<String> systemErrElements = new ArrayList<>();
-			systemOutElements.add(formatNonStandardAttributesAsString(testIdentifier));
+			systemOutElements.add(formatNonStandardAttributesAsString(testIdentifier, testPlan));
 			collectReportEntries(testIdentifier, systemOutElements, systemErrElements);
 			writeOutputElements("system-out", systemOutElements);
 			writeOutputElements("system-err", systemErrElements);
@@ -330,9 +334,18 @@ class XmlReportWriter {
 			return LocalDateTime.now(reportData.getClock()).withNano(0);
 		}
 
-		private String formatNonStandardAttributesAsString(TestIdentifier testIdentifier) {
+		private String formatNonStandardAttributesAsString(TestIdentifier testIdentifier, TestPlan testPlan) {
+			var allDisplayNames = getSelfAndAncestors(testIdentifier, testPlan) //
+					.map(TestIdentifier::getDisplayName) //
+					.collect(toCollection(ArrayDeque::new));
+			var fullDisplayName = String.join(" > ", (Iterable<String>) allDisplayNames::descendingIterator);
 			return "unique-id: " + testIdentifier.getUniqueId() //
-					+ "\ndisplay-name: " + testIdentifier.getDisplayName();
+					+ "\ndisplay-name: " + fullDisplayName;
+		}
+
+		@SuppressWarnings({ "DataFlowIssue", "ConstantValue" })
+		private Stream<TestIdentifier> getSelfAndAncestors(TestIdentifier testIdentifier, TestPlan testPlan) {
+			return Stream.iterate(testIdentifier, Objects::nonNull, it -> testPlan.getParent(it).orElse(null));
 		}
 
 		private void writeOutputElements(String elementName, List<String> elements) throws XMLStreamException {

--- a/platform-tests/src/test/java/org/junit/platform/reporting/legacy/xml/LegacyXmlReportGeneratingListenerTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/reporting/legacy/xml/LegacyXmlReportGeneratingListenerTests.java
@@ -90,7 +90,7 @@ class LegacyXmlReportGeneratingListenerTests {
 		assertThat(testcase.attr("classname")).isEqualTo("dummy");
 		assertThat(testcase.child("system-out").text()) //
 				.containsSubsequence("unique-id: [engine:dummy]/[test:succeedingTest]",
-					"display-name: display<-->Name 😎");
+					"display-name: dummy > display<-->Name 😎");
 
 		assertThat(testsuite.find("skipped")).isEmpty();
 		assertThat(testsuite.find("failure")).isEmpty();
@@ -313,7 +313,7 @@ class LegacyXmlReportGeneratingListenerTests {
 				}
 			}, "child");
 		container.addChild(new DemoHierarchicalTestDescriptor(container.getUniqueId().append("test", "someTest"),
-			"someTest", (c, t) -> {
+			"someTest", (_, _) -> {
 			}));
 
 		executeTests(engine);

--- a/platform-tests/src/test/java/org/junit/platform/reporting/legacy/xml/XmlReportWriterTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/reporting/legacy/xml/XmlReportWriterTests.java
@@ -35,6 +35,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import org.joox.Match;
+import org.jspecify.annotations.NullMarked;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.util.SetSystemProperty;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -92,9 +93,14 @@ class XmlReportWriterTests {
 
 	@Test
 	void writesCapturedOutput() throws Exception {
-		var uniqueId = engineDescriptor.getUniqueId().append("test", "test");
-		var testDescriptor = new TestDescriptorStub(uniqueId, "successfulTest");
-		engineDescriptor.addChild(testDescriptor);
+		var classDescriptor = new TestDescriptorStub(engineDescriptor.getUniqueId().append("class", "SomeClass"),
+			"SomeClass");
+		engineDescriptor.addChild(classDescriptor);
+
+		var testDescriptor = new TestDescriptorStub(classDescriptor.getUniqueId().append("test", "successfulTest"),
+			"successfulTest");
+		classDescriptor.addChild(testDescriptor);
+
 		var testPlan = TestPlan.from(true, Set.of(engineDescriptor), configParams, dummyOutputDirectoryCreator());
 
 		var reportData = new XmlReportData(testPlan, Clock.systemDefaultZone());
@@ -104,13 +110,14 @@ class XmlReportWriterTests {
 			"foo", "bar"));
 		reportData.addReportEntry(TestIdentifier.from(testDescriptor), reportEntry);
 		reportData.addReportEntry(TestIdentifier.from(testDescriptor), ReportEntry.from(Map.of("baz", "qux")));
-		reportData.markFinished(testPlan.getTestIdentifier(uniqueId), successful());
+		reportData.markFinished(testPlan.getTestIdentifier(testDescriptor.getUniqueId()), successful());
 
 		var testsuite = writeXmlReport(testPlan, reportData);
 
 		assertValidAccordingToJenkinsSchema(testsuite.document());
 		assertThat(testsuite.find("system-out").text(0)) //
-				.containsSubsequence("unique-id: ", "test:test", "display-name: successfulTest");
+				.containsSubsequence("unique-id: [engine:engine]/[class:SomeClass]/[test:successfulTest]",
+					"display-name: Engine > SomeClass > successfulTest");
 		assertThat(testsuite.find("system-out").text(1)) //
 				.containsSubsequence("Report Entry #1 (timestamp: ", "- foo: bar", "Report Entry #2 (timestamp: ",
 					"- baz: qux");
@@ -140,6 +147,7 @@ class XmlReportWriterTests {
 	}
 
 	@Test
+	@NullMarked
 	void writesEmptyErrorElementForFailedTestWithoutCause() throws Exception {
 		engineDescriptor = new EngineDescriptor(UniqueId.forEngine("myEngineId"), "Fancy Engine") {
 			@Override


### PR DESCRIPTION
Rather than just including the display name of the test, the display
names of all ancestors are now included as well, separated by the `>`
character. This includes display names of parents otherwise not
represented in the legacy XML format (for example, the invocation of a
`@ParameterizedClass`).

Resolves #5409.
