### PR TITLE
Return an immutable set from AbstractTestDescriptor::getChildren

### DIFF
--- a/documentation/modules/ROOT/partials/release-notes/release-notes-6.1.0.adoc
+++ b/documentation/modules/ROOT/partials/release-notes/release-notes-6.1.0.adoc
@@ -16,8 +16,8 @@ repository on GitHub.
 [[v6.1.0-junit-platform-bug-fixes]]
 ==== Bug Fixes
 
-* `TestDescriptor.getChildren()` now returns immutable set of children rather than a
-  merely unmodifiable.
+* `AbstractTestDescriptor.getChildren()` now returns immutable set of children rather than a
+  merely unmodifiable set.
 
 [[v6.1.0-junit-platform-deprecations-and-breaking-changes]]
 ==== Deprecations and Breaking Changes

--- a/documentation/modules/ROOT/partials/release-notes/release-notes-6.1.0.adoc
+++ b/documentation/modules/ROOT/partials/release-notes/release-notes-6.1.0.adoc
@@ -16,7 +16,8 @@ repository on GitHub.
 [[v6.1.0-junit-platform-bug-fixes]]
 ==== Bug Fixes
 
-* ❓
+* `TestDescriptor.getChildren()` now returns immutable set of children rather than a
+  merely unmodifiable.
 
 [[v6.1.0-junit-platform-deprecations-and-breaking-changes]]
 ==== Deprecations and Breaking Changes

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/TestDescriptor.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/TestDescriptor.java
@@ -345,8 +345,7 @@ public interface TestDescriptor {
 	default void accept(Visitor visitor) {
 		Preconditions.notNull(visitor, "Visitor must not be null");
 		visitor.visit(this);
-		// Create a copy of the set in order to avoid a ConcurrentModificationException
-		new LinkedHashSet<>(this.getChildren()).forEach(child -> child.accept(visitor));
+		this.getChildren().forEach(child -> child.accept(visitor));
 	}
 
 	/**

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/AbstractTestDescriptor.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/AbstractTestDescriptor.java
@@ -148,7 +148,7 @@ public abstract class AbstractTestDescriptor implements TestDescriptor {
 
 	@Override
 	public final Set<? extends TestDescriptor> getChildren() {
-		return Collections.unmodifiableSet(this.children);
+		return Collections.unmodifiableSet(new LinkedHashSet<>(this.children));
 	}
 
 	@Override

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/EngineExecutionOrchestrator.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/EngineExecutionOrchestrator.java
@@ -74,7 +74,8 @@ public class EngineExecutionOrchestrator {
 	 * {@linkplain TestExecutionListener testExecutionListener} of execution
 	 * events.
 	 */
-	@API(status = INTERNAL, since = "1.9", consumers = "org.junit.platform.suite.engine")
+	@API(status = INTERNAL, since = "1.9", consumers = { "org.junit.platform.testkit",
+			"org.junit.platform.suite.engine" })
 	public void execute(LauncherDiscoveryResult discoveryResult, EngineExecutionListener engineExecutionListener,
 			TestExecutionListener testExecutionListener, NamespacedHierarchicalStore<Namespace> requestLevelStore,
 			CancellationToken cancellationToken) {
@@ -176,8 +177,7 @@ public class EngineExecutionOrchestrator {
 	 * discovery results} and notifies the supplied {@linkplain
 	 * EngineExecutionListener listener} of execution events.
 	 */
-	@API(status = INTERNAL, since = "1.7", consumers = "org.junit.platform.testkit")
-	public void execute(LauncherDiscoveryResult discoveryResult, EngineExecutionListener engineExecutionListener,
+	private void execute(LauncherDiscoveryResult discoveryResult, EngineExecutionListener engineExecutionListener,
 			NamespacedHierarchicalStore<Namespace> requestLevelStore, CancellationToken cancellationToken) {
 		Preconditions.notNull(discoveryResult, "discoveryResult must not be null");
 		Preconditions.notNull(engineExecutionListener, "engineExecutionListener must not be null");

--- a/junit-platform-suite-engine/src/main/java/org/junit/platform/suite/engine/SuiteTestEngine.java
+++ b/junit-platform-suite-engine/src/main/java/org/junit/platform/suite/engine/SuiteTestEngine.java
@@ -12,6 +12,7 @@ package org.junit.platform.suite.engine;
 
 import static org.apiguardian.api.API.Status.INTERNAL;
 
+import java.util.LinkedHashSet;
 import java.util.Optional;
 
 import org.apiguardian.api.API;
@@ -71,12 +72,14 @@ public final class SuiteTestEngine implements TestEngine {
 
 		engineExecutionListener.executionStarted(suiteEngineDescriptor);
 
-		// @formatter:off
-		suiteEngineDescriptor.getChildren()
-				.stream()
-				.map(SuiteTestDescriptor.class::cast)
-				.forEach(suiteTestDescriptor -> suiteTestDescriptor.execute(engineExecutionListener, requestLevelStore, cancellationToken));
-		// @formatter:on
+		// Create a mutable copy so test descriptors can be made available for
+		// GC immediately after execution.
+		var children = new LinkedHashSet<>(suiteEngineDescriptor.getChildren());
+		for (var iterator = children.iterator(); iterator.hasNext();) {
+			var suiteTestDescriptor = (SuiteTestDescriptor) iterator.next();
+			suiteTestDescriptor.execute(engineExecutionListener, requestLevelStore, cancellationToken);
+			iterator.remove();
+		}
 		engineExecutionListener.executionFinished(suiteEngineDescriptor, TestExecutionResult.successful());
 	}
 

--- a/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/EngineTestKit.java
+++ b/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/EngineTestKit.java
@@ -44,6 +44,7 @@ import org.junit.platform.engine.TestEngine;
 import org.junit.platform.engine.support.store.Namespace;
 import org.junit.platform.engine.support.store.NamespacedHierarchicalStore;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
+import org.junit.platform.launcher.TestExecutionListener;
 import org.junit.platform.launcher.core.EngineDiscoveryOrchestrator;
 import org.junit.platform.launcher.core.EngineExecutionOrchestrator;
 import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
@@ -259,8 +260,11 @@ public final class EngineTestKit {
 		LauncherDiscoveryResult discoveryResult = discoverUsingOrchestrator(testEngine, discoveryRequest);
 		TestDescriptor engineTestDescriptor = discoveryResult.getEngineTestDescriptor(testEngine);
 		Preconditions.notNull(engineTestDescriptor, "TestEngine did not yield a TestDescriptor");
-		withRequestLevelStore(
-			store -> new EngineExecutionOrchestrator().execute(discoveryResult, listener, store, cancellationToken));
+		TestExecutionListener noop = new TestExecutionListener() {
+
+		};
+		withRequestLevelStore(store -> new EngineExecutionOrchestrator().execute(discoveryResult, listener, noop, store,
+			cancellationToken));
 	}
 
 	private static void withRequestLevelStore(Consumer<NamespacedHierarchicalStore<Namespace>> action) {

--- a/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/EngineTestKit.java
+++ b/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/EngineTestKit.java
@@ -254,17 +254,17 @@ public final class EngineTestKit {
 	}
 
 	private static void executeUsingLauncherOrchestration(TestEngine testEngine,
-			LauncherDiscoveryRequest discoveryRequest, EngineExecutionListener listener,
+			LauncherDiscoveryRequest discoveryRequest, EngineExecutionListener engineExecutionListener,
 			CancellationToken cancellationToken) {
 
 		LauncherDiscoveryResult discoveryResult = discoverUsingOrchestrator(testEngine, discoveryRequest);
 		TestDescriptor engineTestDescriptor = discoveryResult.getEngineTestDescriptor(testEngine);
 		Preconditions.notNull(engineTestDescriptor, "TestEngine did not yield a TestDescriptor");
-		TestExecutionListener noop = new TestExecutionListener() {
+		TestExecutionListener noopTestExecutionListener = new TestExecutionListener() {
 
 		};
-		withRequestLevelStore(store -> new EngineExecutionOrchestrator().execute(discoveryResult, listener, noop, store,
-			cancellationToken));
+		withRequestLevelStore(store -> new EngineExecutionOrchestrator().execute(discoveryResult,
+			engineExecutionListener, noopTestExecutionListener, store, cancellationToken));
 	}
 
 	private static void withRequestLevelStore(Consumer<NamespacedHierarchicalStore<Namespace>> action) {

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/descriptor/VintageEngineDescriptor.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/descriptor/VintageEngineDescriptor.java
@@ -12,7 +12,10 @@ package org.junit.vintage.engine.descriptor;
 
 import static org.apiguardian.api.API.Status.INTERNAL;
 
+import java.util.Set;
+
 import org.apiguardian.api.API;
+import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.support.descriptor.EngineDescriptor;
 
@@ -24,6 +27,10 @@ public class VintageEngineDescriptor extends EngineDescriptor {
 
 	public VintageEngineDescriptor(UniqueId uniqueId) {
 		super(uniqueId, "JUnit Vintage");
+	}
+
+	public Set<TestDescriptor> getModifiableChildren() {
+		return children;
 	}
 
 }

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/descriptor/VintageEngineDescriptor.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/descriptor/VintageEngineDescriptor.java
@@ -12,10 +12,7 @@ package org.junit.vintage.engine.descriptor;
 
 import static org.apiguardian.api.API.Status.INTERNAL;
 
-import java.util.Set;
-
 import org.apiguardian.api.API;
-import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.support.descriptor.EngineDescriptor;
 
@@ -27,10 +24,6 @@ public class VintageEngineDescriptor extends EngineDescriptor {
 
 	public VintageEngineDescriptor(UniqueId uniqueId) {
 		super(uniqueId, "JUnit Vintage");
-	}
-
-	public Set<TestDescriptor> getModifiableChildren() {
-		return children;
 	}
 
 }

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/execution/VintageExecutor.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/execution/VintageExecutor.java
@@ -14,6 +14,7 @@ import static java.util.Objects.requireNonNullElse;
 import static org.apiguardian.api.API.Status.INTERNAL;
 
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -86,12 +87,16 @@ public class VintageExecutor {
 
 	private void executeClassesAndMethodsSequentially(CancellationToken cancellationToken) {
 		RunnerExecutor runnerExecutor = new RunnerExecutor(engineExecutionListener, cancellationToken);
-		engineDescriptor.getChildren().stream() //
-				.map(RunnerTestDescriptor.class::cast) //
-				.forEach(it -> {
-					runnerExecutor.execute(it);
-					it.removeFromHierarchy();
-				});
+		// Create a copy to avoid a ConcurrentModificationException
+		var children = new LinkedHashSet<>(engineDescriptor.getModifiableChildren());
+		for (var iterator = children.iterator(); iterator.hasNext();) {
+			var testDescriptor = (RunnerTestDescriptor) iterator.next();
+			runnerExecutor.execute(testDescriptor);
+			// Remove testDescriptor references from the engine to allow garbage collection
+			testDescriptor.removeFromHierarchy();
+			// Remove copied testDescriptor references to allow garbage collection
+			iterator.remove();
+		}
 	}
 
 	private boolean executeInParallel(CancellationToken cancellationToken) {

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/execution/VintageExecutor.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/execution/VintageExecutor.java
@@ -93,7 +93,10 @@ public class VintageExecutor {
 			var testDescriptor = (RunnerTestDescriptor) iterator.next();
 			runnerExecutor.execute(testDescriptor);
 			// Remove testDescriptor references from the engine to allow garbage collection
-			testDescriptor.removeFromHierarchy();
+			// TODO: This is weird.
+			if (!testDescriptor.isRoot()) {
+				testDescriptor.removeFromHierarchy();
+			}
 			// Remove copied testDescriptor references to allow garbage collection
 			iterator.remove();
 		}

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/execution/VintageExecutor.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/execution/VintageExecutor.java
@@ -87,17 +87,14 @@ public class VintageExecutor {
 
 	private void executeClassesAndMethodsSequentially(CancellationToken cancellationToken) {
 		RunnerExecutor runnerExecutor = new RunnerExecutor(engineExecutionListener, cancellationToken);
-		// Create a copy to avoid a ConcurrentModificationException
-		var children = new LinkedHashSet<>(engineDescriptor.getModifiableChildren());
+		// Create a mutable copy so test descriptors can be made available for
+		// GC immediately after execution.
+		var children = new LinkedHashSet<>(engineDescriptor.getChildren());
 		for (var iterator = children.iterator(); iterator.hasNext();) {
 			var testDescriptor = (RunnerTestDescriptor) iterator.next();
 			runnerExecutor.execute(testDescriptor);
-			// Remove testDescriptor references from the engine to allow garbage collection
-			// TODO: This is weird.
-			if (!testDescriptor.isRoot()) {
-				testDescriptor.removeFromHierarchy();
-			}
-			// Remove copied testDescriptor references to allow garbage collection
+			// Remove the test descriptor from the engine and iterable to allow GC.
+			engineDescriptor.removeChild(testDescriptor);
 			iterator.remove();
 		}
 	}

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/execution/VintageExecutor.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/execution/VintageExecutor.java
@@ -14,7 +14,6 @@ import static java.util.Objects.requireNonNullElse;
 import static org.apiguardian.api.API.Status.INTERNAL;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -30,7 +29,6 @@ import org.junit.platform.commons.util.ExceptionUtils;
 import org.junit.platform.engine.CancellationToken;
 import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.engine.EngineExecutionListener;
-import org.junit.platform.engine.TestDescriptor;
 import org.junit.vintage.engine.Constants;
 import org.junit.vintage.engine.descriptor.RunnerTestDescriptor;
 import org.junit.vintage.engine.descriptor.VintageEngineDescriptor;
@@ -88,10 +86,12 @@ public class VintageExecutor {
 
 	private void executeClassesAndMethodsSequentially(CancellationToken cancellationToken) {
 		RunnerExecutor runnerExecutor = new RunnerExecutor(engineExecutionListener, cancellationToken);
-		for (Iterator<TestDescriptor> iterator = engineDescriptor.getModifiableChildren().iterator(); iterator.hasNext();) {
-			runnerExecutor.execute((RunnerTestDescriptor) iterator.next());
-			iterator.remove();
-		}
+		engineDescriptor.getChildren().stream() //
+				.map(RunnerTestDescriptor.class::cast) //
+				.forEach(it -> {
+					runnerExecutor.execute(it);
+					it.removeFromHierarchy();
+				});
 	}
 
 	private boolean executeInParallel(CancellationToken cancellationToken) {
@@ -126,7 +126,7 @@ public class VintageExecutor {
 	}
 
 	private List<RunnerTestDescriptor> collectRunnerTestDescriptors(ExecutorService executorService) {
-		return engineDescriptor.getModifiableChildren().stream() //
+		return engineDescriptor.getChildren().stream() //
 				.map(RunnerTestDescriptor.class::cast) //
 				.map(it -> methods ? parallelMethodExecutor(it, executorService) : it) //
 				.toList();

--- a/junit-vintage-engine/src/test/java/org/junit/vintage/engine/VintageTestEngineExecutionTests.java
+++ b/junit-vintage-engine/src/test/java/org/junit/vintage/engine/VintageTestEngineExecutionTests.java
@@ -50,6 +50,8 @@ import org.junit.platform.engine.ExecutionRequest;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.UniqueId;
+import org.junit.platform.engine.discovery.DiscoverySelectors;
+import org.junit.platform.launcher.LauncherConstants;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
 import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
 import org.junit.platform.testkit.engine.EngineExecutionResults;
@@ -158,6 +160,46 @@ class VintageTestEngineExecutionTests {
 			event(test("successfulTest"), started()), //
 			event(test("successfulTest"), finishedSuccessfully()), //
 			event(container(testClass), finishedSuccessfully()), //
+			event(engine(), finishedSuccessfully()));
+	}
+
+	@Test
+	void executesMultiplePlainJUnit4TestCases() {
+		LauncherDiscoveryRequest request = LauncherDiscoveryRequestBuilder.request() //
+				.selectors(DiscoverySelectors.selectClass(PlainJUnit4TestCaseWithTwoTestMethods.class),
+					DiscoverySelectors.selectClass(PlainJUnit4TestCaseWithFiveTestMethods.class)) //
+				.enableImplicitConfigurationParameters(false) //
+				.build();
+
+		execute(request).allEvents().assertEventsMatchLoosely( //
+			event(engine(), started()), //
+			event(container(PlainJUnit4TestCaseWithTwoTestMethods.class), started()), //
+			event(container(PlainJUnit4TestCaseWithTwoTestMethods.class), finishedSuccessfully()), //
+			event(container(PlainJUnit4TestCaseWithFiveTestMethods.class), started()), //
+			event(container(PlainJUnit4TestCaseWithFiveTestMethods.class), finishedSuccessfully()), //
+			event(engine(), finishedSuccessfully()));
+	}
+
+	@Test
+	void executesMultiplePlainJUnit4TestCasesWithMemoryCleanupEnabled() {
+		LauncherDiscoveryRequest request = LauncherDiscoveryRequestBuilder.request() //
+				.configurationParameter(LauncherConstants.MEMORY_CLEANUP_ENABLED_PROPERTY_NAME, "true") //
+				.configurationParameter(LauncherConstants.STACKTRACE_PRUNING_ENABLED_PROPERTY_NAME, "false") //
+				.selectors( //
+					DiscoverySelectors.selectClass(PlainJUnit4TestCaseWithTwoTestMethods.class), //
+					DiscoverySelectors.selectClass(PlainJUnit4TestCaseWithFiveTestMethods.class)) //
+				.enableImplicitConfigurationParameters(false) //
+				.build();
+
+		EngineExecutionResults execute = execute(request);
+
+		// TODO: Disable debug
+		execute.allEvents().debug().assertEventsMatchLoosely( //
+			event(engine(), started()), //
+			event(container(PlainJUnit4TestCaseWithTwoTestMethods.class), started()), //
+			event(container(PlainJUnit4TestCaseWithTwoTestMethods.class), finishedSuccessfully()), //
+			event(container(PlainJUnit4TestCaseWithFiveTestMethods.class), started()), //
+			event(container(PlainJUnit4TestCaseWithFiveTestMethods.class), finishedSuccessfully()), //
 			event(engine(), finishedSuccessfully()));
 	}
 

--- a/junit-vintage-engine/src/test/java/org/junit/vintage/engine/VintageTestEngineExecutionTests.java
+++ b/junit-vintage-engine/src/test/java/org/junit/vintage/engine/VintageTestEngineExecutionTests.java
@@ -193,8 +193,7 @@ class VintageTestEngineExecutionTests {
 
 		EngineExecutionResults execute = execute(request);
 
-		// TODO: Disable debug
-		execute.allEvents().debug().assertEventsMatchLoosely( //
+		execute.allEvents().assertEventsMatchLoosely( //
 			event(engine(), started()), //
 			event(container(PlainJUnit4TestCaseWithTwoTestMethods.class), started()), //
 			event(container(PlainJUnit4TestCaseWithTwoTestMethods.class), finishedSuccessfully()), //

--- a/platform-tests/src/test/java/org/junit/platform/suite/engine/SuiteEngineTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/suite/engine/SuiteEngineTests.java
@@ -55,6 +55,7 @@ import org.junit.platform.engine.support.descriptor.ClassSource;
 import org.junit.platform.engine.support.descriptor.MethodSource;
 import org.junit.platform.engine.support.store.Namespace;
 import org.junit.platform.engine.support.store.NamespacedHierarchicalStore;
+import org.junit.platform.launcher.LauncherConstants;
 import org.junit.platform.launcher.PostDiscoveryFilter;
 import org.junit.platform.launcher.core.NamespacedHierarchicalStoreProviders;
 import org.junit.platform.suite.api.AfterSuite;
@@ -106,9 +107,9 @@ class SuiteEngineTests {
 	@ValueSource(classes = { SelectClassesSuite.class, InheritedSuite.class })
 	void selectClasses(Class<?> suiteClass) {
 		// @formatter:off
-		EngineTestKit.Builder builder = EngineTestKit.engine(ENGINE_ID)
-				.selectors(selectClass(suiteClass));
-			var testKit = builder.outputDirectoryCreator(hierarchicalOutputDirectoryCreator(outputDir));
+		EngineTestKit.Builder testKit = EngineTestKit.engine(ENGINE_ID)
+				.selectors(selectClass(suiteClass))
+				.outputDirectoryCreator(hierarchicalOutputDirectoryCreator(outputDir));
 
 		assertThat(testKit.discover().getDiscoveryIssues())
 				.isEmpty();
@@ -306,15 +307,60 @@ class SuiteEngineTests {
 	@Test
 	void suiteSuite() {
 		// @formatter:off
-		EngineTestKit.Builder builder = EngineTestKit.engine(ENGINE_ID)
-				.selectors(selectClass(SuiteSuite.class));
-			builder.outputDirectoryCreator(hierarchicalOutputDirectoryCreator(outputDir))
+		EngineTestKit.engine(ENGINE_ID)
+				.selectors(selectClass(SuiteSuite.class))
+				.outputDirectoryCreator(hierarchicalOutputDirectoryCreator(outputDir))
 				.execute()
 				.testEvents()
 				.assertThatEvents()
 				.haveExactly(1, event(test(SuiteSuite.class.getName()), finishedSuccessfully()))
 				.haveExactly(1, event(test(SelectClassesSuite.class.getName()), finishedSuccessfully()))
 				.haveExactly(1, event(test(SingleTestTestCase.class.getName()), finishedSuccessfully()));
+		// @formatter:on
+	}
+
+	@Test
+	void multipleSuites() {
+		// @formatter:off
+		var testKit = EngineTestKit.engine(ENGINE_ID)
+				.selectors(
+						selectClass(SelectClassesSuite.class),
+						selectClass(MultipleSuite.class)
+				)
+				.outputDirectoryCreator(hierarchicalOutputDirectoryCreator(outputDir));
+
+		assertThat(testKit.discover().getDiscoveryIssues())
+				.isEmpty();
+
+		testKit
+				.execute()
+				.testEvents()
+				.assertThatEvents()
+				.haveExactly(1, event(test(SelectClassesSuite.class.getName()), finishedSuccessfully()))
+				.haveExactly(2, event(test(MultipleSuite.class.getName()), finishedSuccessfully()));
+		// @formatter:on
+	}
+
+	@Test
+	void multipleSuitesWithMemoryCleanupEnabled() {
+		// @formatter:off
+		var testKit = EngineTestKit.engine(ENGINE_ID)
+				.configurationParameter(LauncherConstants.MEMORY_CLEANUP_ENABLED_PROPERTY_NAME, "true") //
+				.selectors(
+						selectClass(SelectClassesSuite.class),
+						selectClass(MultipleSuite.class)
+				)
+				.outputDirectoryCreator(hierarchicalOutputDirectoryCreator(outputDir));
+
+		assertThat(testKit.discover().getDiscoveryIssues())
+				.isEmpty();
+
+		testKit
+				.execute()
+				.testEvents()
+				.assertThatEvents()
+				.haveExactly(1, event(test(SelectClassesSuite.class.getName()), finishedSuccessfully()))
+				.haveExactly(2, event(test(MultipleSuite.class.getName()), finishedSuccessfully()));
 		// @formatter:on
 	}
 

--- a/platform-tests/src/test/java/org/junit/platform/testkit/engine/EngineTestKitTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/testkit/engine/EngineTestKitTests.java
@@ -81,7 +81,8 @@ class EngineTestKitTests {
 			ArgumentCaptor<NamespacedHierarchicalStore<Namespace>> storeCaptor = forClass(
 				NamespacedHierarchicalStore.class);
 
-			verify(mockOrchestrator).execute(any(), any(), storeCaptor.capture(), eq(CancellationToken.disabled()));
+			verify(mockOrchestrator).execute(any(), any(), any(), storeCaptor.capture(),
+				eq(CancellationToken.disabled()));
 			assertNotNull(storeCaptor.getValue(), "Request level store should be passed to execute");
 		}
 	}


### PR DESCRIPTION
The Javadoc on `TestDescriptor::getChildren` promises to return an immutable set. But in `AbstractTestDescriptor` the returned set is backed by `this.children` which can be modified by invoking `removeFromHierarchy()`, as such the returned set is only unmodifiable.

By making a copy first the set becomes immutable. This also ensures the semantics of `.getChildren()` are now identical to `.getAncestors()` and `.getDescendants()`.

The difference between unmodifiable and immutable matters. After `junit.platform.execution.memory.cleanup.enabled` was introduced in  #5588 we found that both the `SuiteEngine` and `Vintage` engine make  some assumptions.
  
* The `SuiteEngine` iterates over its children with the assumption that this collection is immutable. This is directly resolved by making the returned collection immutable.
* The `VintageEngine` assumes that its children are not externally  modified. This is resolved by using `removeChild` to remove   the `RunnerTestDescriptor`.
 
Closes: #5344.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
  - [x]  Test memory cleanup mode against `VintageEngine`
  - [x]  Test memory cleanup mode against `SuiteEngine`
- [x] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://docs.junit.org/snapshot/) and [Release Notes](https://docs.junit.org/snapshot/release-notes.html)
