### PR TITLE
Test 5.14.x against JDK 25 ga

### DIFF
--- a/.github/workflows/cross-version.yml
+++ b/.github/workflows/cross-version.yml
@@ -25,7 +25,7 @@ jobs:
         - version: 24
           type: ga
         - version: 25
-          type: ea
+          type: ga
         - version: 26
           type: ea
     name: "OpenJDK ${{ matrix.jdk.version }} (${{ matrix.jdk.release || matrix.jdk.type }})"


### PR DESCRIPTION
Java 25 is now generally available. We don't have to test against an early access version.