### PR TITLE
Make `ConsoleLauncher`-created `ClassLoader` uncloseable

### DIFF
--- a/documentation/modules/ROOT/partials/release-notes/release-notes-6.2.0-M1.adoc
+++ b/documentation/modules/ROOT/partials/release-notes/release-notes-6.2.0-M1.adoc
@@ -26,7 +26,9 @@ repository on GitHub.
 [[v6.2.0-M1-junit-platform-new-features-and-improvements]]
 ==== New Features and Improvements
 
-* ❓
+* When using `ConsoleLauncher` with the `-cp`/`--classpath` option, it now creates a
+  custom `ClassLoader` that does _not_ implement `AutoCloseable` to avoid accidentally
+  closing it in test code which can lead to test failures that are hard to diagnose.
 
 
 [[v6.2.0-M1-junit-jupiter]]

--- a/junit-platform-console/src/main/java/org/junit/platform/console/command/ConsoleTestExecutor.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/command/ConsoleTestExecutor.java
@@ -165,15 +165,14 @@ public class ConsoleTestExecutor {
 		launcher.execute(executionRequest);
 	}
 
-	private Optional<ClassLoader> createCustomClassLoader() {
+	private @Nullable CustomClassLoader createCustomClassLoader() {
 		List<Path> additionalClasspathEntries = discoveryOptions.getExistingAdditionalClasspathEntries();
 		if (!additionalClasspathEntries.isEmpty()) {
 			URL[] urls = additionalClasspathEntries.stream().map(this::toURL).toArray(URL[]::new);
 			ClassLoader parentClassLoader = ClassLoaderUtils.getDefaultClassLoader();
-			ClassLoader customClassLoader = URLClassLoader.newInstance(urls, parentClassLoader);
-			return Optional.of(customClassLoader);
+			return new CustomClassLoader(URLClassLoader.newInstance(urls, parentClassLoader));
 		}
-		return Optional.empty();
+		return null;
 	}
 
 	private URL toURL(Path path) {

--- a/junit-platform-console/src/main/java/org/junit/platform/console/command/CustomClassLoader.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/command/CustomClassLoader.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.console.command;
+
+import java.net.URLClassLoader;
+
+/**
+ * Custom class loader that proxies a {@link URLClassLoader} but does
+ * <em>not</em> implement {@link AutoCloseable} so user code is less likely to
+ * accidentally close it.
+ *
+ * @since 6.2
+ */
+class CustomClassLoader extends ClassLoader {
+
+	CustomClassLoader(URLClassLoader parent) {
+		super(parent);
+	}
+
+	void close() throws Exception {
+		((URLClassLoader) getParent()).close();
+	}
+}

--- a/junit-platform-console/src/main/java/org/junit/platform/console/command/CustomClassLoaderCloseStrategy.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/command/CustomClassLoaderCloseStrategy.java
@@ -30,14 +30,12 @@ public enum CustomClassLoaderCloseStrategy {
 	CLOSE_AFTER_CALLING_LAUNCHER {
 
 		@Override
-		public void handle(ClassLoader customClassLoader) {
-			if (customClassLoader instanceof @SuppressWarnings("resource") AutoCloseable closeable) {
-				try {
-					closeable.close();
-				}
-				catch (Exception ex) {
-					throw new JUnitException("Failed to close custom class loader", ex);
-				}
+		void handle(CustomClassLoader customClassLoader) {
+			try {
+				customClassLoader.close();
+			}
+			catch (Exception ex) {
+				throw new JUnitException("Failed to close custom class loader", ex);
 			}
 		}
 	},
@@ -52,7 +50,7 @@ public enum CustomClassLoaderCloseStrategy {
 	KEEP_OPEN {
 
 		@Override
-		public void handle(ClassLoader customClassLoader) {
+		void handle(CustomClassLoader customClassLoader) {
 			// do nothing
 		}
 	};
@@ -60,6 +58,6 @@ public enum CustomClassLoaderCloseStrategy {
 	/**
 	 * Handle the class loader according to the strategy.
 	 */
-	public abstract void handle(ClassLoader classLoader);
+	abstract void handle(CustomClassLoader classLoader);
 
 }

--- a/junit-platform-console/src/main/java/org/junit/platform/console/command/CustomContextClassLoaderExecutor.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/command/CustomContextClassLoaderExecutor.java
@@ -10,37 +10,38 @@
 
 package org.junit.platform.console.command;
 
-import java.util.Optional;
 import java.util.function.Supplier;
+
+import org.jspecify.annotations.Nullable;
 
 /**
  * @since 1.0
  */
 class CustomContextClassLoaderExecutor {
 
-	private final Optional<ClassLoader> customClassLoader;
+	private final @Nullable CustomClassLoader customClassLoader;
 	private final CustomClassLoaderCloseStrategy closeStrategy;
 
-	CustomContextClassLoaderExecutor(Optional<ClassLoader> customClassLoader) {
+	CustomContextClassLoaderExecutor(@Nullable CustomClassLoader customClassLoader) {
 		this(customClassLoader, CustomClassLoaderCloseStrategy.CLOSE_AFTER_CALLING_LAUNCHER);
 	}
 
-	CustomContextClassLoaderExecutor(Optional<ClassLoader> customClassLoader,
+	CustomContextClassLoaderExecutor(@Nullable CustomClassLoader customClassLoader,
 			CustomClassLoaderCloseStrategy closeStrategy) {
 		this.customClassLoader = customClassLoader;
 		this.closeStrategy = closeStrategy;
 	}
 
 	<T> T invoke(Supplier<T> supplier) {
-		if (customClassLoader.isPresent()) {
+		if (customClassLoader != null) {
 			// Only get/set context class loader when necessary to prevent problems with
 			// security managers
-			return replaceThreadContextClassLoaderAndInvoke(customClassLoader.get(), supplier);
+			return replaceThreadContextClassLoaderAndInvoke(customClassLoader, supplier);
 		}
 		return supplier.get();
 	}
 
-	private <T> T replaceThreadContextClassLoaderAndInvoke(ClassLoader customClassLoader, Supplier<T> supplier) {
+	private <T> T replaceThreadContextClassLoaderAndInvoke(CustomClassLoader customClassLoader, Supplier<T> supplier) {
 		ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
 		try {
 			Thread.currentThread().setContextClassLoader(customClassLoader);

--- a/platform-tests/src/test/java/org/junit/platform/console/command/CustomContextClassLoaderExecutorTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/console/command/CustomContextClassLoaderExecutorTests.java
@@ -18,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.jupiter.api.Test;
@@ -31,7 +30,7 @@ class CustomContextClassLoaderExecutorTests {
 	@Test
 	void invokeWithoutCustomClassLoaderDoesNotSetClassLoader() {
 		var originalClassLoader = Thread.currentThread().getContextClassLoader();
-		var executor = new CustomContextClassLoaderExecutor(Optional.empty());
+		var executor = new CustomContextClassLoaderExecutor(null);
 
 		int result = executor.invoke(() -> {
 			assertSame(originalClassLoader, Thread.currentThread().getContextClassLoader());
@@ -45,8 +44,8 @@ class CustomContextClassLoaderExecutorTests {
 	@Test
 	void invokeWithCustomClassLoaderSetsCustomAndResetsToOriginal() {
 		var originalClassLoader = Thread.currentThread().getContextClassLoader();
-		ClassLoader customClassLoader = URLClassLoader.newInstance(new URL[0]);
-		var executor = new CustomContextClassLoaderExecutor(Optional.of(customClassLoader));
+		var customClassLoader = new CustomClassLoader(URLClassLoader.newInstance(new URL[0]));
+		var executor = new CustomContextClassLoaderExecutor(customClassLoader);
 
 		int result = executor.invoke(() -> {
 			assertSame(customClassLoader, Thread.currentThread().getContextClassLoader());
@@ -60,14 +59,14 @@ class CustomContextClassLoaderExecutorTests {
 	@Test
 	void invokeWithCustomClassLoaderAndEnsureItIsClosedAfterUsage() {
 		var closed = new AtomicBoolean(false);
-		ClassLoader localClassLoader = new URLClassLoader(new URL[0]) {
+		var localClassLoader = new URLClassLoader(new URL[0]) {
 			@Override
 			public void close() throws IOException {
 				closed.set(true);
 				super.close();
 			}
 		};
-		var executor = new CustomContextClassLoaderExecutor(Optional.of(localClassLoader));
+		var executor = new CustomContextClassLoaderExecutor(new CustomClassLoader(localClassLoader));
 
 		int result = executor.invoke(() -> 4711);
 
@@ -78,14 +77,14 @@ class CustomContextClassLoaderExecutorTests {
 	@Test
 	void invokeWithCustomClassLoaderAndKeepItOpenAfterUsage() {
 		var closed = new AtomicBoolean(false);
-		ClassLoader localClassLoader = new URLClassLoader(new URL[0]) {
+		var localClassLoader = new URLClassLoader(new URL[0]) {
 			@Override
 			public void close() throws IOException {
 				closed.set(true);
 				super.close();
 			}
 		};
-		var executor = new CustomContextClassLoaderExecutor(Optional.of(localClassLoader),
+		var executor = new CustomContextClassLoaderExecutor(new CustomClassLoader(localClassLoader),
 			CustomClassLoaderCloseStrategy.KEEP_OPEN);
 
 		int result = executor.invoke(() -> 4711);


### PR DESCRIPTION
To avoid hard to diagnose issues like #5632.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://docs.junit.org/snapshot/) and [Release Notes](https://docs.junit.org/snapshot/release-notes.html)
