### PR TITLE
Include hint about enabling thread dumps in timeout failures

### DIFF
--- a/documentation/modules/ROOT/partials/release-notes/release-notes-6.2.0-M1.adoc
+++ b/documentation/modules/ROOT/partials/release-notes/release-notes-6.2.0-M1.adoc
@@ -45,7 +45,8 @@ repository on GitHub.
 [[v6.2.0-M1-junit-jupiter-new-features-and-improvements]]
 ==== New Features and Improvements
 
-* ❓
+* Failures caused by `@Timeout` expirations now include a hint about enabling
+  xref:writing-tests/timeouts.adoc#debugging-thread-dump[thread dumps].
 
 
 [[v6.2.0-M1-junit-vintage]]

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/SameThreadTimeoutInvocation.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/SameThreadTimeoutInvocation.java
@@ -14,7 +14,7 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
-import java.util.function.Supplier;
+import java.util.concurrent.TimeoutException;
 
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.extension.InvocationInterceptor.Invocation;
@@ -25,30 +25,24 @@ import org.junit.platform.commons.util.UnrecoverableExceptions;
  */
 class SameThreadTimeoutInvocation<T extends @Nullable Object> implements Invocation<T> {
 
-	private final Invocation<T> delegate;
-	private final TimeoutDuration timeout;
+	private final TimeoutInvocationParameters<T> parameters;
 	private final ScheduledExecutorService executor;
-	private final Supplier<String> descriptionSupplier;
-	private final PreInterruptCallbackInvocation preInterruptCallback;
 
-	SameThreadTimeoutInvocation(Invocation<T> delegate, TimeoutDuration timeout, ScheduledExecutorService executor,
-			Supplier<String> descriptionSupplier, PreInterruptCallbackInvocation preInterruptCallback) {
-		this.delegate = delegate;
-		this.timeout = timeout;
+	SameThreadTimeoutInvocation(TimeoutInvocationParameters<T> parameters, ScheduledExecutorService executor) {
+		this.parameters = parameters;
 		this.executor = executor;
-		this.descriptionSupplier = descriptionSupplier;
-		this.preInterruptCallback = preInterruptCallback;
 	}
 
 	@SuppressWarnings("NullAway")
 	@Override
 	public T proceed() throws Throwable {
-		InterruptTask interruptTask = new InterruptTask(Thread.currentThread(), preInterruptCallback);
+		InterruptTask interruptTask = new InterruptTask(Thread.currentThread(), parameters.preInterruptCallback());
+		var timeout = parameters.timeout();
 		ScheduledFuture<?> future = executor.schedule(interruptTask, timeout.value(), timeout.unit());
 		Throwable failure = null;
 		T result = null;
 		try {
-			result = delegate.proceed();
+			result = parameters.invocation().proceed();
 		}
 		catch (Throwable t) {
 			UnrecoverableExceptions.rethrowIfUnrecoverable(t);
@@ -61,7 +55,7 @@ class SameThreadTimeoutInvocation<T extends @Nullable Object> implements Invocat
 			}
 			if (interruptTask.executed) {
 				Thread.interrupted();
-				failure = TimeoutExceptionFactory.create(descriptionSupplier.get(), timeout, failure);
+				failure = newTimeoutException(failure);
 				interruptTask.attachSuppressedExceptions(failure);
 			}
 		}
@@ -69,6 +63,11 @@ class SameThreadTimeoutInvocation<T extends @Nullable Object> implements Invocat
 			throw failure;
 		}
 		return result;
+	}
+
+	private TimeoutException newTimeoutException(@Nullable Throwable failure) {
+		return TimeoutExceptionFactory.create(parameters.descriptionSupplier().get(), parameters.timeout(),
+			parameters.threadDumpEnabled(), failure);
 	}
 
 	static class InterruptTask implements Runnable {

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/SeparateThreadTimeoutInvocation.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/SeparateThreadTimeoutInvocation.java
@@ -13,7 +13,6 @@ package org.junit.jupiter.engine.extension;
 import static org.junit.jupiter.api.timeout.PreemptiveTimeoutUtils.executeWithPreemptiveTimeout;
 
 import java.util.concurrent.TimeoutException;
-import java.util.function.Supplier;
 
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.extension.InvocationInterceptor.Invocation;
@@ -23,30 +22,29 @@ import org.junit.jupiter.api.extension.InvocationInterceptor.Invocation;
  */
 class SeparateThreadTimeoutInvocation<T extends @Nullable Object> implements Invocation<T> {
 
-	private final Invocation<T> delegate;
-	private final TimeoutDuration timeout;
-	private final Supplier<String> descriptionSupplier;
-	private final PreInterruptCallbackInvocation preInterruptCallback;
+	private final TimeoutInvocationParameters<T> parameters;
 
-	SeparateThreadTimeoutInvocation(Invocation<T> delegate, TimeoutDuration timeout,
-			Supplier<String> descriptionSupplier, PreInterruptCallbackInvocation preInterruptCallback) {
-		this.delegate = delegate;
-		this.timeout = timeout;
-		this.descriptionSupplier = descriptionSupplier;
-		this.preInterruptCallback = preInterruptCallback;
+	SeparateThreadTimeoutInvocation(TimeoutInvocationParameters<T> parameters) {
+		this.parameters = parameters;
 	}
 
 	@Override
 	@SuppressWarnings("NullAway")
 	public T proceed() throws Throwable {
+		var timeout = parameters.timeout();
+		var delegate = parameters.invocation();
+		var descriptionSupplier = parameters.descriptionSupplier();
 		return executeWithPreemptiveTimeout(timeout.toDuration(), delegate::proceed, descriptionSupplier,
-			(__, ___, cause, testThread) -> {
-				TimeoutException exception = TimeoutExceptionFactory.create(descriptionSupplier.get(), timeout, null);
-				if (testThread != null) {
-					preInterruptCallback.executePreInterruptCallback(testThread, exception::addSuppressed);
-				}
-				exception.initCause(cause);
-				return exception;
-			});
+			(__, ___, cause, testThread) -> newTimeoutException(cause, testThread));
+	}
+
+	private TimeoutException newTimeoutException(@Nullable Throwable cause, @Nullable Thread testThread) {
+		TimeoutException exception = TimeoutExceptionFactory.create(parameters.descriptionSupplier().get(),
+			parameters.timeout(), parameters.threadDumpEnabled(), null);
+		if (testThread != null) {
+			parameters.preInterruptCallback().executePreInterruptCallback(testThread, exception::addSuppressed);
+		}
+		exception.initCause(cause);
+		return exception;
 	}
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TimeoutExceptionFactory.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TimeoutExceptionFactory.java
@@ -10,6 +10,8 @@
 
 package org.junit.jupiter.engine.extension;
 
+import static org.junit.jupiter.api.extension.PreInterruptCallback.THREAD_DUMP_ENABLED_PROPERTY_NAME;
+
 import java.util.concurrent.TimeoutException;
 
 import org.jspecify.annotations.Nullable;
@@ -20,22 +22,23 @@ import org.junit.platform.commons.util.Preconditions;
  */
 class TimeoutExceptionFactory {
 
+	private static final String DETAIL_MESSAGE_THREAD_DUMP_ENABLED = "see thread dump printed to System.out";
+	private static final String DETAIL_MESSAGE_THREAD_DUMP_DISABLED = "to enable thread dumps, set the '"
+			+ THREAD_DUMP_ENABLED_PROPERTY_NAME + "' configuration parameter to 'true'";
+
 	private TimeoutExceptionFactory() {
 	}
 
-	static TimeoutException create(String methodSignature, TimeoutDuration timeoutDuration,
+	static TimeoutException create(String methodSignature, TimeoutDuration timeoutDuration, boolean threadDumpEnabled,
 			@Nullable Throwable failure) {
-		String message = "%s timed out after %s".formatted(
+		String message = "%s timed out after %s (%s)".formatted(
 			Preconditions.notNull(methodSignature, "method signature must not be null"),
-			Preconditions.notNull(timeoutDuration, "timeout duration must not be null"));
+			Preconditions.notNull(timeoutDuration, "timeout duration must not be null"),
+			threadDumpEnabled ? DETAIL_MESSAGE_THREAD_DUMP_ENABLED : DETAIL_MESSAGE_THREAD_DUMP_DISABLED);
 		TimeoutException timeoutException = new TimeoutException(message);
 		if (failure != null) {
 			timeoutException.addSuppressed(failure);
 		}
 		return timeoutException;
-	}
-
-	static TimeoutException create(String methodSignature, TimeoutDuration timeoutDuration) {
-		return create(methodSignature, timeoutDuration, null);
 	}
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TimeoutExtension.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TimeoutExtension.java
@@ -11,6 +11,7 @@
 package org.junit.jupiter.engine.extension;
 
 import static org.junit.jupiter.api.Timeout.ThreadMode.SAME_THREAD;
+import static org.junit.jupiter.api.extension.PreInterruptCallback.THREAD_DUMP_ENABLED_PROPERTY_NAME;
 
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
@@ -25,7 +26,6 @@ import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.InvocationInterceptor;
 import org.junit.jupiter.api.extension.ReflectiveInvocationContext;
-import org.junit.jupiter.engine.extension.TimeoutInvocationFactory.TimeoutInvocationParameters;
 import org.junit.platform.commons.support.AnnotationSupport;
 import org.junit.platform.commons.util.ClassUtils;
 import org.junit.platform.commons.util.ReflectionUtils;
@@ -183,10 +183,21 @@ class TimeoutExtension implements BeforeAllCallback, BeforeEachCallback, Invocat
 			return invocation;
 		}
 
-		ThreadMode threadMode = resolveTimeoutThreadMode(extensionContext, timeoutConfiguration);
-		return new TimeoutInvocationFactory(extensionContext.getRoot().getStore(NAMESPACE)).create(threadMode,
-			new TimeoutInvocationParameters<>(invocation, timeout, () -> describe(invocationContext, extensionContext),
-				PreInterruptCallbackInvocationFactory.create((ExtensionContextInternal) extensionContext)));
+		var threadMode = resolveTimeoutThreadMode(extensionContext, timeoutConfiguration);
+		return new TimeoutInvocationFactory(extensionContext.getRoot().getStore(NAMESPACE)) //
+				.create(threadMode, createParameters(invocation, invocationContext, extensionContext, timeout));
+	}
+
+	private <T extends @Nullable Object> TimeoutInvocationParameters<T> createParameters(Invocation<T> invocation,
+			ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext,
+			TimeoutDuration timeout) {
+		var threadDumpEnabled = extensionContext.getConfigurationParameter(THREAD_DUMP_ENABLED_PROPERTY_NAME) //
+				.map(Boolean::parseBoolean) //
+				.orElse(false);
+		return new TimeoutInvocationParameters<>(invocation, timeout,
+			() -> describe(invocationContext, extensionContext),
+			PreInterruptCallbackInvocationFactory.create((ExtensionContextInternal) extensionContext),
+			threadDumpEnabled);
 	}
 
 	private ThreadMode resolveTimeoutThreadMode(ExtensionContext extensionContext,

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TimeoutInvocationFactory.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TimeoutInvocationFactory.java
@@ -13,12 +13,13 @@ package org.junit.jupiter.engine.extension;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Supplier;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Timeout.ThreadMode;
 import org.junit.jupiter.api.extension.ExtensionContext.Store;
 import org.junit.jupiter.api.extension.InvocationInterceptor.Invocation;
 import org.junit.platform.commons.JUnitException;
+import org.junit.platform.commons.PreconditionViolationException;
 import org.junit.platform.commons.util.Preconditions;
 
 /**
@@ -32,21 +33,18 @@ class TimeoutInvocationFactory {
 		this.store = Preconditions.notNull(store, "store must not be null");
 	}
 
-	<T> Invocation<T> create(ThreadMode threadMode, TimeoutInvocationParameters<T> timeoutInvocationParameters) {
-		Preconditions.notNull(threadMode, "thread mode must not be null");
-		Preconditions.condition(threadMode != ThreadMode.INFERRED, "thread mode must not be INFERRED");
-		Preconditions.notNull(timeoutInvocationParameters, "timeout invocation parameters must not be null");
-		if (threadMode == ThreadMode.SEPARATE_THREAD) {
-			return new SeparateThreadTimeoutInvocation<>(timeoutInvocationParameters.getInvocation(),
-				timeoutInvocationParameters.getTimeoutDuration(), timeoutInvocationParameters.getDescriptionSupplier(),
-				timeoutInvocationParameters.getPreInterruptCallback());
-		}
-		return new SameThreadTimeoutInvocation<>(timeoutInvocationParameters.getInvocation(),
-			timeoutInvocationParameters.getTimeoutDuration(), getThreadExecutorForSameThreadInvocation(),
-			timeoutInvocationParameters.getDescriptionSupplier(),
-			timeoutInvocationParameters.getPreInterruptCallback());
+	<T extends @Nullable Object> Invocation<T> create(ThreadMode threadMode,
+			TimeoutInvocationParameters<T> parameters) {
+		Preconditions.notNull(parameters, "timeout invocation parameters must not be null");
+		return switch (Preconditions.notNull(threadMode, "thread mode must not be null")) {
+			case SAME_THREAD -> new SameThreadTimeoutInvocation<>(parameters,
+				getThreadExecutorForSameThreadInvocation());
+			case SEPARATE_THREAD -> new SeparateThreadTimeoutInvocation<>(parameters);
+			case INFERRED -> throw new PreconditionViolationException("thread mode must not be INFERRED");
+		};
 	}
 
+	@SuppressWarnings("resource")
 	private ScheduledExecutorService getThreadExecutorForSameThreadInvocation() {
 		return store.computeIfAbsent(SingleThreadExecutorResource.class).get();
 	}
@@ -88,37 +86,4 @@ class TimeoutInvocationFactory {
 		}
 	}
 
-	static class TimeoutInvocationParameters<T> {
-
-		private final Invocation<T> invocation;
-		private final TimeoutDuration timeout;
-		private final Supplier<String> descriptionSupplier;
-		private final PreInterruptCallbackInvocation preInterruptCallback;
-
-		TimeoutInvocationParameters(Invocation<T> invocation, TimeoutDuration timeout,
-				Supplier<String> descriptionSupplier, PreInterruptCallbackInvocation preInterruptCallback) {
-			this.invocation = Preconditions.notNull(invocation, "invocation must not be null");
-			this.timeout = Preconditions.notNull(timeout, "timeout must not be null");
-			this.descriptionSupplier = Preconditions.notNull(descriptionSupplier,
-				"description supplier must not be null");
-			this.preInterruptCallback = Preconditions.notNull(preInterruptCallback,
-				"preInterruptCallback must not be null");
-		}
-
-		public Invocation<T> getInvocation() {
-			return invocation;
-		}
-
-		public TimeoutDuration getTimeoutDuration() {
-			return timeout;
-		}
-
-		public Supplier<String> getDescriptionSupplier() {
-			return descriptionSupplier;
-		}
-
-		public PreInterruptCallbackInvocation getPreInterruptCallback() {
-			return preInterruptCallback;
-		}
-	}
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TimeoutInvocationParameters.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TimeoutInvocationParameters.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.engine.extension;
+
+import java.util.function.Supplier;
+
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.extension.InvocationInterceptor;
+import org.junit.platform.commons.util.Preconditions;
+
+record TimeoutInvocationParameters<T extends @Nullable Object>(//
+		InvocationInterceptor.Invocation<T> invocation, TimeoutDuration timeout, Supplier<String> descriptionSupplier,
+		PreInterruptCallbackInvocation preInterruptCallback, Boolean threadDumpEnabled) {
+
+	TimeoutInvocationParameters {
+		Preconditions.notNull(invocation, "invocation must not be null");
+		Preconditions.notNull(timeout, "timeout must not be null");
+		Preconditions.notNull(descriptionSupplier, "description supplier must not be null");
+		Preconditions.notNull(preInterruptCallback, "preInterruptCallback must not be null");
+	}
+}

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/PreInterruptCallbackTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/PreInterruptCallbackTests.java
@@ -167,7 +167,7 @@ class PreInterruptCallbackTests extends AbstractJupiterTestEngineTests {
 		interruptCallbackShallThrowException.set(true);
 		Events tests = executeTestsForClass(DefaultPreInterruptCallbackWithExplicitCallbackTestCase.class).testEvents();
 		tests.failed().assertEventsMatchExactly(event(test(TC),
-			finishedWithFailure(instanceOf(TimeoutException.class), message(TIMEOUT_ERROR_MSG),
+			finishedWithFailure(instanceOf(TimeoutException.class), message(it -> it.startsWith(TIMEOUT_ERROR_MSG)),
 				suppressed(0, instanceOf(InterruptedException.class)),
 				suppressed(1, instanceOf(IllegalStateException.class)))));
 		assertTrue(interruptedTest.get());
@@ -178,7 +178,7 @@ class PreInterruptCallbackTests extends AbstractJupiterTestEngineTests {
 	}
 
 	private static void assertTestHasTimedOut(Events tests) {
-		assertTestHasTimedOut(tests, message(TIMEOUT_ERROR_MSG));
+		assertTestHasTimedOut(tests, message(it -> it.startsWith(TIMEOUT_ERROR_MSG)));
 	}
 
 	private static void assertTestHasTimedOut(Events tests, Condition<Throwable> messageCondition) {

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/SameThreadTimeoutInvocationTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/SameThreadTimeoutInvocationTests.java
@@ -34,12 +34,13 @@ class SameThreadTimeoutInvocationTests {
 		var exception = assertThrows(TimeoutException.class, () -> withExecutor(executor -> {
 			var delegate = new EventuallyInterruptibleInvocation();
 			var duration = new TimeoutDuration(1, NANOSECONDS);
-			var timeoutInvocation = new SameThreadTimeoutInvocation<>(delegate, duration, executor, () -> "execution",
-				PreInterruptCallbackInvocation.NOOP);
+			var parameters = new TimeoutInvocationParameters<>(delegate, duration, () -> "execution",
+				PreInterruptCallbackInvocation.NOOP, false);
+			var timeoutInvocation = new SameThreadTimeoutInvocation<>(parameters, executor);
 			timeoutInvocation.proceed();
 		}));
 		assertFalse(Thread.currentThread().isInterrupted());
-		assertThat(exception).hasMessage("execution timed out after 1 nanosecond");
+		assertThat(exception).hasMessageStartingWith("execution timed out after 1 nanosecond");
 	}
 
 	private void withExecutor(ThrowingConsumer<ScheduledExecutorService> consumer) throws Throwable {

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/SeparateThreadTimeoutInvocationTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/SeparateThreadTimeoutInvocationTests.java
@@ -25,7 +25,6 @@ import org.junit.jupiter.api.Timeout.ThreadMode;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.InvocationInterceptor.Invocation;
 import org.junit.jupiter.engine.execution.NamespaceAwareStore;
-import org.junit.jupiter.engine.extension.TimeoutInvocationFactory.TimeoutInvocationParameters;
 import org.junit.platform.engine.support.store.Namespace;
 import org.junit.platform.engine.support.store.NamespacedHierarchicalStore;
 
@@ -48,7 +47,7 @@ class SeparateThreadTimeoutInvocationTests {
 		});
 
 		assertThatThrownBy(invocation::proceed) //
-				.hasMessage("method() timed out after " + PREEMPTIVE_TIMEOUT_MILLIS + " milliseconds") //
+				.hasMessageStartingWith("method() timed out after " + PREEMPTIVE_TIMEOUT_MILLIS + " milliseconds") //
 				.isInstanceOf(TimeoutException.class) //
 				.hasRootCauseMessage("Execution timed out in thread " + threadName.get());
 	}
@@ -78,7 +77,7 @@ class SeparateThreadTimeoutInvocationTests {
 			Namespace.create(namespace.getParts()));
 		var parameters = new TimeoutInvocationParameters<>(invocation,
 			new TimeoutDuration(PREEMPTIVE_TIMEOUT_MILLIS, MILLISECONDS), () -> "method()",
-			PreInterruptCallbackInvocation.NOOP);
+			PreInterruptCallbackInvocation.NOOP, false);
 		return (SeparateThreadTimeoutInvocation<T>) new TimeoutInvocationFactory(store) //
 				.create(ThreadMode.SEPARATE_THREAD, parameters);
 	}

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/TimeoutExceptionFactoryTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/TimeoutExceptionFactoryTests.java
@@ -34,20 +34,21 @@ class TimeoutExceptionFactoryTests {
 	@Test
 	@DisplayName("creates exception with method signature and timeout")
 	void createExceptionWithMethodSignatureTimeout() {
-		TimeoutException exception = create(methodSignature, tenMillisDuration);
+		TimeoutException exception = create(methodSignature, tenMillisDuration, false, null);
 
 		assertThat(exception) //
-				.hasMessage("test() timed out after 10 milliseconds") //
+				.hasMessage(
+					"test() timed out after 10 milliseconds (to enable thread dumps, set the 'junit.jupiter.execution.timeout.threaddump.enabled' configuration parameter to 'true')") //
 				.hasNoSuppressedExceptions();
 	}
 
 	@Test
 	@DisplayName("creates exception with method signature, timeout and throwable")
 	void createExceptionWithMethodSignatureTimeoutAndThrowable() {
-		TimeoutException exception = create(methodSignature, tenMillisDuration, suppressedException);
+		TimeoutException exception = create(methodSignature, tenMillisDuration, true, suppressedException);
 
 		assertThat(exception) //
-				.hasMessage("test() timed out after 10 milliseconds") //
+				.hasMessage("test() timed out after 10 milliseconds (see thread dump printed to System.out)") //
 				.hasSuppressedException(suppressedException);
 	}
 
@@ -59,14 +60,14 @@ class TimeoutExceptionFactoryTests {
 		@Test
 		@DisplayName("method signature is null")
 		void methodSignatureIsNull() {
-			assertThatThrownBy(() -> create(null, tenMillisDuration, suppressedException)) //
+			assertThatThrownBy(() -> create(null, tenMillisDuration, false, suppressedException)) //
 					.hasMessage("method signature must not be null");
 		}
 
 		@Test
 		@DisplayName("method timeout duration is null")
 		void timeoutDurationIsnull() {
-			assertThatThrownBy(() -> create(methodSignature, null, suppressedException)) //
+			assertThatThrownBy(() -> create(methodSignature, null, false, suppressedException)) //
 					.hasMessage("timeout duration must not be null");
 		}
 	}

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/TimeoutExtensionTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/TimeoutExtensionTests.java
@@ -85,7 +85,7 @@ class TimeoutExtensionTests extends AbstractJupiterTestEngineTests {
 				.isLessThan(Duration.ofSeconds(1));
 		assertThat(execution.getTerminationInfo().getExecutionResult().getThrowable().orElseThrow()) //
 				.isInstanceOf(TimeoutException.class) //
-				.hasMessage("testMethod() timed out after 10 milliseconds");
+				.hasMessageStartingWith("testMethod() timed out after 10 milliseconds");
 	}
 
 	@Test
@@ -124,7 +124,7 @@ class TimeoutExtensionTests extends AbstractJupiterTestEngineTests {
 		else {
 			assertThat(execution.getTerminationInfo().getExecutionResult().getThrowable().orElseThrow()) //
 					.isInstanceOf(TimeoutException.class) //
-					.hasMessage("testMethod() timed out after 10 milliseconds");
+					.hasMessageStartingWith("testMethod() timed out after 10 milliseconds");
 		}
 	}
 
@@ -143,7 +143,7 @@ class TimeoutExtensionTests extends AbstractJupiterTestEngineTests {
 					.isLessThan(Duration.ofSeconds(1));
 			assertThat(execution.getTerminationInfo().getExecutionResult().getThrowable().orElseThrow()) //
 					.isInstanceOf(TimeoutException.class) //
-					.hasMessage("testTemplateMethod() timed out after 10 milliseconds");
+					.hasMessageStartingWith("testTemplateMethod() timed out after 10 milliseconds");
 		});
 	}
 
@@ -161,7 +161,7 @@ class TimeoutExtensionTests extends AbstractJupiterTestEngineTests {
 				.isLessThan(Duration.ofSeconds(1));
 		assertThat(execution.getTerminationInfo().getExecutionResult().getThrowable().orElseThrow()) //
 				.isInstanceOf(TimeoutException.class) //
-				.hasMessage("testFactoryMethod() timed out after 10 milliseconds");
+				.hasMessageStartingWith("testFactoryMethod() timed out after 10 milliseconds");
 	}
 
 	@ParameterizedTest(name = "{0}")
@@ -183,7 +183,7 @@ class TimeoutExtensionTests extends AbstractJupiterTestEngineTests {
 							.isLessThan(Duration.ofSeconds(1));
 					assertThat(execution.getTerminationInfo().getExecutionResult().getThrowable().orElseThrow()) //
 							.isInstanceOf(TimeoutException.class) //
-							.hasMessageEndingWith("timed out after 10000000 nanoseconds");
+							.hasMessageContaining("timed out after 10000000 nanoseconds");
 				}));
 	}
 
@@ -199,7 +199,7 @@ class TimeoutExtensionTests extends AbstractJupiterTestEngineTests {
 		assertThat(execution.getTerminationInfo().getExecutionResult().getStatus()).isEqualTo(FAILED);
 		assertThat(execution.getTerminationInfo().getExecutionResult().getThrowable().orElseThrow()) //
 				.isInstanceOf(TimeoutException.class) //
-				.hasMessage("methodThatDoesNotThrowInterruptedException() timed out after 1 millisecond");
+				.hasMessageStartingWith("methodThatDoesNotThrowInterruptedException() timed out after 1 millisecond");
 	}
 
 	@Test
@@ -217,7 +217,7 @@ class TimeoutExtensionTests extends AbstractJupiterTestEngineTests {
 				.isLessThan(Duration.ofSeconds(1));
 		assertThat(execution.getTerminationInfo().getExecutionResult().getThrowable().orElseThrow()) //
 				.isInstanceOf(TimeoutException.class) //
-				.hasMessage("setUp() timed out after 10 milliseconds");
+				.hasMessageStartingWith("setUp() timed out after 10 milliseconds");
 	}
 
 	@Test
@@ -234,7 +234,7 @@ class TimeoutExtensionTests extends AbstractJupiterTestEngineTests {
 				.isLessThan(Duration.ofSeconds(1));
 		assertThat(execution.getTerminationInfo().getExecutionResult().getThrowable().orElseThrow()) //
 				.isInstanceOf(TimeoutException.class) //
-				.hasMessage("setUp() timed out after 10 milliseconds");
+				.hasMessageStartingWith("setUp() timed out after 10 milliseconds");
 	}
 
 	@Test
@@ -251,7 +251,7 @@ class TimeoutExtensionTests extends AbstractJupiterTestEngineTests {
 				.isLessThan(Duration.ofSeconds(1));
 		assertThat(execution.getTerminationInfo().getExecutionResult().getThrowable().orElseThrow()) //
 				.isInstanceOf(TimeoutException.class) //
-				.hasMessage("tearDown() timed out after 10 milliseconds");
+				.hasMessageStartingWith("tearDown() timed out after 10 milliseconds");
 	}
 
 	@Test
@@ -269,7 +269,7 @@ class TimeoutExtensionTests extends AbstractJupiterTestEngineTests {
 				.isLessThan(Duration.ofSeconds(1));
 		assertThat(execution.getTerminationInfo().getExecutionResult().getThrowable().orElseThrow()) //
 				.isInstanceOf(TimeoutException.class) //
-				.hasMessage("tearDown() timed out after 10 milliseconds");
+				.hasMessageStartingWith("tearDown() timed out after 10 milliseconds");
 	}
 
 	@ParameterizedTest(name = "{0}")
@@ -285,7 +285,7 @@ class TimeoutExtensionTests extends AbstractJupiterTestEngineTests {
 				.map(execution -> execution.getTerminationInfo().getExecutionResult().getThrowable().orElseThrow()) //
 				.findFirst();
 		assertThat(failure).containsInstanceOf(TimeoutException.class);
-		assertThat(failure.orElseThrow()).hasMessage(slowMethod + " timed out after 1 nanosecond");
+		assertThat(failure.orElseThrow()).hasMessageStartingWith(slowMethod + " timed out after 1 nanosecond");
 	}
 
 	static Stream<Arguments> appliesDefaultTimeoutsFromConfigurationParameters() {
@@ -323,7 +323,7 @@ class TimeoutExtensionTests extends AbstractJupiterTestEngineTests {
 				.isLessThan(Duration.ofSeconds(1));
 		assertThat(execution.getTerminationInfo().getExecutionResult().getThrowable().orElseThrow()) //
 				.isInstanceOf(TimeoutException.class) //
-				.hasMessageEndingWith(
+				.hasMessageContaining(
 					"$NestedClassWithOuterSetupMethodTestCase#setUp() timed out after 10 milliseconds");
 	}
 
@@ -357,7 +357,7 @@ class TimeoutExtensionTests extends AbstractJupiterTestEngineTests {
 			Throwable failure = execution.getTerminationInfo().getExecutionResult().getThrowable().orElseThrow();
 			assertThat(failure) //
 					.isInstanceOf(TimeoutException.class) //
-					.hasMessage("testMethod() timed out after 100 milliseconds");
+					.hasMessageStartingWith("testMethod() timed out after 100 milliseconds");
 			assertThat(failure.getCause()) //
 					.hasMessageStartingWith("Execution timed out in ") //
 					.hasStackTraceContaining(TimeoutExceedingSeparateThreadTestCase.class.getName() + ".testMethod");
@@ -418,7 +418,7 @@ class TimeoutExtensionTests extends AbstractJupiterTestEngineTests {
 			Execution stuckExecution = findExecution(results.testEvents(), "stuck()");
 			assertThat(stuckExecution.getTerminationInfo().getExecutionResult().getThrowable().orElseThrow()) //
 					.isInstanceOf(TimeoutException.class) //
-					.hasMessage("stuck() timed out after 10 milliseconds");
+					.hasMessageStartingWith("stuck() timed out after 10 milliseconds");
 
 			Execution testZeroExecution = findExecution(results.testEvents(), "testZero()");
 			assertThat(testZeroExecution.getTerminationInfo().getExecutionResult().getStatus()) //
@@ -437,17 +437,17 @@ class TimeoutExtensionTests extends AbstractJupiterTestEngineTests {
 			Execution stuck = findExecution(results.testEvents(), "testZero()");
 			assertThat(stuck.getTerminationInfo().getExecutionResult().getThrowable().orElseThrow()) //
 					.isInstanceOf(TimeoutException.class) //
-					.hasMessage("testZero() timed out after 10 milliseconds");
+					.hasMessageStartingWith("testZero() timed out after 10 milliseconds");
 
 			Execution testZeroExecution = findExecution(results.testEvents(), "testOne()");
 			assertThat(testZeroExecution.getTerminationInfo().getExecutionResult().getThrowable().orElseThrow()) //
 					.isInstanceOf(TimeoutException.class) //
-					.hasMessage("testOne() timed out after 10 milliseconds");
+					.hasMessageStartingWith("testOne() timed out after 10 milliseconds");
 
 			Execution testOneExecution = findExecution(results.testEvents(), "testTwo()");
 			assertThat(testOneExecution.getTerminationInfo().getExecutionResult().getThrowable().orElseThrow()) //
 					.isInstanceOf(TimeoutException.class) //
-					.hasMessage("testTwo() timed out after 10 milliseconds");
+					.hasMessageStartingWith("testTwo() timed out after 10 milliseconds");
 		}
 
 		@Test
@@ -459,7 +459,7 @@ class TimeoutExtensionTests extends AbstractJupiterTestEngineTests {
 			Execution stuckExecution = findExecution(results.testEvents(), "stuck()");
 			assertThat(stuckExecution.getTerminationInfo().getExecutionResult().getThrowable().orElseThrow()) //
 					.isInstanceOf(TimeoutException.class) //
-					.hasMessage("stuck() timed out after 10 milliseconds");
+					.hasMessageStartingWith("stuck() timed out after 10 milliseconds");
 
 			Execution testZeroExecution = findExecution(results.testEvents(), "testZero()");
 			assertThat(testZeroExecution.getTerminationInfo().getExecutionResult().getStatus()) //
@@ -493,7 +493,7 @@ class TimeoutExtensionTests extends AbstractJupiterTestEngineTests {
 				Execution execution = findExecution(results.testEvents(), "exceptionThrown()");
 				assertThat(execution.getTerminationInfo().getExecutionResult().getThrowable().orElseThrow()) //
 						.isInstanceOf(TimeoutException.class) //
-						.hasMessage("exceptionThrown() timed out after 100 milliseconds");
+						.hasMessageStartingWith("exceptionThrown() timed out after 100 milliseconds");
 			}
 
 			@Test

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/TimeoutInvocationFactoryTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/TimeoutInvocationFactoryTests.java
@@ -24,7 +24,6 @@ import org.junit.jupiter.api.extension.ExtensionContext.Store;
 import org.junit.jupiter.api.extension.InvocationInterceptor.Invocation;
 import org.junit.jupiter.engine.execution.NamespaceAwareStore;
 import org.junit.jupiter.engine.extension.TimeoutInvocationFactory.SingleThreadExecutorResource;
-import org.junit.jupiter.engine.extension.TimeoutInvocationFactory.TimeoutInvocationParameters;
 import org.junit.platform.engine.support.store.Namespace;
 import org.junit.platform.engine.support.store.NamespacedHierarchicalStore;
 import org.mockito.Mock;
@@ -57,7 +56,7 @@ class TimeoutInvocationFactoryTests {
 	@BeforeEach
 	void setUp() {
 		parameters = new TimeoutInvocationParameters<>(invocation, timeoutDuration, () -> "description",
-			PreInterruptCallbackInvocation.NOOP);
+			PreInterruptCallbackInvocation.NOOP, false);
 		timeoutInvocationFactory = new TimeoutInvocationFactory(store);
 	}
 


### PR DESCRIPTION
To make the feature more discoverable.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://docs.junit.org/snapshot/) and [Release Notes](https://docs.junit.org/snapshot/release-notes.html)
