### PR TITLE
Support multiple junit-platform.properties

### DIFF
--- a/documentation/modules/ROOT/partials/release-notes/release-notes-6.1.0-M2.adoc
+++ b/documentation/modules/ROOT/partials/release-notes/release-notes-6.1.0-M2.adoc
@@ -38,6 +38,8 @@ repository on GitHub.
   objects.
 * New `selectClasspathResources(String...)` and `selectClasspathResources(List<String)`
   methods in `DiscoverySelectors`.
+* Multiple `junit-platform.properties` files are now supported. Where the same property is set
+  in more than one file, the first value will be used.
 
 
 [[v6.1.0-M2-junit-jupiter]]

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherConfigurationParameters.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherConfigurationParameters.java
@@ -255,9 +255,12 @@ class LauncherConfigurationParameters implements ConfigurationParameters {
 		Properties props = new Properties();
 
 		try {
-			URL configFileUrl = findConfigFile(configFileName);
-			if (configFileUrl != null) {
-				loadClasspathResource(configFileUrl, props);
+			List<URL> configFileUrls = findConfigFiles(configFileName);
+			// Reverse the list, so that files early on the classpath take priority where there's a conflict
+			Collections.reverse(configFileUrls);
+
+			for (URL url : configFileUrls) {
+				loadClasspathResource(url, props);
 			}
 		}
 		catch (Exception ex) {
@@ -269,14 +272,10 @@ class LauncherConfigurationParameters implements ConfigurationParameters {
 		return props;
 	}
 
-	private static @Nullable URL findConfigFile(String configFileName) throws IOException {
+	private static List<URL> findConfigFiles(String configFileName) throws IOException {
 
 		ClassLoader classLoader = ClassLoaderUtils.getDefaultClassLoader();
 		List<URL> urls = Collections.list(classLoader.getResources(configFileName));
-
-		if (urls.size() == 1) {
-			return urls.get(0);
-		}
 
 		if (urls.size() > 1) {
 
@@ -293,14 +292,12 @@ class LauncherConfigurationParameters implements ConfigurationParameters {
 						Stream.of(configFileUrl + " (*)"), //
 						resources.stream().skip(1).map(URI::toString) //
 					).collect(joining("\n- ", "\n- ", ""));
-					return "Discovered %d '%s' configuration files on the classpath (see below); only the first (*) will be used.%s".formatted(
+					return "Discovered %d '%s' configuration files on the classpath (see below); properties will be merged, but when there is a conflict, only the first (*) will be used.%s".formatted(
 						resources.size(), configFileName, formattedResourceList);
 				});
 			}
-			return configFileUrl;
 		}
-
-		return null;
+		return urls;
 	}
 
 	private static void loadClasspathResource(URL configFileUrl, Properties props) throws IOException {

--- a/platform-tests/src/test/java/org/junit/platform/launcher/core/LauncherConfigurationParametersTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/core/LauncherConfigurationParametersTests.java
@@ -201,11 +201,15 @@ class LauncherConfigurationParametersTests {
 	}
 
 	@Test
-	void warnsOnMultiplePropertyResources(@TempDir Path tempDir, @TrackLogRecords LogRecordListener logRecordListener)
+	void mergesOnMultiplePropertyResources(@TempDir Path tempDir, @TrackLogRecords LogRecordListener logRecordListener)
 			throws Exception {
+		String uniqueKey = KEY + ".unique-modifier";
+		String someValue = "another value from second config file";
 
 		Properties properties = new Properties();
 		properties.setProperty(KEY, "from second config file");
+
+		properties.setProperty(uniqueKey, someValue);
 		try (var out = Files.newOutputStream(tempDir.resolve(CONFIG_FILE_NAME))) {
 			properties.store(out, "");
 		}
@@ -217,14 +221,18 @@ class LauncherConfigurationParametersTests {
 			Thread.currentThread().setContextClassLoader(customClassLoader);
 			ConfigurationParameters configParams = fromMapAndFile(Map.of(), CONFIG_FILE_NAME);
 
-			assertThat(configParams.get(KEY)).contains(CONFIG_FILE);
+			assertThat(configParams.get(KEY)).isPresent();
+			assertThat(configParams.get(KEY).orElse("<missing>")).isEqualTo(CONFIG_FILE);
+
+			assertThat(configParams.get(uniqueKey)).isPresent();
+			assertThat(configParams.get(uniqueKey).orElse("<missing>")).isEqualTo(someValue);
 
 			assertThat(logRecordListener.stream(Level.WARNING).map(LogRecord::getMessage)) //
 					.hasSize(1) //
 					.first(as(InstanceOfAssertFactories.STRING)) //
 					.contains("""
 							Discovered 2 '%s' configuration files on the classpath (see below); \
-							only the first (*) will be used.
+							properties will be merged, but when there is a conflict, only the first (*) will be used.
 							- %s (*)
 							- %s"""//
 							.formatted(CONFIG_FILE_NAME, originalResource,


### PR DESCRIPTION
Ingest properties from all junit-platform.properties files on the classpath, rather than just the first. Where the same property exists in multiple files, maintain the current behaviour.

Resolves [#2794](https://github.com/junit-team/junit-framework/issues/2794)

This ended up being a fairly straightforward change, because all the testing was already in place, and just needed a slight extension for the new behaviour. What I've done is loaded *all* properties files with the expected name. I reverse the order so that if the same property is present in multiple files, the first occurrence 'wins'. 

I also kept the warning (but with amended wording, of course). If we wanted to be really fancy we could only warn if there actually is a conflict, but I wasn't sure if the extra effort was warranted.

I strengthened the assertions in the test to equals rather than contains, since it's easy to accidentally use similar values in test properties files.

I looked through the docs but couldn't find anywhere where it says you can only have one properties file, so I don't think there's anything to change there.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [X] There are no TODOs left in the code
- [X] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [X] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [X] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [X] NOT APPLICABLE Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [X]  Change is documented in the [User Guide](https://docs.junit.org/snapshot/) and [Release Notes](https://docs.junit.org/snapshot/release-notes.html)
