### PR TITLE
Lock discussion on resolved issues

### DIFF
--- a/.github/workflows/lock-resolved-issues.yml
+++ b/.github/workflows/lock-resolved-issues.yml
@@ -1,0 +1,26 @@
+name: Lock resolved issues
+
+on:
+  schedule:
+    - cron: '13 7 * * 6'
+  workflow_dispatch:
+
+concurrency:
+  group: lock-resolved-issues
+
+jobs:
+  action:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+      discussions: write
+    steps:
+      - uses: dessant/lock-threads@7266a7ce5c1df01b1c6db85bf8cd86c737dadbe7 # v6.0.0
+        with:
+          issue-comment: |
+            This issue was resolved and the conversation been locked due to inactivity.
+
+            The JUnit team generally speaking doesn't look at resolved issues. If you do have a similar request or problem, please create a new issue. You can include a reference to this issue to provide additional context.
+          process-only: issues
+          log-output: true


### PR DESCRIPTION
There is a small trickle of people who comment on an old already closed issue with a question or feature request. Unfortunately, by doing this their comment falls outside of workflow. We generally only look at and discuss new issues.

Presumably people who do this have put in some effort to research our backlog for related items. By locking the thread with an instructional explanation we can hopefully nudge them into the right direction.

By default, [`dessant/lock-threads`](https://github.com/dessant/lock-threads) will lock the conversation on resolved issues, pull requests and discussions after 365 days. This has been limited to just issues.


---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
