### PR TITLE
Register console launchers CustomClassLoader as parallel capable

### DIFF
--- a/junit-platform-console/src/main/java/org/junit/platform/console/command/CustomClassLoader.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/command/CustomClassLoader.java
@@ -21,6 +21,10 @@ import java.net.URLClassLoader;
  */
 class CustomClassLoader extends ClassLoader {
 
+	static {
+		ClassLoader.registerAsParallelCapable();
+	}
+
 	CustomClassLoader(URLClassLoader parent) {
 		super(parent);
 	}

--- a/platform-tests/src/test/java/org/junit/platform/console/command/CustomClassLoaderTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/console/command/CustomClassLoaderTests.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2015-2026 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.console.command;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * @since 6.2
+ */
+class CustomClassLoaderTests {
+
+	@Test
+	void customClassLoaderIsRegisteredAsParallelCapable() {
+		var customClassLoader = new CustomClassLoader(URLClassLoader.newInstance(new URL[0]));
+		assertTrue(customClassLoader.isRegisteredAsParallelCapable());
+	}
+
+}


### PR DESCRIPTION
It never loads any classes, it should be able to do that in parallel.

Follow up #5672 addressing https://github.com/junit-team/junit-framework/pull/5672#discussion_r3260296115

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
