### PR TITLE
Emit discovery issue for 'junit-' prefixed third-party engines

### DIFF
--- a/documentation/modules/ROOT/pages/advanced-topics/engines.adoc
+++ b/documentation/modules/ROOT/pages/advanced-topics/engines.adoc
@@ -34,8 +34,8 @@ by the JUnit Team may use the `junit-` prefix for their `TestEngine` IDs.
 
 * If any third-party `TestEngine` claims to be `junit-jupiter` or `junit-vintage`, an
   exception will be thrown, immediately halting execution of the JUnit Platform.
-* If any third-party `TestEngine` uses the `junit-` prefix for its ID, a warning message
-  will be logged. Later releases of the JUnit Platform will throw an exception for such
+* If any third-party `TestEngine` uses the `junit-` prefix for its ID, a discovery issue
+  will be created. Later releases of the JUnit Platform will throw an exception for such
   violations.
 ====
 

--- a/documentation/modules/ROOT/partials/release-notes/release-notes-6.2.0-M1.adoc
+++ b/documentation/modules/ROOT/partials/release-notes/release-notes-6.2.0-M1.adoc
@@ -29,7 +29,8 @@ repository on GitHub.
 * When using `ConsoleLauncher` with the `-cp`/`--classpath` option, it now creates a
   custom `ClassLoader` that does _not_ implement `AutoCloseable` to avoid accidentally
   closing it in test code which can lead to test failures that are hard to diagnose.
-
+* When using a third-party engine that uses the `junit-` prefix a discovery issue is
+  emitted.
 
 [[v6.2.0-M1-junit-jupiter]]
 === JUnit Jupiter

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/EngineDiscoveryOrchestrator.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/EngineDiscoveryOrchestrator.java
@@ -192,6 +192,7 @@ public class EngineDiscoveryOrchestrator {
 		LauncherDiscoveryListener listener = request.getDiscoveryListener();
 		try {
 			listener.engineDiscoveryStarted(uniqueEngineId);
+			EngineIdValidator.validateReservedPrefix(testEngine, uniqueEngineId, issueCollector);
 			TestDescriptor engineRoot = testEngine.discover(request, uniqueEngineId);
 			discoveryResultValidator.validate(testEngine, engineRoot);
 			listener.engineDiscoveryFinished(uniqueEngineId, EngineDiscoveryResult.successful());

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/EngineIdValidator.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/EngineIdValidator.java
@@ -10,14 +10,17 @@
 
 package org.junit.platform.launcher.core;
 
+import static org.junit.platform.engine.DiscoveryIssue.Severity.WARNING;
+
 import java.util.HashSet;
 import java.util.Set;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.platform.commons.JUnitException;
-import org.junit.platform.commons.logging.Logger;
-import org.junit.platform.commons.logging.LoggerFactory;
 import org.junit.platform.commons.util.Preconditions;
+import org.junit.platform.engine.DiscoveryIssue;
 import org.junit.platform.engine.TestEngine;
+import org.junit.platform.engine.UniqueId;
 
 /**
  * @since 1.7
@@ -25,18 +28,23 @@ import org.junit.platform.engine.TestEngine;
 class EngineIdValidator {
 
 	private EngineIdValidator() {
+		/* no-op */
+	}
+
+	static void validateReservedPrefix(TestEngine testEngine, UniqueId uniqueEngineId,
+			DiscoveryIssueCollector issueCollector) {
+		String engineId = testEngine.getId();
+		if (engineId.startsWith("junit-") && wellKnownClassNameForEngineId(testEngine) == null) {
+			var message = "Third-party TestEngine implementations are forbidden to use the reserved 'junit-' prefix for their ID";
+			issueCollector.issueEncountered(uniqueEngineId, DiscoveryIssue.create(WARNING, message));
+		}
 	}
 
 	static Iterable<TestEngine> validate(Iterable<TestEngine> testEngines) {
 		Set<String> ids = new HashSet<>();
 		for (TestEngine testEngine : testEngines) {
-			// check usage of reserved ID prefix
-			if (!validateReservedIds(testEngine)) {
-				getLogger().warn(
-					() -> "Third-party TestEngine implementations are forbidden to use the reserved 'junit-' prefix for their ID: '%s'".formatted(
-						testEngine.getId()));
-			}
-
+			// check usage of reserved ids
+			validateReservedIds(testEngine);
 			// check uniqueness
 			if (!ids.add(testEngine.getId())) {
 				throw new JUnitException(
@@ -46,32 +54,23 @@ class EngineIdValidator {
 		return testEngines;
 	}
 
-	private static Logger getLogger() {
-		// Not a constant to avoid problems with building GraalVM native images
-		return LoggerFactory.getLogger(EngineIdValidator.class);
+	// https://github.com/junit-team/junit-framework/issues/1557
+	private static void validateReservedIds(TestEngine testEngine) {
+		var expectedClassName = wellKnownClassNameForEngineId(testEngine);
+		if (expectedClassName == null) {
+			return;
+		}
+		validateWellKnownClassName(testEngine, expectedClassName);
 	}
 
-	// https://github.com/junit-team/junit-framework/issues/1557
-	private static boolean validateReservedIds(TestEngine testEngine) {
+	private static @Nullable String wellKnownClassNameForEngineId(TestEngine testEngine) {
 		String engineId = Preconditions.notBlank(testEngine.getId(),
 			() -> "ID for TestEngine [%s] must not be null or blank".formatted(testEngine.getClass().getName()));
-		if (!engineId.startsWith("junit-")) {
-			return true;
-		}
 		return switch (engineId) {
-			case "junit-jupiter" -> {
-				validateWellKnownClassName(testEngine, "org.junit.jupiter.engine.JupiterTestEngine");
-				yield true;
-			}
-			case "junit-vintage" -> {
-				validateWellKnownClassName(testEngine, "org.junit.vintage.engine.VintageTestEngine");
-				yield true;
-			}
-			case "junit-platform-suite" -> {
-				validateWellKnownClassName(testEngine, "org.junit.platform.suite.engine.SuiteTestEngine");
-				yield true;
-			}
-			default -> false;
+			case "junit-jupiter" -> "org.junit.jupiter.engine.JupiterTestEngine";
+			case "junit-vintage" -> "org.junit.vintage.engine.VintageTestEngine";
+			case "junit-platform-suite" -> "org.junit.platform.suite.engine.SuiteTestEngine";
+			default -> null;
 		};
 	}
 

--- a/platform-tests/src/test/java/org/junit/platform/launcher/core/DefaultLauncherTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/core/DefaultLauncherTests.java
@@ -603,14 +603,12 @@ class DefaultLauncherTests {
 	}
 
 	@Test
-	void thirdPartyEngineUsingReservedEngineIdPrefixEmitsWarning(@TrackLogRecords LogRecordListener listener) {
+	void thirdPartyEngineUsingReservedEngineIdPrefixEmitsDiscoveryIssue() {
 		var id = "junit-using-reserved-prefix";
 		var launcher = createLauncher(new TestEngineStub(id));
-		launcher.discover(request().build());
-		assertThat(listener.stream(EngineIdValidator.class, Level.WARNING).map(LogRecord::getMessage)) //
-				.containsExactly(
-					"Third-party TestEngine implementations are forbidden to use the reserved 'junit-' prefix for their ID: '"
-							+ id + "'");
+		var exception = assertThrows(DiscoveryIssueException.class, () -> launcher.discover(request().build()));
+		assertThat(exception).hasMessageContaining(
+			"[WARNING] Third-party TestEngine implementations are forbidden to use the reserved 'junit-' prefix for their ID");
 	}
 
 	@Test


### PR DESCRIPTION
This is a small upgrade in severity, from easy to ignore log message to much harder to ignore discovery issue. With the next major we can also easily change the severity into `ERROR`.

Contributes to #1572.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://docs.junit.org/snapshot/) and [Release Notes](https://docs.junit.org/snapshot/release-notes.html)
