### PR TITLE
Prefer @Nullable to Optional for fields

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ConditionEvaluationResult.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ConditionEvaluationResult.java
@@ -82,11 +82,11 @@ public class ConditionEvaluationResult {
 
 	private final boolean enabled;
 
-	private final Optional<String> reason;
+	private final @Nullable String reason;
 
 	private ConditionEvaluationResult(boolean enabled, @Nullable String reason) {
 		this.enabled = enabled;
-		this.reason = StringUtils.isNotBlank(reason) ? Optional.of(reason.strip()) : Optional.empty();
+		this.reason = StringUtils.isNotBlank(reason) ? reason.strip() : null;
 	}
 
 	/**
@@ -103,7 +103,7 @@ public class ConditionEvaluationResult {
 	 * if available.
 	 */
 	public Optional<String> getReason() {
-		return this.reason;
+		return Optional.ofNullable(this.reason);
 	}
 
 	@Override
@@ -111,7 +111,7 @@ public class ConditionEvaluationResult {
 		// @formatter:off
 		return new ToStringBuilder(this)
 				.append("enabled", this.enabled)
-				.append("reason", this.reason.orElse("<unknown>"))
+				.append("reason", reason != null ? reason : "<unknown>")
 				.toString();
 		// @formatter:on
 	}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ReflectiveInvocationContext.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ReflectiveInvocationContext.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.apiguardian.api.API;
+import org.jspecify.annotations.Nullable;
 
 /**
  * {@code ReflectiveInvocationContext} encapsulates the <em>context</em> of
@@ -56,7 +57,7 @@ public interface ReflectiveInvocationContext<T extends Executable> {
 	 * @return the arguments of the executable in this invocation context;
 	 * immutable and never {@code null}
 	 */
-	List<Object> getArguments();
+	List<@Nullable Object> getArguments();
 
 	/**
 	 * Get the target object of this invocation context, if available.

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ReflectiveInvocationContext.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ReflectiveInvocationContext.java
@@ -17,7 +17,6 @@ import java.util.List;
 import java.util.Optional;
 
 import org.apiguardian.api.API;
-import org.jspecify.annotations.Nullable;
 
 /**
  * {@code ReflectiveInvocationContext} encapsulates the <em>context</em> of
@@ -57,7 +56,7 @@ public interface ReflectiveInvocationContext<T extends Executable> {
 	 * @return the arguments of the executable in this invocation context;
 	 * immutable and never {@code null}
 	 */
-	List<@Nullable Object> getArguments();
+	List<Object> getArguments();
 
 	/**
 	 * Get the target object of this invocation context, if available.

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DynamicNodeTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DynamicNodeTestDescriptor.java
@@ -30,18 +30,18 @@ import org.junit.platform.engine.UniqueId;
 abstract class DynamicNodeTestDescriptor extends JupiterTestDescriptor {
 
 	protected final int index;
-	private final Optional<ExecutionMode> executionMode;
+	private final @Nullable ExecutionMode executionMode;
 
 	DynamicNodeTestDescriptor(UniqueId uniqueId, int index, DynamicNode dynamicNode, @Nullable TestSource testSource,
 			JupiterConfiguration configuration) {
 		super(uniqueId, dynamicNode.getDisplayName(), testSource, configuration);
 		this.index = index;
-		this.executionMode = dynamicNode.getExecutionMode().map(JupiterTestDescriptor::toExecutionMode);
+		this.executionMode = dynamicNode.getExecutionMode().map(JupiterTestDescriptor::toExecutionMode).orElse(null);
 	}
 
 	@Override
 	Optional<ExecutionMode> getExplicitExecutionMode() {
-		return executionMode;
+		return Optional.ofNullable(executionMode);
 	}
 
 	@Override

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/MutableExtensionRegistry.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/MutableExtensionRegistry.java
@@ -292,8 +292,7 @@ public class MutableExtensionRegistry implements ExtensionRegistry, ExtensionReg
 		private final Class<?> testClass;
 		private final Function<Object, ? extends Extension> initializer;
 
-		@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-		private Optional<Extension> extension = Optional.empty();
+		private @Nullable Extension extension;
 
 		LateInitEntry(Class<?> testClass, Function<Object, ? extends Extension> initializer) {
 			this.testClass = testClass;
@@ -302,7 +301,7 @@ public class MutableExtensionRegistry implements ExtensionRegistry, ExtensionReg
 
 		@Override
 		public Optional<Extension> getExtension() {
-			return extension;
+			return Optional.ofNullable(extension);
 		}
 
 		private Class<?> getTestClass() {
@@ -310,12 +309,12 @@ public class MutableExtensionRegistry implements ExtensionRegistry, ExtensionReg
 		}
 
 		void initialize(Object testInstance) {
-			Preconditions.condition(extension.isEmpty(), "Extension already initialized");
-			extension = Optional.of(initializer.apply(testInstance));
+			Preconditions.condition(extension == null, "Extension already initialized");
+			extension = initializer.apply(testInstance);
 		}
 
 		LateInitEntry copy() {
-			Preconditions.condition(extension.isEmpty(), "Extension already initialized");
+			Preconditions.condition(extension == null, "Extension already initialized");
 			return new LateInitEntry(testClass, initializer);
 		}
 	}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TestInfoParameterResolver.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TestInfoParameterResolver.java
@@ -48,14 +48,14 @@ class TestInfoParameterResolver implements ParameterResolver {
 
 		private final String displayName;
 		private final Set<String> tags;
-		private final Optional<Class<?>> testClass;
-		private final Optional<Method> testMethod;
+		private final @Nullable Class<?> testClass;
+		private final @Nullable Method testMethod;
 
 		DefaultTestInfo(ExtensionContext extensionContext) {
 			this.displayName = extensionContext.getDisplayName();
 			this.tags = extensionContext.getTags();
-			this.testClass = extensionContext.getTestClass();
-			this.testMethod = extensionContext.getTestMethod();
+			this.testClass = extensionContext.getTestClass().orElse(null);
+			this.testMethod = extensionContext.getTestMethod().orElse(null);
 		}
 
 		@Override
@@ -70,12 +70,12 @@ class TestInfoParameterResolver implements ParameterResolver {
 
 		@Override
 		public Optional<Class<?>> getTestClass() {
-			return this.testClass;
+			return Optional.ofNullable(this.testClass);
 		}
 
 		@Override
 		public Optional<Method> getTestMethod() {
-			return this.testMethod;
+			return Optional.ofNullable(this.testMethod);
 		}
 
 		@Override
@@ -84,15 +84,10 @@ class TestInfoParameterResolver implements ParameterResolver {
 			return new ToStringBuilder(this)
 					.append("displayName", this.displayName)
 					.append("tags", this.tags)
-					.append("testClass", nullSafeGet(this.testClass))
-					.append("testMethod", nullSafeGet(this.testMethod))
+					.append("testClass", this.testClass)
+					.append("testMethod", this.testMethod)
 					.toString();
 			// @formatter:on
-		}
-
-		@SuppressWarnings({ "OptionalAssignedToNull", "NullableOptional" })
-		private static @Nullable Object nullSafeGet(@Nullable Optional<?> optional) {
-			return optional != null ? optional.orElse(null) : null;
 		}
 
 	}

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/EvaluatedArgumentSet.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/EvaluatedArgumentSet.java
@@ -11,7 +11,6 @@
 package org.junit.jupiter.params;
 
 import java.util.Arrays;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.IntUnaryOperator;
 

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/EvaluatedArgumentSet.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/EvaluatedArgumentSet.java
@@ -53,9 +53,9 @@ class EvaluatedArgumentSet {
 
 	private final @Nullable Object[] all;
 	private final @Nullable Object[] consumed;
-	private final Optional<String> name;
+	private final @Nullable String name;
 
-	private EvaluatedArgumentSet(@Nullable Object[] all, @Nullable Object[] consumed, Optional<String> name) {
+	private EvaluatedArgumentSet(@Nullable Object[] all, @Nullable Object[] consumed, @Nullable String name) {
 		this.all = all;
 		this.consumed = consumed;
 		this.name = name;
@@ -89,7 +89,8 @@ class EvaluatedArgumentSet {
 		return extractFromNamed(this.consumed[index], Named::getPayload);
 	}
 
-	Optional<String> getName() {
+	@Nullable
+	String getName() {
 		return this.name;
 	}
 
@@ -100,11 +101,11 @@ class EvaluatedArgumentSet {
 		return arguments.length > newLength ? Arrays.copyOf(arguments, newLength) : arguments;
 	}
 
-	private static Optional<String> determineName(Arguments arguments) {
+	private static @Nullable String determineName(Arguments arguments) {
 		if (arguments instanceof ArgumentSet set) {
-			return Optional.of(set.getName());
+			return set.getName();
 		}
-		return Optional.empty();
+		return null;
 	}
 
 	private static @Nullable Object[] extractFromNamed(@Nullable Object[] arguments,

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedInvocationNameFormatter.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedInvocationNameFormatter.java
@@ -182,7 +182,7 @@ class ParameterizedInvocationNameFormatter {
 		formatters.put(ARGUMENTS_PLACEHOLDER, new CachingByArgumentsLengthPartialFormatter(
 			length -> new MessageFormatPartialFormatter(argumentsPattern(length), argumentMaxLength)));
 		formatters.put(ARGUMENT_SET_NAME_OR_ARGUMENTS_WITH_NAMES_PLACEHOLDER, (context, result) -> {
-			PartialFormatter formatterToUse = context.argumentSetName.isPresent() //
+			PartialFormatter formatterToUse = context.argumentSetName != null //
 					? argumentSetNameFormatter //
 					: argumentsWithNamesFormatter;
 			formatterToUse.append(context, result);
@@ -206,7 +206,7 @@ class ParameterizedInvocationNameFormatter {
 
 	@SuppressWarnings("ArrayRecordComponent")
 	private record ArgumentsContext(int invocationIndex, @Nullable Object[] consumedArguments,
-			Optional<String> argumentSetName, boolean quoteTextArguments) {
+			@Nullable String argumentSetName, boolean quoteTextArguments) {
 	}
 
 	@FunctionalInterface
@@ -222,8 +222,8 @@ class ParameterizedInvocationNameFormatter {
 
 		@Override
 		public void append(ArgumentsContext context, StringBuffer result) {
-			if (context.argumentSetName.isPresent()) {
-				result.append(context.argumentSetName.get());
+			if (context.argumentSetName != null) {
+				result.append(context.argumentSetName);
 				return;
 			}
 			throw new ExtensionConfigurationException(

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/FilterResult.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/FilterResult.java
@@ -72,11 +72,11 @@ public class FilterResult {
 
 	private final boolean included;
 
-	private final Optional<String> reason;
+	private final @Nullable String reason;
 
 	private FilterResult(boolean included, @Nullable String reason) {
 		this.included = included;
-		this.reason = Optional.ofNullable(reason);
+		this.reason = reason;
 	}
 
 	/**
@@ -98,7 +98,7 @@ public class FilterResult {
 	 * if available.
 	 */
 	public Optional<String> getReason() {
-		return this.reason;
+		return Optional.ofNullable(this.reason);
 	}
 
 	@Override
@@ -106,7 +106,7 @@ public class FilterResult {
 		// @formatter:off
 		return new ToStringBuilder(this)
 				.append("included", this.included)
-				.append("reason", this.reason.orElse("<unknown>"))
+				.append("reason", this.reason != null ? this.reason : "<unknown>")
 				.toString();
 		// @formatter:on
 	}

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/Node.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/Node.java
@@ -226,7 +226,7 @@ public interface Node<C extends EngineExecutionContext> {
 		private static final SkipResult alwaysExecuteSkipResult = new SkipResult(false, null);
 
 		private final boolean skipped;
-		private final Optional<String> reason;
+		private final @Nullable String reason;
 
 		/**
 		 * Factory for creating <em>skipped</em> results.
@@ -254,7 +254,7 @@ public interface Node<C extends EngineExecutionContext> {
 
 		private SkipResult(boolean skipped, @Nullable String reason) {
 			this.skipped = skipped;
-			this.reason = Optional.ofNullable(reason);
+			this.reason = reason;
 		}
 
 		/**
@@ -271,7 +271,7 @@ public interface Node<C extends EngineExecutionContext> {
 		 * if available.
 		 */
 		public Optional<String> getReason() {
-			return this.reason;
+			return Optional.ofNullable(this.reason);
 		}
 
 		@Override
@@ -279,7 +279,7 @@ public interface Node<C extends EngineExecutionContext> {
 			// @formatter:off
 			return new ToStringBuilder(this)
 					.append("skipped", this.skipped)
-					.append("reason", this.reason.orElse("<unknown>"))
+					.append("reason", this.reason != null ? this.reason : "<unknown>")
 					.toString();
 			// @formatter:on
 		}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/StreamInterceptingTestExecutionListener.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/StreamInterceptingTestExecutionListener.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiConsumer;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.platform.commons.util.StringUtils;
 import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.engine.TestExecutionResult;
@@ -34,8 +35,8 @@ import org.junit.platform.launcher.core.CompositeTestExecutionListener.EagerTest
  */
 class StreamInterceptingTestExecutionListener implements EagerTestExecutionListener {
 
-	private final Optional<StreamInterceptor> stdoutInterceptor;
-	private final Optional<StreamInterceptor> stderrInterceptor;
+	private final @Nullable StreamInterceptor stdoutInterceptor;
+	private final @Nullable StreamInterceptor stderrInterceptor;
 	private final BiConsumer<TestIdentifier, ReportEntry> reporter;
 
 	static Optional<StreamInterceptingTestExecutionListener> create(ConfigurationParameters configurationParameters,
@@ -50,47 +51,61 @@ class StreamInterceptingTestExecutionListener implements EagerTestExecutionListe
 		int maxSize = configurationParameters.get(CAPTURE_MAX_BUFFER_PROPERTY_NAME, Integer::valueOf) //
 				.orElse(CAPTURE_MAX_BUFFER_DEFAULT);
 
-		Optional<StreamInterceptor> stdoutInterceptor = captureStdout ? StreamInterceptor.registerStdout(maxSize)
-				: Optional.empty();
-		Optional<StreamInterceptor> stderrInterceptor = captureStderr ? StreamInterceptor.registerStderr(maxSize)
-				: Optional.empty();
+		StreamInterceptor stdoutInterceptor = captureStdout ? StreamInterceptor.registerStdout(maxSize) : null;
+		StreamInterceptor stderrInterceptor = captureStderr ? StreamInterceptor.registerStderr(maxSize) : null;
 
-		if ((stdoutInterceptor.isEmpty() && captureStdout) || (stderrInterceptor.isEmpty() && captureStderr)) {
-			stdoutInterceptor.ifPresent(StreamInterceptor::unregister);
-			stderrInterceptor.ifPresent(StreamInterceptor::unregister);
+		if ((stdoutInterceptor == null && captureStdout) || (stderrInterceptor == null && captureStderr)) {
+			if (stdoutInterceptor != null) {
+				stdoutInterceptor.unregister();
+			}
+			if (stderrInterceptor != null) {
+				stderrInterceptor.unregister();
+			}
 			return Optional.empty();
 		}
 		return Optional.of(new StreamInterceptingTestExecutionListener(stdoutInterceptor, stderrInterceptor, reporter));
 	}
 
-	private StreamInterceptingTestExecutionListener(Optional<StreamInterceptor> stdoutInterceptor,
-			Optional<StreamInterceptor> stderrInterceptor, BiConsumer<TestIdentifier, ReportEntry> reporter) {
+	private StreamInterceptingTestExecutionListener(@Nullable StreamInterceptor stdoutInterceptor,
+			@Nullable StreamInterceptor stderrInterceptor, BiConsumer<TestIdentifier, ReportEntry> reporter) {
 		this.stdoutInterceptor = stdoutInterceptor;
 		this.stderrInterceptor = stderrInterceptor;
 		this.reporter = reporter;
 	}
 
 	void unregister() {
-		stdoutInterceptor.ifPresent(StreamInterceptor::unregister);
-		stderrInterceptor.ifPresent(StreamInterceptor::unregister);
+		if (stdoutInterceptor != null) {
+			stdoutInterceptor.unregister();
+		}
+		if (stderrInterceptor != null) {
+			stderrInterceptor.unregister();
+		}
 	}
 
 	@Override
 	public void executionJustStarted(TestIdentifier testIdentifier) {
-		stdoutInterceptor.ifPresent(StreamInterceptor::capture);
-		stderrInterceptor.ifPresent(StreamInterceptor::capture);
+		if (stdoutInterceptor != null) {
+			stdoutInterceptor.capture();
+		}
+		if (stderrInterceptor != null) {
+			stderrInterceptor.capture();
+		}
 	}
 
 	@Override
 	public void executionJustFinished(TestIdentifier testIdentifier, TestExecutionResult testExecutionResult) {
 		Map<String, String> map = new HashMap<>();
-		String out = stdoutInterceptor.map(StreamInterceptor::consume).orElse("");
-		if (StringUtils.isNotBlank(out)) {
-			map.put(STDOUT_REPORT_ENTRY_KEY, out);
+		if (stdoutInterceptor != null) {
+			String out = stdoutInterceptor.consume();
+			if (StringUtils.isNotBlank(out)) {
+				map.put(STDOUT_REPORT_ENTRY_KEY, out);
+			}
 		}
-		String err = stderrInterceptor.map(StreamInterceptor::consume).orElse("");
-		if (StringUtils.isNotBlank(err)) {
-			map.put(STDERR_REPORT_ENTRY_KEY, err);
+		if (stderrInterceptor != null) {
+			String err = stderrInterceptor.consume();
+			if (StringUtils.isNotBlank(err)) {
+				map.put(STDERR_REPORT_ENTRY_KEY, err);
+			}
 		}
 		if (!map.isEmpty()) {
 			reporter.accept(testIdentifier, ReportEntry.from(map));

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/StreamInterceptor.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/StreamInterceptor.java
@@ -15,7 +15,6 @@ import java.io.PrintStream;
 import java.nio.charset.Charset;
 import java.util.ArrayDeque;
 import java.util.Deque;
-import java.util.Optional;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.function.Consumer;
 
@@ -35,22 +34,22 @@ class StreamInterceptor extends PrintStream {
 	private final ThreadLocal<RewindableByteArrayOutputStream> output = ThreadLocal.withInitial(
 		RewindableByteArrayOutputStream::new);
 
-	static Optional<StreamInterceptor> registerStdout(int maxNumberOfBytesPerThread) {
+	static @Nullable StreamInterceptor registerStdout(int maxNumberOfBytesPerThread) {
 		return register(System.out, System::setOut, maxNumberOfBytesPerThread);
 	}
 
-	static Optional<StreamInterceptor> registerStderr(int maxNumberOfBytesPerThread) {
+	static @Nullable StreamInterceptor registerStderr(int maxNumberOfBytesPerThread) {
 		return register(System.err, System::setErr, maxNumberOfBytesPerThread);
 	}
 
-	static Optional<StreamInterceptor> register(PrintStream originalStream, Consumer<PrintStream> streamSetter,
+	static @Nullable StreamInterceptor register(PrintStream originalStream, Consumer<PrintStream> streamSetter,
 			int maxNumberOfBytesPerThread) {
 		if (originalStream instanceof StreamInterceptor) {
-			return Optional.empty();
+			return null;
 		}
 		StreamInterceptor interceptor = new StreamInterceptor(originalStream, streamSetter, maxNumberOfBytesPerThread);
 		streamSetter.accept(interceptor);
-		return Optional.of(interceptor);
+		return interceptor;
 	}
 
 	private StreamInterceptor(PrintStream originalStream, Consumer<PrintStream> unregisterAction,

--- a/platform-tests/src/test/java/org/junit/platform/launcher/core/StreamInterceptingTestExecutionListenerIntegrationTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/core/StreamInterceptingTestExecutionListenerIntegrationTests.java
@@ -103,8 +103,8 @@ class StreamInterceptingTestExecutionListenerIntegrationTests {
 		var engine = new DemoHierarchicalTestEngine("engine");
 		TestDescriptor test = engine.addTest("test", () -> printStreamSupplier.get().print("1234567890"));
 
-		assertThat(StreamInterceptor.registerStdout(1)).isPresent();
-		assertThat(StreamInterceptor.registerStderr(1)).isPresent();
+		assertThat(StreamInterceptor.registerStdout(1)).isNotNull();
+		assertThat(StreamInterceptor.registerStderr(1)).isNotNull();
 
 		var launcher = createLauncher(engine);
 		var listener = mock(TestExecutionListener.class);

--- a/platform-tests/src/test/java/org/junit/platform/launcher/core/StreamInterceptorTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/core/StreamInterceptorTests.java
@@ -12,6 +12,7 @@ package org.junit.platform.launcher.core;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
@@ -37,8 +38,9 @@ class StreamInterceptorTests {
 
 	@Test
 	void interceptsWriteOperationsToStreamPerThread() {
-		streamInterceptor = StreamInterceptor.register(targetStream, newStream -> this.targetStream = newStream,
-			3).orElseThrow(RuntimeException::new);
+		streamInterceptor = StreamInterceptor.register(targetStream, newStream -> this.targetStream = newStream, 3);
+		assertNotNull(streamInterceptor);
+
 		// @formatter:off
 		IntStream.range(0, 1000)
 				.parallel()
@@ -53,8 +55,8 @@ class StreamInterceptorTests {
 	void unregisterRestoresOriginalStream() {
 		var originalStream = targetStream;
 
-		streamInterceptor = StreamInterceptor.register(targetStream, newStream -> this.targetStream = newStream,
-			3).orElseThrow(RuntimeException::new);
+		streamInterceptor = StreamInterceptor.register(targetStream, newStream -> this.targetStream = newStream, 3);
+		assertNotNull(streamInterceptor);
 		assertSame(streamInterceptor, targetStream);
 
 		streamInterceptor.unregister();
@@ -65,8 +67,8 @@ class StreamInterceptorTests {
 	void writeForwardsOperationsToOriginalStream() throws Exception {
 		var originalStream = targetStream;
 
-		streamInterceptor = StreamInterceptor.register(targetStream, newStream -> this.targetStream = newStream,
-			2).orElseThrow(RuntimeException::new);
+		streamInterceptor = StreamInterceptor.register(targetStream, newStream -> this.targetStream = newStream, 2);
+		assertNotNull(streamInterceptor);
 		assertNotSame(originalStream, targetStream);
 
 		targetStream.write('a');
@@ -77,8 +79,8 @@ class StreamInterceptorTests {
 
 	@Test
 	void handlesNestedCaptures() {
-		streamInterceptor = StreamInterceptor.register(targetStream, newStream -> this.targetStream = newStream,
-			100).orElseThrow(RuntimeException::new);
+		streamInterceptor = StreamInterceptor.register(targetStream, newStream -> this.targetStream = newStream, 100);
+		assertNotNull(streamInterceptor);
 
 		String outermost, inner, innermost;
 
@@ -107,8 +109,8 @@ class StreamInterceptorTests {
 
 	@Test
 	void capturesOutputFromNonTestThreads() throws Exception {
-		streamInterceptor = StreamInterceptor.register(targetStream, newStream -> this.targetStream = newStream,
-			100).orElseThrow(RuntimeException::new);
+		streamInterceptor = StreamInterceptor.register(targetStream, newStream -> this.targetStream = newStream, 100);
+		assertNotNull(streamInterceptor);
 
 		streamInterceptor.capture();
 		var thread = new Thread(() -> targetStream.println("from non-test thread"));


### PR DESCRIPTION
Optional was not intended to be used as Maybe type[1], but rather as way to return something from an API to indicate there was no result in a way that wasn't likely to cause errors.

We actually used it as a Maybe type in a few places, but now that we have JSpecify that isn't nessesary anymore, and we can simplify the code base a little bit.

I have kept the method signature of optional getters the same in most places by wrapping the value in the getter. I.e:

```java
 	public Optional<T> getX() {
 		return Optional.ofNullable(this.x);
 	}
```

The assumption is that escape analysis will prevent undue garbage creation and not creating an `Optional` instance on the heap avoids a tiny bit of memory allocation.

1. https://stackoverflow.com/questions/26327957/should-java-8-getters-return-optional-type/26328555#26328555


---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://docs.junit.org/snapshot/) and [Release Notes](https://docs.junit.org/snapshot/release-notes.html)
