### PR TITLE
Fix typo: county -> country. Improve Javadoc @link with WritesDefaultLocale

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/util/DefaultLocale.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/util/DefaultLocale.java
@@ -34,8 +34,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
  *     <li>using a {@link Locale.Builder Locale.Builder} together with
  *         <ul>
  *            <li>a language</li>
- *            <li>a language and a county</li>
- *            <li>a language, a county, and a variant</li>
+ *            <li>a language and a country</li>
+ *            <li>a language, a country, and a variant</li>
  *         </ul>
  *     </li>
  * </ul>
@@ -62,7 +62,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * <a href="https://docs.junit.org/current/writing-tests/parallel-execution.html">parallel test execution</a>,
  * all tests annotated with {@link DefaultLocale @DefaultLocale},
  * {@link ReadsDefaultLocale @ReadsDefaultLocale}, and
- * {@link WritesDefaultLocale} are scheduled in a way that guarantees
+ * {@link WritesDefaultLocale @WritesDefaultLocale} are scheduled in a way that guarantees
  * correctness under mutation of shared global state.
  *
  * <p>For more details and examples, see the


### PR DESCRIPTION
Very minor PR to fix a typo and have the same `@WritesDefaultLocale` notation as the other two annotations in the Javadoc.

I was checking out the new JUnit 6.1 RC and especially the new `@DefaultLocale` and `@SetSystemProperty`. 
Found this typos on the way reading and using them.

Background: We are using JUnit at [JavaFX](https://github.com/openjdk/jfx), where we migrated away from JUnit 4 -> JUnit 5 (https://github.com/openjdk/jfx/pull/1774) and soon to JUnit 6 (directly to 6.1 probably). 
Just want to let you know that those two extensions will be very helpful for us, thanks!

_EDIT: Just signed the commit, amended and force pushed it._

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://docs.junit.org/snapshot/) and [Release Notes](https://docs.junit.org/snapshot/release-notes.html)
