### PR TITLE
Include class template invocation index in legacy reporting names (Backport to 5.14)

### DIFF
--- a/documentation/modules/ROOT/pages/release-notes.adoc
+++ b/documentation/modules/ROOT/pages/release-notes.adoc
@@ -9,6 +9,8 @@ Please refer to the xref:overview.adoc[User Guide] for comprehensive
 reference documentation for programmers writing tests, extension authors, and engine
 authors as well as build tool and IDE vendors.
 
+include::partial$release-notes/release-notes-5.14.4.adoc[]
+
 include::partial$release-notes/release-notes-5.14.3.adoc[]
 
 include::partial$release-notes/release-notes-5.14.2.adoc[]

--- a/documentation/modules/ROOT/partials/release-notes/release-notes-5.14.4.adoc
+++ b/documentation/modules/ROOT/partials/release-notes/release-notes-5.14.4.adoc
@@ -24,6 +24,8 @@ No changes.
 
 * Include index of `@ClassTemplate`/`@ParameterizedClass` invocations in test names in
   legacy XML reports to make them unique.
+* Legacy XML reports now include parent display names to make it easier to distinguish
+  between invocations for different parameters.
 
 
 [[v5.14.4-junit-vintage]]

--- a/documentation/modules/ROOT/partials/release-notes/release-notes-5.14.4.adoc
+++ b/documentation/modules/ROOT/partials/release-notes/release-notes-5.14.4.adoc
@@ -1,0 +1,32 @@
+[[v5.14.4]]
+== 5.14.4
+
+*Date of Release:* ❓
+
+*Scope:* Bug fix for legacy XML reporting of `@ClassTemplate`/`@ParameterizedClass` tests
+
+For a complete list of all _closed_ issues and pull requests for this release, consult the
+link:{junit-framework-repo}+/milestone/MILESTONE_NUMBER?closed=1+[5.14.4] milestone page in the JUnit
+repository on GitHub.
+
+
+[[v5.14.4-junit-platform]]
+=== JUnit Platform
+
+No changes.
+
+
+[[v5.14.4-junit-jupiter]]
+=== JUnit Jupiter
+
+[[v5.14.4-junit-jupiter-bug-fixes]]
+==== Bug Fixes
+
+* Include index of `@ClassTemplate`/`@ParameterizedClass` invocations in test names in
+  legacy XML reports to make them unique.
+
+
+[[v5.14.4-junit-vintage]]
+=== JUnit Vintage
+
+No changes.

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassBasedTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassBasedTestDescriptor.java
@@ -126,7 +126,7 @@ public abstract class ClassBasedTestDescriptor extends JupiterTestDescriptor
 	}
 
 	@Override
-	public final String getLegacyReportingName() {
+	protected final String getLegacyReportingBaseName() {
 		return getTestClass().getName();
 	}
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassTemplateInvocationTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassTemplateInvocationTestDescriptor.java
@@ -18,6 +18,7 @@ import static org.junit.jupiter.engine.extension.MutableExtensionRegistry.create
 import static org.junit.jupiter.engine.support.JupiterThrowableCollectorFactory.createThrowableCollector;
 
 import java.util.List;
+import java.util.OptionalInt;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
@@ -80,8 +81,13 @@ public class ClassTemplateInvocationTestDescriptor extends JupiterTestDescriptor
 	}
 
 	@Override
-	public String getLegacyReportingName() {
-		return getTestClass().getName() + "[" + index + "]";
+	protected String getLegacyReportingBaseName() {
+		return getTestClass().getName();
+	}
+
+	@Override
+	protected OptionalInt getLegacyReportingIndex() {
+		return OptionalInt.of(index);
 	}
 
 	// --- TestClassAware ------------------------------------------------------

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DynamicNodeTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DynamicNodeTestDescriptor.java
@@ -10,6 +10,8 @@
 
 package org.junit.jupiter.engine.descriptor;
 
+import java.util.OptionalInt;
+
 import org.junit.jupiter.api.DynamicNode;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.engine.config.JupiterConfiguration;
@@ -34,13 +36,22 @@ abstract class DynamicNodeTestDescriptor extends JupiterTestDescriptor {
 	}
 
 	@Override
-	public String getLegacyReportingName() {
+	protected final String getLegacyReportingBaseName() {
 		// @formatter:off
 		return getParent()
-				.map(TestDescriptor::getLegacyReportingName)
-				.orElseGet(this::getDisplayName)
-						+ "[" + index + "]";
+				.map(parent -> {
+					if (parent instanceof JupiterTestDescriptor) {
+						return ((JupiterTestDescriptor) parent).getLegacyReportingBaseName();
+					}
+					return parent.getLegacyReportingName();
+				})
+				.orElseGet(this::getDisplayName);
 		// @formatter:on
+	}
+
+	@Override
+	protected OptionalInt getLegacyReportingIndex() {
+		return OptionalInt.of(index);
 	}
 
 	@Override

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/JupiterTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/JupiterTestDescriptor.java
@@ -12,6 +12,7 @@ package org.junit.jupiter.engine.descriptor;
 
 import static java.util.Collections.emptySet;
 import static java.util.stream.Collectors.collectingAndThen;
+import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toCollection;
 import static java.util.stream.Collectors.toSet;
 import static org.apiguardian.api.API.Status.INTERNAL;
@@ -24,11 +25,13 @@ import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
+import java.util.stream.IntStream;
 
 import org.apiguardian.api.API;
 import org.junit.jupiter.api.Tag;
@@ -76,6 +79,35 @@ public abstract class JupiterTestDescriptor extends AbstractTestDescriptor
 	}
 
 	// --- TestDescriptor ------------------------------------------------------
+
+	@Override
+	public final String getLegacyReportingName() {
+		return getLegacyReportingBaseName()
+				+ getLegacyReportingIndexes().mapToObj(i -> "[" + i + "]").collect(joining());
+	}
+
+	protected String getLegacyReportingBaseName() {
+		return getDisplayName();
+	}
+
+	private IntStream getLegacyReportingIndexes() {
+		OptionalInt ownIndex = getLegacyReportingIndex();
+		return getParent() //
+				.map(it -> it instanceof JupiterTestDescriptor //
+						? ((JupiterTestDescriptor) it).getLegacyReportingIndexes() //
+						: null) //
+				.map(parentIndexes -> IntStream.concat(parentIndexes, asStream(ownIndex))) //
+				.orElse(asStream(ownIndex));
+	}
+
+	private IntStream asStream(final OptionalInt optInt) {
+		return optInt.isPresent() ? IntStream.of(optInt.getAsInt()) : IntStream.empty();
+
+	}
+
+	protected OptionalInt getLegacyReportingIndex() {
+		return OptionalInt.empty();
+	}
 
 	static Set<TestTag> getTags(AnnotatedElement element, Supplier<String> elementDescription,
 			Supplier<TestSource> sourceProvider, Consumer<DiscoveryIssue> issueCollector) {

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/MethodBasedTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/MethodBasedTestDescriptor.java
@@ -87,7 +87,7 @@ public abstract class MethodBasedTestDescriptor extends JupiterTestDescriptor
 	}
 
 	@Override
-	public String getLegacyReportingName() {
+	protected final String getLegacyReportingBaseName() {
 		return String.format("%s(%s)", getTestMethod().getName(),
 			ClassUtils.nullSafeToString(Class::getSimpleName, getTestMethod().getParameterTypes()));
 	}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateInvocationTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateInvocationTestDescriptor.java
@@ -14,6 +14,7 @@ import static java.util.Collections.emptySet;
 import static org.apiguardian.api.API.Status.INTERNAL;
 
 import java.lang.reflect.Method;
+import java.util.OptionalInt;
 import java.util.Set;
 import java.util.function.UnaryOperator;
 
@@ -70,8 +71,8 @@ public class TestTemplateInvocationTestDescriptor extends TestMethodTestDescript
 	}
 
 	@Override
-	public String getLegacyReportingName() {
-		return super.getLegacyReportingName() + "[" + index + "]";
+	protected OptionalInt getLegacyReportingIndex() {
+		return OptionalInt.of(index);
 	}
 
 	@Override

--- a/junit-platform-reporting/src/main/java/org/junit/platform/reporting/legacy/xml/XmlReportWriter.java
+++ b/junit-platform-reporting/src/main/java/org/junit/platform/reporting/legacy/xml/XmlReportWriter.java
@@ -37,6 +37,7 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.text.NumberFormat;
 import java.time.LocalDateTime;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumSet;
@@ -116,7 +117,7 @@ class XmlReportWriter {
 			Writer out) throws XMLStreamException {
 
 		try (XmlReport report = new XmlReport(out)) {
-			report.write(testIdentifier, tests);
+			report.write(testIdentifier, tests, this.reportData.getTestPlan());
 		}
 	}
 
@@ -131,16 +132,16 @@ class XmlReportWriter {
 			this.xml = factory.createXMLStreamWriter(this.out);
 		}
 
-		void write(TestIdentifier testIdentifier, Map<TestIdentifier, AggregatedTestResult> tests)
+		void write(TestIdentifier testIdentifier, Map<TestIdentifier, AggregatedTestResult> tests, TestPlan testPlan)
 				throws XMLStreamException {
 			xml.writeStartDocument("UTF-8", "1.0");
 			newLine();
-			writeTestsuite(testIdentifier, tests);
+			writeTestsuite(testIdentifier, tests, testPlan);
 			xml.writeEndDocument();
 		}
 
-		private void writeTestsuite(TestIdentifier testIdentifier, Map<TestIdentifier, AggregatedTestResult> tests)
-				throws XMLStreamException {
+		private void writeTestsuite(TestIdentifier testIdentifier, Map<TestIdentifier, AggregatedTestResult> tests,
+				TestPlan testPlan) throws XMLStreamException {
 
 			// NumberFormat is not thread-safe. Thus, we instantiate it here and pass it to
 			// writeTestcase instead of using a constant
@@ -154,10 +155,10 @@ class XmlReportWriter {
 			writeSystemProperties();
 
 			for (Entry<TestIdentifier, AggregatedTestResult> entry : tests.entrySet()) {
-				writeTestcase(entry.getKey(), entry.getValue(), numberFormat);
+				writeTestcase(entry.getKey(), entry.getValue(), numberFormat, testPlan);
 			}
 
-			writeOutputElement("system-out", formatNonStandardAttributesAsString(testIdentifier));
+			writeOutputElement("system-out", formatNonStandardAttributesAsString(testIdentifier, testPlan));
 
 			xml.writeEndElement();
 			newLine();
@@ -198,7 +199,7 @@ class XmlReportWriter {
 		}
 
 		private void writeTestcase(TestIdentifier testIdentifier, AggregatedTestResult testResult,
-				NumberFormat numberFormat) throws XMLStreamException {
+				NumberFormat numberFormat, TestPlan testPlan) throws XMLStreamException {
 
 			xml.writeStartElement("testcase");
 
@@ -211,7 +212,7 @@ class XmlReportWriter {
 
 			List<String> systemOutElements = new ArrayList<>();
 			List<String> systemErrElements = new ArrayList<>();
-			systemOutElements.add(formatNonStandardAttributesAsString(testIdentifier));
+			systemOutElements.add(formatNonStandardAttributesAsString(testIdentifier, testPlan));
 			collectReportEntries(testIdentifier, systemOutElements, systemErrElements);
 			writeOutputElements("system-out", systemOutElements);
 			writeOutputElements("system-err", systemErrElements);
@@ -334,9 +335,16 @@ class XmlReportWriter {
 			return LocalDateTime.now(reportData.getClock()).withNano(0);
 		}
 
-		private String formatNonStandardAttributesAsString(TestIdentifier testIdentifier) {
+		private String formatNonStandardAttributesAsString(TestIdentifier testIdentifier, TestPlan testPlan) {
+			ArrayDeque<String> displayNames = new ArrayDeque<>();
+			TestIdentifier current = testIdentifier;
+			while (current != null) {
+				displayNames.push(current.getDisplayName());
+				current = testPlan.getParent(current).orElse(null);
+			}
+			String fullDisplayName = String.join(" > ", displayNames);
 			return "unique-id: " + testIdentifier.getUniqueId() //
-					+ "\ndisplay-name: " + testIdentifier.getDisplayName();
+					+ "\ndisplay-name: " + fullDisplayName;
 		}
 
 		private void writeOutputElements(String elementName, List<String> elements) throws XMLStreamException {

--- a/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedClassIntegrationTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedClassIntegrationTests.java
@@ -37,6 +37,7 @@ import static org.junit.platform.testkit.engine.EventConditions.engine;
 import static org.junit.platform.testkit.engine.EventConditions.event;
 import static org.junit.platform.testkit.engine.EventConditions.finishedSuccessfully;
 import static org.junit.platform.testkit.engine.EventConditions.finishedWithFailure;
+import static org.junit.platform.testkit.engine.EventConditions.legacyReportingName;
 import static org.junit.platform.testkit.engine.EventConditions.started;
 import static org.junit.platform.testkit.engine.EventConditions.test;
 import static org.junit.platform.testkit.engine.EventConditions.uniqueId;
@@ -106,6 +107,7 @@ import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.reporting.ReportEntry;
 import org.junit.platform.testkit.engine.EngineExecutionResults;
 import org.junit.platform.testkit.engine.Event;
+import org.junit.platform.testkit.engine.EventType;
 import org.junit.platform.testkit.engine.Events;
 
 @SuppressWarnings("JUnitMalformedDeclaration")
@@ -132,9 +134,9 @@ public class ParameterizedClassIntegrationTests extends AbstractJupiterTestEngin
 			event(container("#1"), started()), //
 			event(dynamicTestRegistered("test1")), //
 			event(dynamicTestRegistered("test2")), //
-			event(test("test1"), started()), //
+			event(test("test1"), legacyReportingName("test1()[1]"), started()), //
 			event(test("test1"), finishedSuccessfully()), //
-			event(test("test2"), started()), //
+			event(test("test2"), legacyReportingName("test2()[1]"), started()), //
 			event(test("test2"), finishedSuccessfully()), //
 			event(container("#1"), finishedSuccessfully()), //
 
@@ -142,9 +144,9 @@ public class ParameterizedClassIntegrationTests extends AbstractJupiterTestEngin
 			event(container("#2"), started()), //
 			event(dynamicTestRegistered("test1")), //
 			event(dynamicTestRegistered("test2")), //
-			event(test("test1"), started()), //
+			event(test("test1"), legacyReportingName("test1()[2]"), started()), //
 			event(test("test1"), finishedWithFailure(message(it -> it.contains("negative")))), //
-			event(test("test2"), started()), //
+			event(test("test2"), legacyReportingName("test2()[2]"), started()), //
 			event(test("test2"), finishedWithFailure(message(it -> it.contains("negative")))), //
 			event(container("#2"), finishedSuccessfully()), //
 
@@ -461,6 +463,18 @@ public class ParameterizedClassIntegrationTests extends AbstractJupiterTestEngin
 					"afterAll: %s".formatted(classTemplateClass.getSimpleName())
 					// @formatter:on
 			);
+			var legacyReportingNames = results.testEvents() //
+					.filter(it -> it.getType() == EventType.STARTED) //
+					.map(e -> e.getTestDescriptor().getLegacyReportingName());
+			assertThat(legacyReportingNames).containsExactly( //
+				"test(boolean, TestReporter)[1][1][1]", //
+				"test(boolean, TestReporter)[1][1][2]", //
+				"test(boolean, TestReporter)[1][2][1]", //
+				"test(boolean, TestReporter)[1][2][2]", //
+				"test(boolean, TestReporter)[2][1][1]", //
+				"test(boolean, TestReporter)[2][1][2]", //
+				"test(boolean, TestReporter)[2][2][1]", //
+				"test(boolean, TestReporter)[2][2][2]");
 		}
 
 		@ParameterizedTest

--- a/platform-tests/src/test/java/org/junit/platform/reporting/legacy/xml/LegacyXmlReportGeneratingListenerTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/reporting/legacy/xml/LegacyXmlReportGeneratingListenerTests.java
@@ -90,7 +90,7 @@ class LegacyXmlReportGeneratingListenerTests {
 		assertThat(testcase.attr("classname")).isEqualTo("dummy");
 		assertThat(testcase.child("system-out").text()) //
 				.containsSubsequence("unique-id: [engine:dummy]/[test:succeedingTest]",
-					"display-name: display<-->Name 😎");
+					"display-name: dummy > display<-->Name 😎");
 
 		assertThat(testsuite.find("skipped")).isEmpty();
 		assertThat(testsuite.find("failure")).isEmpty();

--- a/platform-tests/src/test/java/org/junit/platform/reporting/legacy/xml/XmlReportWriterTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/reporting/legacy/xml/XmlReportWriterTests.java
@@ -91,9 +91,14 @@ class XmlReportWriterTests {
 
 	@Test
 	void writesCapturedOutput() throws Exception {
-		var uniqueId = engineDescriptor.getUniqueId().append("test", "test");
-		var testDescriptor = new TestDescriptorStub(uniqueId, "successfulTest");
-		engineDescriptor.addChild(testDescriptor);
+		var classDescriptor = new TestDescriptorStub(engineDescriptor.getUniqueId().append("class", "SomeClass"),
+			"SomeClass");
+		engineDescriptor.addChild(classDescriptor);
+
+		var testDescriptor = new TestDescriptorStub(classDescriptor.getUniqueId().append("test", "successfulTest"),
+			"successfulTest");
+		classDescriptor.addChild(testDescriptor);
+
 		var testPlan = TestPlan.from(true, Set.of(engineDescriptor), configParams, dummyOutputDirectoryCreator());
 
 		var reportData = new XmlReportData(testPlan, Clock.systemDefaultZone());
@@ -103,13 +108,14 @@ class XmlReportWriterTests {
 			"foo", "bar"));
 		reportData.addReportEntry(TestIdentifier.from(testDescriptor), reportEntry);
 		reportData.addReportEntry(TestIdentifier.from(testDescriptor), ReportEntry.from(Map.of("baz", "qux")));
-		reportData.markFinished(testPlan.getTestIdentifier(uniqueId), successful());
+		reportData.markFinished(testPlan.getTestIdentifier(testDescriptor.getUniqueId()), successful());
 
 		var testsuite = writeXmlReport(testPlan, reportData);
 
 		assertValidAccordingToJenkinsSchema(testsuite.document());
 		assertThat(testsuite.find("system-out").text(0)) //
-				.containsSubsequence("unique-id: ", "test:test", "display-name: successfulTest");
+				.containsSubsequence("unique-id: [engine:engine]/[class:SomeClass]/[test:successfulTest]",
+					"display-name: Engine > SomeClass > successfulTest");
 		assertThat(testsuite.find("system-out").text(1)) //
 				.containsSubsequence("Report Entry #1 (timestamp: ", "- foo: bar", "Report Entry #2 (timestamp: ",
 					"- baz: qux");

--- a/platform-tooling-support-tests/src/test/resources/platform/tooling/support/tests/AntStarterTests_snapshots/open-test-report.xml.snapshot
+++ b/platform-tooling-support-tests/src/test/resources/platform/tooling/support/tests/AntStarterTests_snapshots/open-test-report.xml.snapshot
@@ -54,7 +54,7 @@ test-method: ant_starter
   <e:started id="4" name="parameterizedTest(int)" parentId="3" time="2025-03-23T13:14:52.998289212Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#1]/[test-template:parameterizedTest(int)]</junit:uniqueId>
-      <junit:legacyReportingName>parameterizedTest(int)</junit:legacyReportingName>
+      <junit:legacyReportingName>parameterizedTest(int)[1]</junit:legacyReportingName>
       <junit:type>CONTAINER</junit:type>
     </metadata>
     <sources>
@@ -65,7 +65,7 @@ test-method: ant_starter
   <e:started id="5" name="[1] 1" parentId="4" time="2025-03-23T13:14:53.008677106Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#1]/[test-template:parameterizedTest(int)]/[test-template-invocation:#1]</junit:uniqueId>
-      <junit:legacyReportingName>parameterizedTest(int)[1]</junit:legacyReportingName>
+      <junit:legacyReportingName>parameterizedTest(int)[1][1]</junit:legacyReportingName>
       <junit:type>TEST</junit:type>
     </metadata>
     <sources>
@@ -80,7 +80,7 @@ test-method: ant_starter
   <e:started id="6" name="[2] 2" parentId="4" time="2025-03-23T13:14:53.023592120Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#1]/[test-template:parameterizedTest(int)]/[test-template-invocation:#2]</junit:uniqueId>
-      <junit:legacyReportingName>parameterizedTest(int)[2]</junit:legacyReportingName>
+      <junit:legacyReportingName>parameterizedTest(int)[1][2]</junit:legacyReportingName>
       <junit:type>TEST</junit:type>
     </metadata>
     <sources>
@@ -99,7 +99,7 @@ test-method: ant_starter
   <e:started id="7" name="Inner" parentId="3" time="2025-03-23T13:14:53.026002648Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#1]/[nested-class-template:Inner]</junit:uniqueId>
-      <junit:legacyReportingName>com.example.project.CalculatorParameterizedClassTests$Inner</junit:legacyReportingName>
+      <junit:legacyReportingName>com.example.project.CalculatorParameterizedClassTests$Inner[1]</junit:legacyReportingName>
       <junit:type>CONTAINER</junit:type>
     </metadata>
     <sources>
@@ -110,7 +110,7 @@ test-method: ant_starter
   <e:started id="8" name="[1] 1" parentId="7" time="2025-03-23T13:14:53.027989515Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#1]/[nested-class-template:Inner]/[class-template-invocation:#1]</junit:uniqueId>
-      <junit:legacyReportingName>com.example.project.CalculatorParameterizedClassTests$Inner[1]</junit:legacyReportingName>
+      <junit:legacyReportingName>com.example.project.CalculatorParameterizedClassTests$Inner[1][1]</junit:legacyReportingName>
       <junit:type>CONTAINER</junit:type>
     </metadata>
     <sources>
@@ -121,7 +121,7 @@ test-method: ant_starter
   <e:started id="9" name="regularTest()" parentId="8" time="2025-03-23T13:14:53.029786032Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#1]/[nested-class-template:Inner]/[class-template-invocation:#1]/[method:regularTest()]</junit:uniqueId>
-      <junit:legacyReportingName>regularTest()</junit:legacyReportingName>
+      <junit:legacyReportingName>regularTest()[1][1]</junit:legacyReportingName>
       <junit:type>TEST</junit:type>
     </metadata>
     <sources>
@@ -140,7 +140,7 @@ test-method: ant_starter
   <e:started id="10" name="[2] 2" parentId="7" time="2025-03-23T13:14:53.032699802Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#1]/[nested-class-template:Inner]/[class-template-invocation:#2]</junit:uniqueId>
-      <junit:legacyReportingName>com.example.project.CalculatorParameterizedClassTests$Inner[2]</junit:legacyReportingName>
+      <junit:legacyReportingName>com.example.project.CalculatorParameterizedClassTests$Inner[1][2]</junit:legacyReportingName>
       <junit:type>CONTAINER</junit:type>
     </metadata>
     <sources>
@@ -151,7 +151,7 @@ test-method: ant_starter
   <e:started id="11" name="regularTest()" parentId="10" time="2025-03-23T13:14:53.033608120Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#1]/[nested-class-template:Inner]/[class-template-invocation:#2]/[method:regularTest()]</junit:uniqueId>
-      <junit:legacyReportingName>regularTest()</junit:legacyReportingName>
+      <junit:legacyReportingName>regularTest()[1][2]</junit:legacyReportingName>
       <junit:type>TEST</junit:type>
     </metadata>
     <sources>
@@ -189,7 +189,7 @@ test-method: ant_starter
   <e:started id="13" name="parameterizedTest(int)" parentId="12" time="2025-03-23T13:14:53.037827579Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#2]/[test-template:parameterizedTest(int)]</junit:uniqueId>
-      <junit:legacyReportingName>parameterizedTest(int)</junit:legacyReportingName>
+      <junit:legacyReportingName>parameterizedTest(int)[2]</junit:legacyReportingName>
       <junit:type>CONTAINER</junit:type>
     </metadata>
     <sources>
@@ -200,7 +200,7 @@ test-method: ant_starter
   <e:started id="14" name="[1] 1" parentId="13" time="2025-03-23T13:14:53.039333837Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#2]/[test-template:parameterizedTest(int)]/[test-template-invocation:#1]</junit:uniqueId>
-      <junit:legacyReportingName>parameterizedTest(int)[1]</junit:legacyReportingName>
+      <junit:legacyReportingName>parameterizedTest(int)[2][1]</junit:legacyReportingName>
       <junit:type>TEST</junit:type>
     </metadata>
     <sources>
@@ -215,7 +215,7 @@ test-method: ant_starter
   <e:started id="15" name="[2] 2" parentId="13" time="2025-03-23T13:14:53.041061063Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#2]/[test-template:parameterizedTest(int)]/[test-template-invocation:#2]</junit:uniqueId>
-      <junit:legacyReportingName>parameterizedTest(int)[2]</junit:legacyReportingName>
+      <junit:legacyReportingName>parameterizedTest(int)[2][2]</junit:legacyReportingName>
       <junit:type>TEST</junit:type>
     </metadata>
     <sources>
@@ -234,7 +234,7 @@ test-method: ant_starter
   <e:started id="16" name="Inner" parentId="12" time="2025-03-23T13:14:53.042817885Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#2]/[nested-class-template:Inner]</junit:uniqueId>
-      <junit:legacyReportingName>com.example.project.CalculatorParameterizedClassTests$Inner</junit:legacyReportingName>
+      <junit:legacyReportingName>com.example.project.CalculatorParameterizedClassTests$Inner[2]</junit:legacyReportingName>
       <junit:type>CONTAINER</junit:type>
     </metadata>
     <sources>
@@ -245,7 +245,7 @@ test-method: ant_starter
   <e:started id="17" name="[1] 1" parentId="16" time="2025-03-23T13:14:53.044477163Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#2]/[nested-class-template:Inner]/[class-template-invocation:#1]</junit:uniqueId>
-      <junit:legacyReportingName>com.example.project.CalculatorParameterizedClassTests$Inner[1]</junit:legacyReportingName>
+      <junit:legacyReportingName>com.example.project.CalculatorParameterizedClassTests$Inner[2][1]</junit:legacyReportingName>
       <junit:type>CONTAINER</junit:type>
     </metadata>
     <sources>
@@ -256,7 +256,7 @@ test-method: ant_starter
   <e:started id="18" name="regularTest()" parentId="17" time="2025-03-23T13:14:53.045461144Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#2]/[nested-class-template:Inner]/[class-template-invocation:#1]/[method:regularTest()]</junit:uniqueId>
-      <junit:legacyReportingName>regularTest()</junit:legacyReportingName>
+      <junit:legacyReportingName>regularTest()[2][1]</junit:legacyReportingName>
       <junit:type>TEST</junit:type>
     </metadata>
     <sources>
@@ -275,7 +275,7 @@ test-method: ant_starter
   <e:started id="19" name="[2] 2" parentId="16" time="2025-03-23T13:14:53.047014521Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#2]/[nested-class-template:Inner]/[class-template-invocation:#2]</junit:uniqueId>
-      <junit:legacyReportingName>com.example.project.CalculatorParameterizedClassTests$Inner[2]</junit:legacyReportingName>
+      <junit:legacyReportingName>com.example.project.CalculatorParameterizedClassTests$Inner[2][2]</junit:legacyReportingName>
       <junit:type>CONTAINER</junit:type>
     </metadata>
     <sources>
@@ -286,7 +286,7 @@ test-method: ant_starter
   <e:started id="20" name="regularTest()" parentId="19" time="2025-03-23T13:14:53.047746896Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#2]/[nested-class-template:Inner]/[class-template-invocation:#2]/[method:regularTest()]</junit:uniqueId>
-      <junit:legacyReportingName>regularTest()</junit:legacyReportingName>
+      <junit:legacyReportingName>regularTest()[2][2]</junit:legacyReportingName>
       <junit:type>TEST</junit:type>
     </metadata>
     <sources>

--- a/platform-tooling-support-tests/src/test/resources/platform/tooling/support/tests/GradleStarterTests_snapshots/open-test-report.xml.snapshot
+++ b/platform-tooling-support-tests/src/test/resources/platform/tooling/support/tests/GradleStarterTests_snapshots/open-test-report.xml.snapshot
@@ -54,7 +54,7 @@ test-method: buildJupiterStarterProject
   <e:started id="4" name="parameterizedTest(int)" parentId="3" time="2025-03-23T13:09:41.934481780Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#1]/[test-template:parameterizedTest(int)]</junit:uniqueId>
-      <junit:legacyReportingName>parameterizedTest(int)</junit:legacyReportingName>
+      <junit:legacyReportingName>parameterizedTest(int)[1]</junit:legacyReportingName>
       <junit:type>CONTAINER</junit:type>
     </metadata>
     <sources>
@@ -65,7 +65,7 @@ test-method: buildJupiterStarterProject
   <e:started id="5" name="[1] 1" parentId="4" time="2025-03-23T13:09:41.945209083Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#1]/[test-template:parameterizedTest(int)]/[test-template-invocation:#1]</junit:uniqueId>
-      <junit:legacyReportingName>parameterizedTest(int)[1]</junit:legacyReportingName>
+      <junit:legacyReportingName>parameterizedTest(int)[1][1]</junit:legacyReportingName>
       <junit:type>TEST</junit:type>
     </metadata>
     <sources>
@@ -80,7 +80,7 @@ test-method: buildJupiterStarterProject
   <e:started id="6" name="[2] 2" parentId="4" time="2025-03-23T13:09:41.958401457Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#1]/[test-template:parameterizedTest(int)]/[test-template-invocation:#2]</junit:uniqueId>
-      <junit:legacyReportingName>parameterizedTest(int)[2]</junit:legacyReportingName>
+      <junit:legacyReportingName>parameterizedTest(int)[1][2]</junit:legacyReportingName>
       <junit:type>TEST</junit:type>
     </metadata>
     <sources>
@@ -99,7 +99,7 @@ test-method: buildJupiterStarterProject
   <e:started id="7" name="Inner" parentId="3" time="2025-03-23T13:09:41.962824770Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#1]/[nested-class-template:Inner]</junit:uniqueId>
-      <junit:legacyReportingName>com.example.project.CalculatorParameterizedClassTests$Inner</junit:legacyReportingName>
+      <junit:legacyReportingName>com.example.project.CalculatorParameterizedClassTests$Inner[1]</junit:legacyReportingName>
       <junit:type>CONTAINER</junit:type>
     </metadata>
     <sources>
@@ -110,7 +110,7 @@ test-method: buildJupiterStarterProject
   <e:started id="8" name="[1] 1" parentId="7" time="2025-03-23T13:09:41.966042658Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#1]/[nested-class-template:Inner]/[class-template-invocation:#1]</junit:uniqueId>
-      <junit:legacyReportingName>com.example.project.CalculatorParameterizedClassTests$Inner[1]</junit:legacyReportingName>
+      <junit:legacyReportingName>com.example.project.CalculatorParameterizedClassTests$Inner[1][1]</junit:legacyReportingName>
       <junit:type>CONTAINER</junit:type>
     </metadata>
     <sources>
@@ -121,7 +121,7 @@ test-method: buildJupiterStarterProject
   <e:started id="9" name="regularTest()" parentId="8" time="2025-03-23T13:09:41.967595502Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#1]/[nested-class-template:Inner]/[class-template-invocation:#1]/[method:regularTest()]</junit:uniqueId>
-      <junit:legacyReportingName>regularTest()</junit:legacyReportingName>
+      <junit:legacyReportingName>regularTest()[1][1]</junit:legacyReportingName>
       <junit:type>TEST</junit:type>
     </metadata>
     <sources>
@@ -140,7 +140,7 @@ test-method: buildJupiterStarterProject
   <e:started id="10" name="[2] 2" parentId="7" time="2025-03-23T13:09:41.970717090Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#1]/[nested-class-template:Inner]/[class-template-invocation:#2]</junit:uniqueId>
-      <junit:legacyReportingName>com.example.project.CalculatorParameterizedClassTests$Inner[2]</junit:legacyReportingName>
+      <junit:legacyReportingName>com.example.project.CalculatorParameterizedClassTests$Inner[1][2]</junit:legacyReportingName>
       <junit:type>CONTAINER</junit:type>
     </metadata>
     <sources>
@@ -151,7 +151,7 @@ test-method: buildJupiterStarterProject
   <e:started id="11" name="regularTest()" parentId="10" time="2025-03-23T13:09:41.972023454Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#1]/[nested-class-template:Inner]/[class-template-invocation:#2]/[method:regularTest()]</junit:uniqueId>
-      <junit:legacyReportingName>regularTest()</junit:legacyReportingName>
+      <junit:legacyReportingName>regularTest()[1][2]</junit:legacyReportingName>
       <junit:type>TEST</junit:type>
     </metadata>
     <sources>
@@ -189,7 +189,7 @@ test-method: buildJupiterStarterProject
   <e:started id="13" name="parameterizedTest(int)" parentId="12" time="2025-03-23T13:09:41.978390792Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#2]/[test-template:parameterizedTest(int)]</junit:uniqueId>
-      <junit:legacyReportingName>parameterizedTest(int)</junit:legacyReportingName>
+      <junit:legacyReportingName>parameterizedTest(int)[2]</junit:legacyReportingName>
       <junit:type>CONTAINER</junit:type>
     </metadata>
     <sources>
@@ -200,7 +200,7 @@ test-method: buildJupiterStarterProject
   <e:started id="14" name="[1] 1" parentId="13" time="2025-03-23T13:09:41.980269927Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#2]/[test-template:parameterizedTest(int)]/[test-template-invocation:#1]</junit:uniqueId>
-      <junit:legacyReportingName>parameterizedTest(int)[1]</junit:legacyReportingName>
+      <junit:legacyReportingName>parameterizedTest(int)[2][1]</junit:legacyReportingName>
       <junit:type>TEST</junit:type>
     </metadata>
     <sources>
@@ -215,7 +215,7 @@ test-method: buildJupiterStarterProject
   <e:started id="15" name="[2] 2" parentId="13" time="2025-03-23T13:09:41.983240152Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#2]/[test-template:parameterizedTest(int)]/[test-template-invocation:#2]</junit:uniqueId>
-      <junit:legacyReportingName>parameterizedTest(int)[2]</junit:legacyReportingName>
+      <junit:legacyReportingName>parameterizedTest(int)[2][2]</junit:legacyReportingName>
       <junit:type>TEST</junit:type>
     </metadata>
     <sources>
@@ -234,7 +234,7 @@ test-method: buildJupiterStarterProject
   <e:started id="16" name="Inner" parentId="12" time="2025-03-23T13:09:41.985103698Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#2]/[nested-class-template:Inner]</junit:uniqueId>
-      <junit:legacyReportingName>com.example.project.CalculatorParameterizedClassTests$Inner</junit:legacyReportingName>
+      <junit:legacyReportingName>com.example.project.CalculatorParameterizedClassTests$Inner[2]</junit:legacyReportingName>
       <junit:type>CONTAINER</junit:type>
     </metadata>
     <sources>
@@ -245,7 +245,7 @@ test-method: buildJupiterStarterProject
   <e:started id="17" name="[1] 1" parentId="16" time="2025-03-23T13:09:41.986693621Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#2]/[nested-class-template:Inner]/[class-template-invocation:#1]</junit:uniqueId>
-      <junit:legacyReportingName>com.example.project.CalculatorParameterizedClassTests$Inner[1]</junit:legacyReportingName>
+      <junit:legacyReportingName>com.example.project.CalculatorParameterizedClassTests$Inner[2][1]</junit:legacyReportingName>
       <junit:type>CONTAINER</junit:type>
     </metadata>
     <sources>
@@ -256,7 +256,7 @@ test-method: buildJupiterStarterProject
   <e:started id="18" name="regularTest()" parentId="17" time="2025-03-23T13:09:41.988031503Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#2]/[nested-class-template:Inner]/[class-template-invocation:#1]/[method:regularTest()]</junit:uniqueId>
-      <junit:legacyReportingName>regularTest()</junit:legacyReportingName>
+      <junit:legacyReportingName>regularTest()[2][1]</junit:legacyReportingName>
       <junit:type>TEST</junit:type>
     </metadata>
     <sources>
@@ -275,7 +275,7 @@ test-method: buildJupiterStarterProject
   <e:started id="19" name="[2] 2" parentId="16" time="2025-03-23T13:09:41.989884669Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#2]/[nested-class-template:Inner]/[class-template-invocation:#2]</junit:uniqueId>
-      <junit:legacyReportingName>com.example.project.CalculatorParameterizedClassTests$Inner[2]</junit:legacyReportingName>
+      <junit:legacyReportingName>com.example.project.CalculatorParameterizedClassTests$Inner[2][2]</junit:legacyReportingName>
       <junit:type>CONTAINER</junit:type>
     </metadata>
     <sources>
@@ -286,7 +286,7 @@ test-method: buildJupiterStarterProject
   <e:started id="20" name="regularTest()" parentId="19" time="2025-03-23T13:09:41.990722727Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#2]/[nested-class-template:Inner]/[class-template-invocation:#2]/[method:regularTest()]</junit:uniqueId>
-      <junit:legacyReportingName>regularTest()</junit:legacyReportingName>
+      <junit:legacyReportingName>regularTest()[2][2]</junit:legacyReportingName>
       <junit:type>TEST</junit:type>
     </metadata>
     <sources>

--- a/platform-tooling-support-tests/src/test/resources/platform/tooling/support/tests/MavenStarterTests_snapshots/open-test-report.xml.snapshot
+++ b/platform-tooling-support-tests/src/test/resources/platform/tooling/support/tests/MavenStarterTests_snapshots/open-test-report.xml.snapshot
@@ -54,7 +54,7 @@ test-method: verifyJupiterStarterProject
   <e:started id="4" name="parameterizedTest(int)" parentId="3" time="2025-03-23T13:17:16.913Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#1]/[test-template:parameterizedTest(int)]</junit:uniqueId>
-      <junit:legacyReportingName>parameterizedTest(int)</junit:legacyReportingName>
+      <junit:legacyReportingName>parameterizedTest(int)[1]</junit:legacyReportingName>
       <junit:type>CONTAINER</junit:type>
     </metadata>
     <sources>
@@ -65,7 +65,7 @@ test-method: verifyJupiterStarterProject
   <e:started id="5" name="[1] 1" parentId="4" time="2025-03-23T13:17:16.927Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#1]/[test-template:parameterizedTest(int)]/[test-template-invocation:#1]</junit:uniqueId>
-      <junit:legacyReportingName>parameterizedTest(int)[1]</junit:legacyReportingName>
+      <junit:legacyReportingName>parameterizedTest(int)[1][1]</junit:legacyReportingName>
       <junit:type>TEST</junit:type>
     </metadata>
     <sources>
@@ -80,7 +80,7 @@ test-method: verifyJupiterStarterProject
   <e:started id="6" name="[2] 2" parentId="4" time="2025-03-23T13:17:16.948Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#1]/[test-template:parameterizedTest(int)]/[test-template-invocation:#2]</junit:uniqueId>
-      <junit:legacyReportingName>parameterizedTest(int)[2]</junit:legacyReportingName>
+      <junit:legacyReportingName>parameterizedTest(int)[1][2]</junit:legacyReportingName>
       <junit:type>TEST</junit:type>
     </metadata>
     <sources>
@@ -99,7 +99,7 @@ test-method: verifyJupiterStarterProject
   <e:started id="7" name="Inner" parentId="3" time="2025-03-23T13:17:16.952Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#1]/[nested-class-template:Inner]</junit:uniqueId>
-      <junit:legacyReportingName>com.example.project.CalculatorParameterizedClassTests$Inner</junit:legacyReportingName>
+      <junit:legacyReportingName>com.example.project.CalculatorParameterizedClassTests$Inner[1]</junit:legacyReportingName>
       <junit:type>CONTAINER</junit:type>
     </metadata>
     <sources>
@@ -110,7 +110,7 @@ test-method: verifyJupiterStarterProject
   <e:started id="8" name="[1] 1" parentId="7" time="2025-03-23T13:17:16.956Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#1]/[nested-class-template:Inner]/[class-template-invocation:#1]</junit:uniqueId>
-      <junit:legacyReportingName>com.example.project.CalculatorParameterizedClassTests$Inner[1]</junit:legacyReportingName>
+      <junit:legacyReportingName>com.example.project.CalculatorParameterizedClassTests$Inner[1][1]</junit:legacyReportingName>
       <junit:type>CONTAINER</junit:type>
     </metadata>
     <sources>
@@ -121,7 +121,7 @@ test-method: verifyJupiterStarterProject
   <e:started id="9" name="regularTest()" parentId="8" time="2025-03-23T13:17:16.959Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#1]/[nested-class-template:Inner]/[class-template-invocation:#1]/[method:regularTest()]</junit:uniqueId>
-      <junit:legacyReportingName>regularTest()</junit:legacyReportingName>
+      <junit:legacyReportingName>regularTest()[1][1]</junit:legacyReportingName>
       <junit:type>TEST</junit:type>
     </metadata>
     <sources>
@@ -140,7 +140,7 @@ test-method: verifyJupiterStarterProject
   <e:started id="10" name="[2] 2" parentId="7" time="2025-03-23T13:17:16.965Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#1]/[nested-class-template:Inner]/[class-template-invocation:#2]</junit:uniqueId>
-      <junit:legacyReportingName>com.example.project.CalculatorParameterizedClassTests$Inner[2]</junit:legacyReportingName>
+      <junit:legacyReportingName>com.example.project.CalculatorParameterizedClassTests$Inner[1][2]</junit:legacyReportingName>
       <junit:type>CONTAINER</junit:type>
     </metadata>
     <sources>
@@ -151,7 +151,7 @@ test-method: verifyJupiterStarterProject
   <e:started id="11" name="regularTest()" parentId="10" time="2025-03-23T13:17:16.966Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#1]/[nested-class-template:Inner]/[class-template-invocation:#2]/[method:regularTest()]</junit:uniqueId>
-      <junit:legacyReportingName>regularTest()</junit:legacyReportingName>
+      <junit:legacyReportingName>regularTest()[1][2]</junit:legacyReportingName>
       <junit:type>TEST</junit:type>
     </metadata>
     <sources>
@@ -189,7 +189,7 @@ test-method: verifyJupiterStarterProject
   <e:started id="13" name="parameterizedTest(int)" parentId="12" time="2025-03-23T13:17:16.976Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#2]/[test-template:parameterizedTest(int)]</junit:uniqueId>
-      <junit:legacyReportingName>parameterizedTest(int)</junit:legacyReportingName>
+      <junit:legacyReportingName>parameterizedTest(int)[2]</junit:legacyReportingName>
       <junit:type>CONTAINER</junit:type>
     </metadata>
     <sources>
@@ -200,7 +200,7 @@ test-method: verifyJupiterStarterProject
   <e:started id="14" name="[1] 1" parentId="13" time="2025-03-23T13:17:16.978Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#2]/[test-template:parameterizedTest(int)]/[test-template-invocation:#1]</junit:uniqueId>
-      <junit:legacyReportingName>parameterizedTest(int)[1]</junit:legacyReportingName>
+      <junit:legacyReportingName>parameterizedTest(int)[2][1]</junit:legacyReportingName>
       <junit:type>TEST</junit:type>
     </metadata>
     <sources>
@@ -215,7 +215,7 @@ test-method: verifyJupiterStarterProject
   <e:started id="15" name="[2] 2" parentId="13" time="2025-03-23T13:17:16.981Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#2]/[test-template:parameterizedTest(int)]/[test-template-invocation:#2]</junit:uniqueId>
-      <junit:legacyReportingName>parameterizedTest(int)[2]</junit:legacyReportingName>
+      <junit:legacyReportingName>parameterizedTest(int)[2][2]</junit:legacyReportingName>
       <junit:type>TEST</junit:type>
     </metadata>
     <sources>
@@ -234,7 +234,7 @@ test-method: verifyJupiterStarterProject
   <e:started id="16" name="Inner" parentId="12" time="2025-03-23T13:17:16.983Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#2]/[nested-class-template:Inner]</junit:uniqueId>
-      <junit:legacyReportingName>com.example.project.CalculatorParameterizedClassTests$Inner</junit:legacyReportingName>
+      <junit:legacyReportingName>com.example.project.CalculatorParameterizedClassTests$Inner[2]</junit:legacyReportingName>
       <junit:type>CONTAINER</junit:type>
     </metadata>
     <sources>
@@ -245,7 +245,7 @@ test-method: verifyJupiterStarterProject
   <e:started id="17" name="[1] 1" parentId="16" time="2025-03-23T13:17:16.985Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#2]/[nested-class-template:Inner]/[class-template-invocation:#1]</junit:uniqueId>
-      <junit:legacyReportingName>com.example.project.CalculatorParameterizedClassTests$Inner[1]</junit:legacyReportingName>
+      <junit:legacyReportingName>com.example.project.CalculatorParameterizedClassTests$Inner[2][1]</junit:legacyReportingName>
       <junit:type>CONTAINER</junit:type>
     </metadata>
     <sources>
@@ -256,7 +256,7 @@ test-method: verifyJupiterStarterProject
   <e:started id="18" name="regularTest()" parentId="17" time="2025-03-23T13:17:16.987Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#2]/[nested-class-template:Inner]/[class-template-invocation:#1]/[method:regularTest()]</junit:uniqueId>
-      <junit:legacyReportingName>regularTest()</junit:legacyReportingName>
+      <junit:legacyReportingName>regularTest()[2][1]</junit:legacyReportingName>
       <junit:type>TEST</junit:type>
     </metadata>
     <sources>
@@ -275,7 +275,7 @@ test-method: verifyJupiterStarterProject
   <e:started id="19" name="[2] 2" parentId="16" time="2025-03-23T13:17:16.989Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#2]/[nested-class-template:Inner]/[class-template-invocation:#2]</junit:uniqueId>
-      <junit:legacyReportingName>com.example.project.CalculatorParameterizedClassTests$Inner[2]</junit:legacyReportingName>
+      <junit:legacyReportingName>com.example.project.CalculatorParameterizedClassTests$Inner[2][2]</junit:legacyReportingName>
       <junit:type>CONTAINER</junit:type>
     </metadata>
     <sources>
@@ -286,7 +286,7 @@ test-method: verifyJupiterStarterProject
   <e:started id="20" name="regularTest()" parentId="19" time="2025-03-23T13:17:16.990Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#2]/[nested-class-template:Inner]/[class-template-invocation:#2]/[method:regularTest()]</junit:uniqueId>
-      <junit:legacyReportingName>regularTest()</junit:legacyReportingName>
+      <junit:legacyReportingName>regularTest()[2][2]</junit:legacyReportingName>
       <junit:type>TEST</junit:type>
     </metadata>
     <sources>


### PR DESCRIPTION
This is a backport of commit b9756dd28af6fc9570a14fe1e5a25ce235e4ad86 which stems from #5409 & #5441
as well as commit ee3a100cd4f8ebedf0733d0e6c4131c331eadfd0 which stems from #5524 & #5618

Changes were made to compile under Java 8

I have updated release notes but not sure if this is the correct procedure.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://docs.junit.org/snapshot/) and [Release Notes](https://docs.junit.org/snapshot/release-notes.html)
