### PR TITLE
 Reduce NullAway suppressions in throwing code

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertInstanceOf.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertInstanceOf.java
@@ -49,14 +49,14 @@ class AssertInstanceOf {
 	private static <T> T assertInstanceOf(Class<T> expectedType, @Nullable Object actualValue,
 			@Nullable Object messageOrSupplier) {
 		if (!expectedType.isInstance(actualValue)) {
-			assertionFailure() //
+			throw assertionFailure() //
 					.message(messageOrSupplier) //
 					.reason(actualValue == null ? "Unexpected null value" : "Unexpected type") //
 					.expected(expectedType) //
 					.actual(actualValue == null ? null : actualValue.getClass()) //
 					.cause(actualValue instanceof Throwable t ? t : null) //
 					.trimStacktrace(Assertions.class) //
-					.buildAndThrow();
+					.build();
 		}
 		return expectedType.cast(actualValue);
 	}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertionUtils.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertionUtils.java
@@ -17,8 +17,8 @@ import java.util.Deque;
 import java.util.function.Supplier;
 
 import org.jspecify.annotations.Nullable;
-import org.junit.platform.commons.annotation.Contract;
 import org.junit.platform.commons.util.UnrecoverableExceptions;
+import org.opentest4j.AssertionFailedError;
 
 /**
  * {@code AssertionUtils} is a collection of utility methods that are common to
@@ -32,41 +32,36 @@ class AssertionUtils {
 		/* no-op */
 	}
 
-	@Contract(" -> fail")
-	static void fail() {
+	static AssertionFailedError failure() {
 		throw assertionFailure() //
 				.trimStacktrace(Assertions.class) //
 				.build();
 	}
 
-	@Contract("_ -> fail")
-	static void fail(@Nullable String message) {
-		throw assertionFailure() //
+	static AssertionFailedError failure(@Nullable String message) {
+		return assertionFailure() //
 				.message(message) //
 				.trimStacktrace(Assertions.class) //
 				.build();
 	}
 
-	@Contract("_, _ -> fail")
-	static void fail(@Nullable String message, @Nullable Throwable cause) {
-		throw assertionFailure() //
+	static AssertionFailedError failure(@Nullable String message, @Nullable Throwable cause) {
+		return assertionFailure() //
 				.message(message) //
 				.cause(cause) //
 				.trimStacktrace(Assertions.class) //
 				.build();
 	}
 
-	@Contract("_ -> fail")
-	static void fail(@Nullable Throwable cause) {
+	static AssertionFailedError failure(@Nullable Throwable cause) {
 		throw assertionFailure() //
 				.cause(cause) //
 				.trimStacktrace(Assertions.class) //
 				.build();
 	}
 
-	@Contract("_ -> fail")
-	static void fail(Supplier<@Nullable String> messageSupplier) {
-		throw assertionFailure() //
+	static AssertionFailedError failure(Supplier<@Nullable String> messageSupplier) {
+		return assertionFailure() //
 				.message(nullSafeGet(messageSupplier)) //
 				.trimStacktrace(Assertions.class) //
 				.build();
@@ -133,7 +128,7 @@ class AssertionUtils {
 	}
 
 	private static void failIllegalDelta(String delta) {
-		fail("positive delta expected but was: <" + delta + ">");
+		throw failure("positive delta expected but was: <" + delta + ">");
 	}
 
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
@@ -117,10 +117,9 @@ public class Assertions {
 	 * generic return type {@code V}.
 	 */
 	@Contract(" -> fail")
-	@SuppressWarnings({ "NullAway", "TypeParameterUnusedInFormals" })
+	@SuppressWarnings("TypeParameterUnusedInFormals")
 	public static <V> V fail() {
-		AssertionUtils.fail();
-		return null; // appeasing the compiler: this line will never be executed.
+		throw AssertionUtils.failure();
 	}
 
 	/**
@@ -138,10 +137,9 @@ public class Assertions {
 	 * }</pre>
 	 */
 	@Contract("_ -> fail")
-	@SuppressWarnings({ "NullAway", "TypeParameterUnusedInFormals" })
+	@SuppressWarnings("TypeParameterUnusedInFormals")
 	public static <V> V fail(@Nullable String message) {
-		AssertionUtils.fail(message);
-		return null; // appeasing the compiler: this line will never be executed.
+		throw AssertionUtils.failure(message);
 	}
 
 	/**
@@ -152,10 +150,9 @@ public class Assertions {
 	 * generic return type {@code V}.
 	 */
 	@Contract("_, _ -> fail")
-	@SuppressWarnings({ "NullAway", "TypeParameterUnusedInFormals" })
+	@SuppressWarnings("TypeParameterUnusedInFormals")
 	public static <V> V fail(@Nullable String message, @Nullable Throwable cause) {
-		AssertionUtils.fail(message, cause);
-		return null; // appeasing the compiler: this line will never be executed.
+		throw AssertionUtils.failure(message, cause);
 	}
 
 	/**
@@ -165,10 +162,9 @@ public class Assertions {
 	 * generic return type {@code V}.
 	 */
 	@Contract("_ -> fail")
-	@SuppressWarnings({ "NullAway", "TypeParameterUnusedInFormals" })
+	@SuppressWarnings("TypeParameterUnusedInFormals")
 	public static <V> V fail(@Nullable Throwable cause) {
-		AssertionUtils.fail(cause);
-		return null; // appeasing the compiler: this line will never be executed.
+		throw AssertionUtils.failure(cause);
 	}
 
 	/**
@@ -179,10 +175,9 @@ public class Assertions {
 	 * generic return type {@code V}.
 	 */
 	@Contract("_ -> fail")
-	@SuppressWarnings({ "NullAway", "TypeParameterUnusedInFormals" })
+	@SuppressWarnings("TypeParameterUnusedInFormals")
 	public static <V> V fail(Supplier<@Nullable String> messageSupplier) {
-		AssertionUtils.fail(messageSupplier);
-		return null; // appeasing the compiler: this line will never be executed.
+		throw AssertionUtils.failure(messageSupplier);
 	}
 
 	// --- assertTrue ----------------------------------------------------------


### PR DESCRIPTION
Instead of using `throwFoo(); return null;` with suppressed `NullAway` lint just do `throw newFoo()`.

This removes the need for `NullAway` suppressions since now Java type system is happy deducing the return type of the methods to the bottom type which coerces to anything.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://docs.junit.org/snapshot/) and [Release Notes](https://docs.junit.org/snapshot/release-notes.html) (the change is effectively internal)
