### PR TITLE
Prefer @Nullable to Optional for InterceptingExecutableInvoker

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ReflectiveInvocationContext.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ReflectiveInvocationContext.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.apiguardian.api.API;
+import org.jspecify.annotations.Nullable;
 
 /**
  * {@code ReflectiveInvocationContext} encapsulates the <em>context</em> of
@@ -56,7 +57,7 @@ public interface ReflectiveInvocationContext<T extends Executable> {
 	 * @return the arguments of the executable in this invocation context;
 	 * immutable and never {@code null}
 	 */
-	List<Object> getArguments();
+	List<@Nullable Object> getArguments();
 
 	/**
 	 * Get the target object of this invocation context, if available.

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ReflectiveInvocationContext.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ReflectiveInvocationContext.java
@@ -55,7 +55,7 @@ public interface ReflectiveInvocationContext<T extends Executable> {
 	 * Get the arguments of the executable in this invocation context.
 	 *
 	 * @return the arguments of the executable in this invocation context;
-	 * immutable and never {@code null}
+	 * immutable and never {@code null} but may contain {@code null}.
 	 */
 	List<@Nullable Object> getArguments();
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassBasedTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassBasedTestDescriptor.java
@@ -347,7 +347,7 @@ public abstract class ClassBasedTestDescriptor extends JupiterTestDescriptor
 	protected final TestInstances instantiateTestClass(Optional<TestInstances> outerInstances,
 			ExtensionRegistry registry, ExtensionContextSupplier extensionContext) {
 
-		Optional<Object> outerInstance = outerInstances.map(TestInstances::getInnermostInstance);
+		Object outerInstance = outerInstances.map(TestInstances::getInnermostInstance).orElse(null);
 		invokeTestInstancePreConstructCallbacks(new DefaultTestInstanceFactoryContext(getTestClass(), outerInstance),
 			registry, extensionContext);
 		Object instance = this.testInstanceFactory != null //
@@ -357,7 +357,7 @@ public abstract class ClassBasedTestDescriptor extends JupiterTestDescriptor
 				.orElse(DefaultTestInstances.of(instance));
 	}
 
-	private Object invokeTestInstanceFactory(TestInstanceFactory testInstanceFactory, Optional<Object> outerInstance,
+	private Object invokeTestInstanceFactory(TestInstanceFactory testInstanceFactory, @Nullable Object outerInstance,
 			ExtensionContextSupplier extensionContext) {
 		Object instance;
 
@@ -402,7 +402,7 @@ public abstract class ClassBasedTestDescriptor extends JupiterTestDescriptor
 		return instance;
 	}
 
-	private Object invokeTestClassConstructor(Optional<Object> outerInstance, ExtensionRegistry registry,
+	private Object invokeTestClassConstructor(@Nullable Object outerInstance, ExtensionRegistry registry,
 			ExtensionContextSupplier extensionContext) {
 
 		Constructor<?> constructor = ReflectionUtils.getDeclaredConstructor(getTestClass());

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassBasedTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassBasedTestDescriptor.java
@@ -344,17 +344,17 @@ public abstract class ClassBasedTestDescriptor extends JupiterTestDescriptor
 			ExtensionContextSupplier extensionContext, ExtensionRegistry registry,
 			JupiterEngineExecutionContext context);
 
-	protected final TestInstances instantiateTestClass(Optional<TestInstances> outerInstances,
+	protected final TestInstances instantiateTestClass(@Nullable TestInstances outerInstances,
 			ExtensionRegistry registry, ExtensionContextSupplier extensionContext) {
 
-		Object outerInstance = outerInstances.map(TestInstances::getInnermostInstance).orElse(null);
+		Object outerInstance = outerInstances != null ? outerInstances.getInnermostInstance() : null;
 		invokeTestInstancePreConstructCallbacks(new DefaultTestInstanceFactoryContext(getTestClass(), outerInstance),
 			registry, extensionContext);
 		Object instance = this.testInstanceFactory != null //
 				? invokeTestInstanceFactory(this.testInstanceFactory, outerInstance, extensionContext) //
 				: invokeTestClassConstructor(outerInstance, registry, extensionContext);
-		return outerInstances.map(instances -> DefaultTestInstances.of(instances, instance)) //
-				.orElse(DefaultTestInstances.of(instance));
+		return outerInstances != null ? DefaultTestInstances.of(outerInstances, instance)
+				: DefaultTestInstances.of(instance);
 	}
 
 	private Object invokeTestInstanceFactory(TestInstanceFactory testInstanceFactory, @Nullable Object outerInstance,

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassTestDescriptor.java
@@ -16,7 +16,6 @@ import static org.junit.jupiter.engine.descriptor.DisplayNameUtils.createDisplay
 
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
@@ -93,7 +92,7 @@ public class ClassTestDescriptor extends ClassBasedTestDescriptor {
 	protected TestInstances instantiateTestClass(JupiterEngineExecutionContext parentExecutionContext,
 			ExtensionContextSupplier extensionContext, ExtensionRegistry registry,
 			JupiterEngineExecutionContext context) {
-		return instantiateTestClass(Optional.empty(), registry, extensionContext);
+		return instantiateTestClass(null, registry, extensionContext);
 	}
 
 	// --- ResourceLockAware ---------------------------------------------------

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DefaultTestInstanceFactoryContext.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DefaultTestInstanceFactoryContext.java
@@ -12,6 +12,7 @@ package org.junit.jupiter.engine.descriptor;
 
 import java.util.Optional;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.extension.TestInstanceFactoryContext;
 import org.junit.platform.commons.util.ToStringBuilder;
 
@@ -20,7 +21,7 @@ import org.junit.platform.commons.util.ToStringBuilder;
  *
  * @since 5.3
  */
-record DefaultTestInstanceFactoryContext(Class<?> testClass, Optional<Object> outerInstance)
+record DefaultTestInstanceFactoryContext(Class<?> testClass, @Nullable Object outerInstance)
 		implements TestInstanceFactoryContext {
 
 	@Override
@@ -30,7 +31,7 @@ record DefaultTestInstanceFactoryContext(Class<?> testClass, Optional<Object> ou
 
 	@Override
 	public Optional<Object> getOuterInstance() {
-		return this.outerInstance;
+		return Optional.ofNullable(this.outerInstance);
 	}
 
 	@Override

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/NestedClassTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/NestedClassTestDescriptor.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.engine.descriptor.ResourceLockAware.enclosingIns
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -107,7 +106,7 @@ public class NestedClassTestDescriptor extends ClassBasedTestDescriptor {
 		ExtensionRegistry extensionRegistryForOuterInstanceCreation = parentExecutionContext.getExtensionRegistry();
 		TestInstances outerInstances = parentExecutionContext.getTestInstancesProvider().getTestInstances(
 			extensionRegistryForOuterInstanceCreation, context);
-		return instantiateTestClass(Optional.of(outerInstances), registry, extensionContext);
+		return instantiateTestClass(outerInstances, registry, extensionContext);
 	}
 
 	// --- ResourceLockAware ---------------------------------------------------

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/ConstructorInvocation.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/ConstructorInvocation.java
@@ -43,8 +43,9 @@ class ConstructorInvocation<T> implements Invocation<T>, ReflectiveInvocationCon
 	}
 
 	@Override
-	public List<Object> getArguments() {
-		return unmodifiableList(Arrays.asList(this.arguments));
+	public List<@Nullable Object> getArguments() {
+		List<@Nullable Object> list = Arrays.asList(this.arguments);
+		return unmodifiableList(list);
 	}
 
 	@Override

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/DefaultExecutableInvoker.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/DefaultExecutableInvoker.java
@@ -15,7 +15,6 @@ import static org.junit.jupiter.engine.execution.ParameterResolutionUtils.resolv
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
-import java.util.Optional;
 
 import org.apiguardian.api.API;
 import org.jspecify.annotations.Nullable;
@@ -42,16 +41,14 @@ public class DefaultExecutableInvoker implements ExecutableInvoker {
 	@Override
 	public <T> T invoke(Constructor<T> constructor, @Nullable Object outerInstance) {
 		@Nullable
-		Object[] arguments = resolveParameters(constructor, Optional.empty(), Optional.ofNullable(outerInstance),
-			extensionContext, extensionRegistry);
+		Object[] arguments = resolveParameters(constructor, null, outerInstance, extensionContext, extensionRegistry);
 		return ReflectionUtils.newInstance(constructor, arguments);
 	}
 
 	@Override
 	public @Nullable Object invoke(Method method, @Nullable Object target) {
 		@Nullable
-		Object[] arguments = resolveParameters(method, Optional.ofNullable(target), extensionContext,
-			extensionRegistry);
+		Object[] arguments = resolveParameters(method, target, extensionContext, extensionRegistry);
 		return MethodReflectionUtils.invoke(method, target, arguments);
 	}
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/DefaultParameterContext.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/DefaultParameterContext.java
@@ -13,6 +13,7 @@ package org.junit.jupiter.engine.execution;
 import java.lang.reflect.Parameter;
 import java.util.Optional;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.platform.commons.util.Preconditions;
 import org.junit.platform.commons.util.ToStringBuilder;
@@ -20,12 +21,11 @@ import org.junit.platform.commons.util.ToStringBuilder;
 /**
  * @since 5.0
  */
-record DefaultParameterContext(Parameter parameter, int index, Optional<Object> target) implements ParameterContext {
+record DefaultParameterContext(Parameter parameter, int index, @Nullable Object target) implements ParameterContext {
 
 	DefaultParameterContext {
 		Preconditions.condition(index >= 0, "index must be greater than or equal to zero");
 		Preconditions.notNull(parameter, "parameter must not be null");
-		Preconditions.notNull(target, "target must not be null");
 	}
 
 	@Override
@@ -40,7 +40,7 @@ record DefaultParameterContext(Parameter parameter, int index, Optional<Object> 
 
 	@Override
 	public Optional<Object> getTarget() {
-		return this.target;
+		return Optional.ofNullable(this.target);
 	}
 
 	@Override

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/InterceptingExecutableInvoker.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/InterceptingExecutableInvoker.java
@@ -16,7 +16,6 @@ import static org.junit.jupiter.engine.execution.ParameterResolutionUtils.resolv
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Executable;
 import java.lang.reflect.Method;
-import java.util.Optional;
 
 import org.apiguardian.api.API;
 import org.jspecify.annotations.Nullable;
@@ -76,8 +75,7 @@ public class InterceptingExecutableInvoker {
 	 *
 	 * @param method the method to invoke and resolve parameters for
 	 * @param target the target on which the executable will be invoked,
-	 * potentially wrapped in an {@link Optional}; can be {@code null} or an
-	 * empty {@code Optional} for a {@code static} method
+	 * can be {@code null} for a {@code static} method.
 	 * @param extensionContext the current {@code ExtensionContext}
 	 * @param extensionRegistry the {@code ExtensionRegistry} to retrieve
 	 * {@code ParameterResolvers} from

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/InterceptingExecutableInvoker.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/InterceptingExecutableInvoker.java
@@ -55,13 +55,12 @@ public class InterceptingExecutableInvoker {
 	 * invocation via all registered {@linkplain InvocationInterceptor
 	 * interceptors}
 	 */
-	public <T> T invoke(Constructor<T> constructor, Optional<Object> outerInstance,
+	public <T> T invoke(Constructor<T> constructor, @Nullable Object outerInstance,
 			ExtensionContextSupplier extensionContext, ExtensionRegistry extensionRegistry,
 			ReflectiveInterceptorCall<Constructor<T>, T> interceptorCall) {
 
 		@Nullable
-		Object[] arguments = resolveParameters(constructor, Optional.empty(), outerInstance, extensionContext,
-			extensionRegistry);
+		Object[] arguments = resolveParameters(constructor, null, outerInstance, extensionContext, extensionRegistry);
 		ConstructorInvocation<T> invocation = new ConstructorInvocation<>(constructor, arguments);
 		return invoke(invocation, invocation, extensionContext, extensionRegistry, interceptorCall);
 	}
@@ -89,16 +88,13 @@ public class InterceptingExecutableInvoker {
 			ExtensionContext extensionContext, ExtensionRegistry extensionRegistry,
 			ReflectiveInterceptorCall<Method, T> interceptorCall) {
 
-		@SuppressWarnings({ "unchecked", "rawtypes" })
-		Optional<Object> optionalTarget = (target instanceof Optional optional ? optional
-				: Optional.ofNullable(target));
 		@Nullable
-		Object[] arguments = resolveParameters(method, optionalTarget, extensionContext, extensionRegistry);
-		MethodInvocation<T> invocation = new MethodInvocation<>(method, optionalTarget, arguments);
+		Object[] arguments = resolveParameters(method, target, extensionContext, extensionRegistry);
+		MethodInvocation<T> invocation = new MethodInvocation<>(method, target, arguments);
 		return invoke(invocation, invocation, extensionContext, extensionRegistry, interceptorCall);
 	}
 
-	private <E extends Executable, T> T invoke(Invocation<T> originalInvocation,
+	private <E extends Executable, T extends @Nullable Object> T invoke(Invocation<T> originalInvocation,
 			ReflectiveInvocationContext<E> invocationContext, ExtensionContext extensionContext,
 			ExtensionRegistry extensionRegistry, ReflectiveInterceptorCall<E, T> call) {
 		return interceptorChain.invoke(originalInvocation, extensionRegistry, (interceptor,

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/MethodInvocation.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/MethodInvocation.java
@@ -36,10 +36,7 @@ class MethodInvocation<T extends @Nullable Object> implements Invocation<T>, Ref
 
 	@Override
 	public Class<?> getTargetClass() {
-		if (target != null) {
-			return this.target.getClass();
-		}
-		return this.method.getDeclaringClass();
+		return this.target != null ? this.target.getClass() : this.method.getDeclaringClass();
 	}
 
 	@Override

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/MethodInvocation.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/MethodInvocation.java
@@ -25,10 +25,10 @@ import org.junit.jupiter.engine.support.MethodReflectionUtils;
 class MethodInvocation<T extends @Nullable Object> implements Invocation<T>, ReflectiveInvocationContext<Method> {
 
 	private final Method method;
-	private final Optional<Object> target;
+	private final @Nullable Object target;
 	private final @Nullable Object[] arguments;
 
-	MethodInvocation(Method method, Optional<Object> target, @Nullable Object[] arguments) {
+	MethodInvocation(Method method, @Nullable Object target, @Nullable Object[] arguments) {
 		this.method = method;
 		this.target = target;
 		this.arguments = arguments;
@@ -36,12 +36,15 @@ class MethodInvocation<T extends @Nullable Object> implements Invocation<T>, Ref
 
 	@Override
 	public Class<?> getTargetClass() {
-		return this.target.<Class<?>> map(Object::getClass).orElseGet(this.method::getDeclaringClass);
+		if (target != null) {
+			return this.target.getClass();
+		}
+		return this.method.getDeclaringClass();
 	}
 
 	@Override
 	public Optional<Object> getTarget() {
-		return this.target;
+		return Optional.ofNullable(this.target);
 	}
 
 	@Override
@@ -50,15 +53,15 @@ class MethodInvocation<T extends @Nullable Object> implements Invocation<T>, Ref
 	}
 
 	@Override
-	public List<Object> getArguments() {
-		return unmodifiableList(Arrays.asList(this.arguments));
+	public List<@Nullable Object> getArguments() {
+		List<@Nullable Object> list = Arrays.asList(this.arguments);
+		return unmodifiableList(list);
 	}
 
 	@Override
 	@SuppressWarnings({ "unchecked", "NullAway" })
 	public T proceed() {
-		var actualTarget = this.target.orElse(null);
-		return (T) MethodReflectionUtils.invoke(this.method, actualTarget, this.arguments);
+		return (T) MethodReflectionUtils.invoke(this.method, this.target, this.arguments);
 	}
 
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/ParameterResolutionUtils.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/ParameterResolutionUtils.java
@@ -21,7 +21,6 @@ import java.lang.reflect.Executable;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.util.List;
-import java.util.Optional;
 
 import org.apiguardian.api.API;
 import org.jspecify.annotations.Nullable;
@@ -32,7 +31,6 @@ import org.junit.jupiter.api.extension.ParameterResolver;
 import org.junit.jupiter.engine.extension.ExtensionRegistry;
 import org.junit.platform.commons.logging.Logger;
 import org.junit.platform.commons.logging.LoggerFactory;
-import org.junit.platform.commons.util.Preconditions;
 import org.junit.platform.commons.util.StringUtils;
 import org.junit.platform.commons.util.UnrecoverableExceptions;
 
@@ -60,10 +58,10 @@ public class ParameterResolutionUtils {
 	 * @return the array of Objects to be used as parameters in the executable
 	 * invocation; never {@code null} though potentially empty
 	 */
-	public static @Nullable Object[] resolveParameters(Method method, Optional<Object> target,
+	public static @Nullable Object[] resolveParameters(Method method, @Nullable Object target,
 			ExtensionContext extensionContext, ExtensionRegistry extensionRegistry) {
 
-		return resolveParameters(method, target, Optional.empty(), __ -> extensionContext, extensionRegistry,
+		return resolveParameters(method, target, null, __ -> extensionContext, extensionRegistry,
 			isKotlinSuspendingFunction(method) //
 					? getKotlinSuspendingFunctionParameters(method) //
 					: method.getParameters());
@@ -86,24 +84,22 @@ public class ParameterResolutionUtils {
 	 * @return the array of Objects to be used as parameters in the executable
 	 * invocation; never {@code null} though potentially empty
 	 */
-	public static @Nullable Object[] resolveParameters(Executable executable, Optional<Object> target,
-			Optional<Object> outerInstance, ExtensionContext extensionContext, ExtensionRegistry extensionRegistry) {
+	public static @Nullable Object[] resolveParameters(Executable executable, @Nullable Object target,
+			@Nullable Object outerInstance, ExtensionContext extensionContext, ExtensionRegistry extensionRegistry) {
 		return resolveParameters(executable, target, outerInstance, __ -> extensionContext, extensionRegistry);
 	}
 
-	public static @Nullable Object[] resolveParameters(Executable executable, Optional<Object> target,
-			Optional<Object> outerInstance, ExtensionContextSupplier extensionContext,
+	public static @Nullable Object[] resolveParameters(Executable executable, @Nullable Object target,
+			@Nullable Object outerInstance, ExtensionContextSupplier extensionContext,
 			ExtensionRegistry extensionRegistry) {
 
 		return resolveParameters(executable, target, outerInstance, extensionContext, extensionRegistry,
 			executable.getParameters());
 	}
 
-	private static @Nullable Object[] resolveParameters(Executable executable, Optional<Object> target,
-			Optional<Object> outerInstance, ExtensionContextSupplier extensionContext,
+	private static @Nullable Object[] resolveParameters(Executable executable, @Nullable Object target,
+			@Nullable Object outerInstance, ExtensionContextSupplier extensionContext,
 			ExtensionRegistry extensionRegistry, Parameter[] parameters) {
-
-		Preconditions.notNull(target, "target must not be null");
 
 		@Nullable
 		Object[] values = new Object[parameters.length];
@@ -111,8 +107,8 @@ public class ParameterResolutionUtils {
 
 		// Ensure that the outer instance is resolved as the first parameter if
 		// the executable is a constructor for an inner class.
-		if (outerInstance.isPresent()) {
-			values[0] = outerInstance.get();
+		if (outerInstance != null) {
+			values[0] = outerInstance;
 			start = 1;
 		}
 

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ResolverFacade.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ResolverFacade.java
@@ -704,14 +704,14 @@ class ResolverFacade {
 
 		private ParameterContext toParameterContext(ExtensionContext extensionContext,
 				Optional<ParameterContext> originalParameterContext) {
-			Optional<Object> target = originalParameterContext.flatMap(ParameterContext::getTarget);
-			if (target.isEmpty()) {
-				target = extensionContext.getTestInstance();
+			Object target = originalParameterContext.flatMap(ParameterContext::getTarget).orElse(null);
+			if (target == null) {
+				target = extensionContext.getTestInstance().orElse(null);
 			}
 			return toParameterContext(target);
 		}
 
-		private ParameterContext toParameterContext(Optional<Object> target) {
+		private ParameterContext toParameterContext(@Nullable Object target) {
 			return new ParameterContext() {
 				@Override
 				public java.lang.reflect.Parameter getParameter() {
@@ -725,7 +725,7 @@ class ResolverFacade {
 
 				@Override
 				public Optional<Object> getTarget() {
-					return target;
+					return Optional.ofNullable(target);
 				}
 			};
 		}

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/MethodArgumentsProvider.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/MethodArgumentsProvider.java
@@ -16,7 +16,6 @@ import static org.junit.platform.commons.util.CollectionUtils.isConvertibleToStr
 
 import java.lang.reflect.Method;
 import java.util.List;
-import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
@@ -45,7 +44,7 @@ class MethodArgumentsProvider extends AnnotationBasedArgumentsProvider<MethodSou
 	protected Stream<? extends Arguments> provideArguments(ParameterDeclarations parameters, ExtensionContext context,
 			MethodSource methodSource) {
 		Class<?> testClass = context.getRequiredTestClass();
-		Optional<Method> testMethod = context.getTestMethod();
+		Method testMethod = context.getTestMethod().orElse(null);
 		Object testInstance = context.getTestInstance().orElse(null);
 		String[] methodNames = methodSource.value();
 		// @formatter:off
@@ -58,15 +57,15 @@ class MethodArgumentsProvider extends AnnotationBasedArgumentsProvider<MethodSou
 		// @formatter:on
 	}
 
-	private static Method findFactoryMethod(Class<?> testClass, Optional<Method> testMethod, String factoryMethodName) {
+	private static Method findFactoryMethod(Class<?> testClass, @Nullable Method testMethod, String factoryMethodName) {
 		String originalFactoryMethodName = factoryMethodName;
 
 		// If the user did not provide a factory method name, find a "default" local
 		// factory method with the same name as the parameterized test method.
 		if (StringUtils.isBlank(factoryMethodName)) {
-			Preconditions.condition(testMethod.isPresent(),
+			Preconditions.condition(testMethod != null,
 				"You must specify a method name when using @MethodSource with @ParameterizedClass");
-			factoryMethodName = testMethod.get().getName();
+			factoryMethodName = testMethod.getName();
 			return findFactoryMethodBySimpleName(testClass, testMethod, factoryMethodName);
 		}
 
@@ -107,7 +106,7 @@ class MethodArgumentsProvider extends AnnotationBasedArgumentsProvider<MethodSou
 	}
 
 	// package-private for testing
-	static Method findFactoryMethodByFullyQualifiedName(Class<?> testClass, Optional<Method> testMethod,
+	static Method findFactoryMethodByFullyQualifiedName(Class<?> testClass, @Nullable Method testMethod,
 			String fullyQualifiedMethodName) {
 		String[] methodParts = ReflectionUtils.parseFullyQualifiedMethodName(fullyQualifiedMethodName);
 		String className = methodParts[0];
@@ -146,10 +145,10 @@ class MethodArgumentsProvider extends AnnotationBasedArgumentsProvider<MethodSou
 	 * @throws PreconditionViolationException if the factory method was not found or
 	 * multiple competing factory methods with the same name were found
 	 */
-	private static Method findFactoryMethodBySimpleName(Class<?> clazz, Optional<Method> testMethod,
+	private static Method findFactoryMethodBySimpleName(Class<?> clazz, @Nullable Method testMethod,
 			String factoryMethodName) {
 		Predicate<Method> isCandidate = candidate -> factoryMethodName.equals(candidate.getName())
-				&& !candidate.equals(testMethod.orElse(null));
+				&& !candidate.equals(testMethod);
 		List<Method> candidates = ReflectionUtils.findMethods(clazz, isCandidate);
 
 		List<Method> factoryMethods = candidates.stream().filter(isFactoryMethod).toList();

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/execution/InterceptingExecutableInvokerTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/execution/InterceptingExecutableInvokerTests.java
@@ -14,7 +14,6 @@ import static java.util.Objects.requireNonNull;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Executable;
-import java.util.Optional;
 
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.ReflectiveInterceptorCall;
@@ -34,8 +33,8 @@ class InterceptingExecutableInvokerTests extends AbstractExecutableInvokerTests 
 
 	@Override
 	<T> T invokeConstructor(Constructor<T> constructor, @Nullable Object outerInstance) {
-		return newInvoker().invoke(constructor, Optional.ofNullable(outerInstance), __ -> extensionContext,
-			extensionRegistry, passthroughInterceptor());
+		return newInvoker().invoke(constructor, outerInstance, __ -> extensionContext, extensionRegistry,
+			passthroughInterceptor());
 	}
 
 	private InterceptingExecutableInvoker newInvoker() {

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/execution/ParameterResolutionUtilsTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/execution/ParameterResolutionUtilsTests.java
@@ -22,7 +22,6 @@ import static org.mockito.Mockito.mock;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.math.BigDecimal;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
@@ -89,8 +88,8 @@ class ParameterResolutionUtilsTests {
 			ConstructorInjectionTestCase.class);
 
 		Exception exception = assertThrows(ParameterResolutionException.class,
-			() -> ParameterResolutionUtils.resolveParameters(constructor, Optional.empty(), Optional.empty(),
-				extensionContext, extensionRegistry));
+			() -> ParameterResolutionUtils.resolveParameters(constructor, null, null, extensionContext,
+				extensionRegistry));
 
 		assertThat(exception.getMessage())//
 				.contains("No ParameterResolver registered for parameter [java.lang.String")//
@@ -353,12 +352,12 @@ class ParameterResolutionUtilsTests {
 
 	private <T> @Nullable Object[] resolveConstructorParameters(Class<T> clazz, @Nullable Object outerInstance) {
 		Constructor<T> constructor = ReflectionUtils.getDeclaredConstructor(clazz);
-		return ParameterResolutionUtils.resolveParameters(constructor, Optional.empty(),
-			Optional.ofNullable(outerInstance), extensionContext, extensionRegistry);
+		return ParameterResolutionUtils.resolveParameters(constructor, null, outerInstance, extensionContext,
+			extensionRegistry);
 	}
 
 	private @Nullable Object[] resolveMethodParameters() {
-		return ParameterResolutionUtils.resolveParameters(requireNonNull(this.method), Optional.of(this.instance),
+		return ParameterResolutionUtils.resolveParameters(requireNonNull(this.method), this.instance,
 			this.extensionContext, this.extensionRegistry);
 	}
 

--- a/jupiter-tests/src/test/java/org/junit/jupiter/params/provider/MethodArgumentsProviderTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/params/provider/MethodArgumentsProviderTests.java
@@ -249,7 +249,7 @@ class MethodArgumentsProviderTests {
 	void providesArgumentsUsingExternalFactoryMethodInTypeFromDifferentClassLoader() throws Exception {
 		try (var testClassLoader = TestClassLoader.forClasses(TestCase.class, ExternalFactoryMethods.class)) {
 			var testClass = testClassLoader.loadClass(TestCase.class.getName());
-			var testMethod = ReflectionUtils.findMethod(testClass, "test").get();
+			var testMethod = ReflectionUtils.findMethod(testClass, "test").orElseThrow();
 			var fullyQualifiedMethodName = ExternalFactoryMethods.class.getName() + "#stringsProvider";
 
 			assertThat(testClass.getClassLoader()).isSameAs(testClassLoader);
@@ -257,8 +257,8 @@ class MethodArgumentsProviderTests {
 			var arguments = provideArguments(testClass, false, fullyQualifiedMethodName);
 			assertThat(arguments).containsExactly(array("string1"), array("string2"));
 
-			var factoryMethod = MethodArgumentsProvider.findFactoryMethodByFullyQualifiedName(testClass,
-				Optional.of(testMethod), fullyQualifiedMethodName);
+			var factoryMethod = MethodArgumentsProvider.findFactoryMethodByFullyQualifiedName(testClass, testMethod,
+				fullyQualifiedMethodName);
 			assertThat(factoryMethod).isNotNull();
 			assertThat(factoryMethod.getName()).isEqualTo("stringsProvider");
 			assertThat(factoryMethod.getParameterTypes()).isEmpty();


### PR DESCRIPTION
Same as https://github.com/junit-team/junit-framework/pull/5700, but for the `InterceptingExecutableInvoker` specifically. 

An interesting aspect of this API was that we open taken in nullable values, wrap them in an `Optional`, pass them down the call chain and then unwrap them later on. With JSpecify available this isn't necessary at all and we can also remove this behaviour.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://docs.junit.org/snapshot/) and [Release Notes](https://docs.junit.org/snapshot/release-notes.html)
