### PR TITLE
Narrow down types in `StringToObjectConverter` hierarchy

### DIFF
--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/conversion/ConversionException.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/conversion/ConversionException.java
@@ -15,6 +15,7 @@ import static org.apiguardian.api.API.Status.MAINTAINED;
 import java.io.Serial;
 
 import org.apiguardian.api.API;
+import org.jspecify.annotations.Nullable;
 import org.junit.platform.commons.JUnitException;
 
 /**
@@ -33,7 +34,7 @@ public class ConversionException extends JUnitException {
 		super(message);
 	}
 
-	public ConversionException(String message, Throwable cause) {
+	public ConversionException(String message, @Nullable Throwable cause) {
 		super(message, cause);
 	}
 

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/conversion/StringToBooleanConverter.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/conversion/StringToBooleanConverter.java
@@ -20,7 +20,7 @@ class StringToBooleanConverter implements StringToObjectConverter {
 	}
 
 	@Override
-	public Object convert(String source, Class<?> targetType) {
+	public Boolean convert(String source, Class<?> targetType) {
 		boolean isTrue = "true".equalsIgnoreCase(source);
 		Preconditions.condition(isTrue || "false".equalsIgnoreCase(source),
 			() -> "String must be 'true' or 'false' (ignoring case): " + source);

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/conversion/StringToCharacterConverter.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/conversion/StringToCharacterConverter.java
@@ -20,7 +20,7 @@ class StringToCharacterConverter implements StringToObjectConverter {
 	}
 
 	@Override
-	public Object convert(String source, Class<?> targetType) {
+	public Character convert(String source, Class<?> targetType) {
 		Preconditions.condition(source.length() == 1, () -> "String must have length of 1: " + source);
 		return source.charAt(0);
 	}

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/conversion/StringToClassConverter.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/conversion/StringToClassConverter.java
@@ -10,7 +10,6 @@
 
 package org.junit.platform.commons.support.conversion;
 
-import org.jspecify.annotations.Nullable;
 import org.junit.platform.commons.support.ReflectionSupport;
 
 class StringToClassConverter implements StringToObjectConverter {
@@ -26,10 +25,10 @@ class StringToClassConverter implements StringToObjectConverter {
 	}
 
 	@Override
-	public @Nullable Object convert(String className, Class<?> targetType, ClassLoader classLoader) throws Exception {
+	public Class<?> convert(String className, Class<?> targetType, ClassLoader classLoader) throws Exception {
 		// @formatter:off
 		return ReflectionSupport.tryToLoadClass(className, classLoader)
-				.getOrThrow(cause -> new ConversionException(
+				.getNonNullOrThrow(cause -> new ConversionException(
 						"Failed to convert String \"" + className + "\" to type java.lang.Class", cause));
 		// @formatter:on
 	}

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/conversion/StringToEnumConverter.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/conversion/StringToEnumConverter.java
@@ -19,7 +19,7 @@ class StringToEnumConverter implements StringToObjectConverter {
 
 	@Override
 	@SuppressWarnings({ "unchecked", "rawtypes" })
-	public Object convert(String source, Class targetType) throws Exception {
+	public Enum convert(String source, Class targetType) throws Exception {
 		return Enum.valueOf(targetType, source);
 	}
 

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/conversion/StringToNumberConverter.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/conversion/StringToNumberConverter.java
@@ -19,7 +19,7 @@ import org.junit.platform.commons.util.Preconditions;
 
 class StringToNumberConverter implements StringToObjectConverter {
 
-	private static final Map<Class<?>, Function<String, ?>> CONVERTERS = Map.of( //
+	private static final Map<Class<? extends Number>, Function<String, ? extends Number>> CONVERTERS = Map.of( //
 		Byte.class, Byte::decode, //
 		Short.class, Short::decode, //
 		Integer.class, Integer::decode, //
@@ -39,8 +39,8 @@ class StringToNumberConverter implements StringToObjectConverter {
 	}
 
 	@Override
-	public Object convert(String source, Class<?> targetType) {
-		Function<String, ?> converter = Preconditions.notNull(CONVERTERS.get(targetType),
+	public Number convert(String source, Class<?> targetType) {
+		Function<String, ? extends Number> converter = Preconditions.notNull(CONVERTERS.get(targetType),
 			() -> "No registered converter for %s".formatted(targetType.getName()));
 		return converter.apply(source.replace("_", ""));
 	}


### PR DESCRIPTION
This PR cherry-picks a few changes from #4219 that narrow down the types used across the `StringToObjectConverter` hierarchy.