### PR TITLE
Support NetBSD and DragonFlyBSD in `@EnabledOnOs` and `@DisabledOnOs`

### DIFF
--- a/documentation/modules/ROOT/partials/release-notes/release-notes-6.2.0-M1.adoc
+++ b/documentation/modules/ROOT/partials/release-notes/release-notes-6.2.0-M1.adoc
@@ -48,6 +48,7 @@ repository on GitHub.
 [[v6.2.0-M1-junit-jupiter-new-features-and-improvements]]
 ==== New Features and Improvements
 
+* Added `OS.NETBSD` enum constant for use with `@EnabledOnOs` and `@DisabledOnOs`.
 * Failures caused by `@Timeout` expirations now include a hint about enabling
   xref:writing-tests/timeouts.adoc#debugging-thread-dump[thread dumps].
 

--- a/documentation/modules/ROOT/partials/release-notes/release-notes-6.2.0-M1.adoc
+++ b/documentation/modules/ROOT/partials/release-notes/release-notes-6.2.0-M1.adoc
@@ -48,7 +48,8 @@ repository on GitHub.
 [[v6.2.0-M1-junit-jupiter-new-features-and-improvements]]
 ==== New Features and Improvements
 
-* Added `OS.NETBSD` enum constant for use with `@EnabledOnOs` and `@DisabledOnOs`.
+* Added `OS.NETBSD` and `OS.DRAGONFLYBSD` enum constants for use with `@EnabledOnOs`
+  and `@DisabledOnOs`.
 * Failures caused by `@Timeout` expirations now include a hint about enabling
   xref:writing-tests/timeouts.adoc#debugging-thread-dump[thread dumps].
 

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/OS.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/OS.java
@@ -30,6 +30,7 @@ import org.junit.platform.commons.util.StringUtils;
  *
  * @since 5.1
  * @see #AIX
+ * @see #DRAGONFLYBSD
  * @see #FREEBSD
  * @see #LINUX
  * @see #MAC
@@ -51,6 +52,14 @@ public enum OS {
 	 */
 	@API(status = STABLE, since = "5.3")
 	AIX,
+
+	/**
+	 * DragonFly BSD operating system.
+	 *
+	 * @since 6.2
+	 */
+	@API(status = STABLE, since = "6.2")
+	DRAGONFLYBSD,
 
 	/**
 	 * FreeBSD operating system.
@@ -97,8 +106,9 @@ public enum OS {
 	WINDOWS,
 
 	/**
-	 * An operating system other than {@link #AIX}, {@link #FREEBSD}, {@link #LINUX},
-	 * {@link #MAC}, {@link #NETBSD}, {@link #OPENBSD}, {@link #SOLARIS}, or {@link #WINDOWS}.
+	 * An operating system other than {@link #AIX}, {@link #DRAGONFLYBSD},
+	 * {@link #FREEBSD}, {@link #LINUX}, {@link #MAC}, {@link #NETBSD},
+	 * {@link #OPENBSD}, {@link #SOLARIS}, or {@link #WINDOWS}.
 	 */
 	OTHER;
 
@@ -133,6 +143,9 @@ public enum OS {
 
 		if (osName.contains("aix")) {
 			return AIX;
+		}
+		if (osName.contains("dragonflybsd")) {
+			return DRAGONFLYBSD;
 		}
 		if (osName.contains("freebsd")) {
 			return FREEBSD;

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/OS.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/OS.java
@@ -33,6 +33,7 @@ import org.junit.platform.commons.util.StringUtils;
  * @see #FREEBSD
  * @see #LINUX
  * @see #MAC
+ * @see #NETBSD
  * @see #OPENBSD
  * @see #SOLARIS
  * @see #WINDOWS
@@ -70,6 +71,14 @@ public enum OS {
 	MAC,
 
 	/**
+	 * NetBSD operating system.
+	 *
+	 * @since 6.2
+	 */
+	@API(status = STABLE, since = "6.2")
+	NETBSD,
+
+	/**
 	 * OpenBSD operating system.
 	 *
 	 * @since 5.9
@@ -89,7 +98,7 @@ public enum OS {
 
 	/**
 	 * An operating system other than {@link #AIX}, {@link #FREEBSD}, {@link #LINUX},
-	 * {@link #MAC}, {@link #OPENBSD}, {@link #SOLARIS}, or {@link #WINDOWS}.
+	 * {@link #MAC}, {@link #NETBSD}, {@link #OPENBSD}, {@link #SOLARIS}, or {@link #WINDOWS}.
 	 */
 	OTHER;
 
@@ -133,6 +142,9 @@ public enum OS {
 		}
 		if (osName.contains("mac")) {
 			return MAC;
+		}
+		if (osName.contains("netbsd")) {
+			return NETBSD;
 		}
 		if (osName.contains("openbsd")) {
 			return OPENBSD;

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/condition/DisabledOnOsConditionTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/condition/DisabledOnOsConditionTests.java
@@ -12,6 +12,7 @@ package org.junit.jupiter.api.condition;
 
 import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onAix;
 import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onArchitecture;
+import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onDragonflybsd;
 import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onFreebsd;
 import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onLinux;
 import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onMac;
@@ -83,6 +84,15 @@ class DisabledOnOsConditionTests extends AbstractExecutionConditionTests {
 	void aix() {
 		evaluateCondition();
 		assertDisabledOnCurrentOsIf(onAix());
+	}
+
+	/**
+	 * @see DisabledOnOsIntegrationTests#dragonflybsd()
+	 */
+	@Test
+	void dragonflybsd() {
+		evaluateCondition();
+		assertDisabledOnCurrentOsIf(onDragonflybsd());
 	}
 
 	/**
@@ -163,8 +173,8 @@ class DisabledOnOsConditionTests extends AbstractExecutionConditionTests {
 	@Test
 	void other() {
 		evaluateCondition();
-		assertDisabledOnCurrentOsIf(!(onAix() || onFreebsd() || onLinux() || onMac() || onNetbsd() || onOpenbsd()
-				|| onSolaris() || onWindows()));
+		assertDisabledOnCurrentOsIf(!(onAix() || onDragonflybsd() || onFreebsd() || onLinux() || onMac() || onNetbsd()
+				|| onOpenbsd() || onSolaris() || onWindows()));
 	}
 
 	/**

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/condition/DisabledOnOsConditionTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/condition/DisabledOnOsConditionTests.java
@@ -15,6 +15,7 @@ import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onArch
 import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onFreebsd;
 import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onLinux;
 import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onMac;
+import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onNetbsd;
 import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onOpenbsd;
 import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onSolaris;
 import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onWindows;
@@ -130,6 +131,15 @@ class DisabledOnOsConditionTests extends AbstractExecutionConditionTests {
 	}
 
 	/**
+	 * @see DisabledOnOsIntegrationTests#netbsd()
+	 */
+	@Test
+	void netbsd() {
+		evaluateCondition();
+		assertDisabledOnCurrentOsIf(onNetbsd());
+	}
+
+	/**
 	 * @see DisabledOnOsIntegrationTests#windows()
 	 */
 	@Test
@@ -153,8 +163,8 @@ class DisabledOnOsConditionTests extends AbstractExecutionConditionTests {
 	@Test
 	void other() {
 		evaluateCondition();
-		assertDisabledOnCurrentOsIf(
-			!(onAix() || onFreebsd() || onLinux() || onMac() || onOpenbsd() || onSolaris() || onWindows()));
+		assertDisabledOnCurrentOsIf(!(onAix() || onFreebsd() || onLinux() || onMac() || onNetbsd() || onOpenbsd()
+				|| onSolaris() || onWindows()));
 	}
 
 	/**

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/condition/DisabledOnOsIntegrationTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/condition/DisabledOnOsIntegrationTests.java
@@ -18,6 +18,7 @@ import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onArch
 import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onFreebsd;
 import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onLinux;
 import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onMac;
+import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onNetbsd;
 import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onOpenbsd;
 import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onSolaris;
 import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onWindows;
@@ -25,6 +26,7 @@ import static org.junit.jupiter.api.condition.OS.AIX;
 import static org.junit.jupiter.api.condition.OS.FREEBSD;
 import static org.junit.jupiter.api.condition.OS.LINUX;
 import static org.junit.jupiter.api.condition.OS.MAC;
+import static org.junit.jupiter.api.condition.OS.NETBSD;
 import static org.junit.jupiter.api.condition.OS.OPENBSD;
 import static org.junit.jupiter.api.condition.OS.OTHER;
 import static org.junit.jupiter.api.condition.OS.SOLARIS;
@@ -57,7 +59,7 @@ class DisabledOnOsIntegrationTests {
 	}
 
 	@Test
-	@DisabledOnOs(value = { AIX, FREEBSD, LINUX, MAC, OPENBSD, WINDOWS, SOLARIS,
+	@DisabledOnOs(value = { AIX, FREEBSD, LINUX, MAC, NETBSD, OPENBSD, WINDOWS, SOLARIS,
 			OTHER }, disabledReason = "Disabled on every OS")
 	void disabledOnEveryOs() {
 		fail("should be disabled");
@@ -100,6 +102,12 @@ class DisabledOnOsIntegrationTests {
 	}
 
 	@Test
+	@DisabledOnOs(NETBSD)
+	void netbsd() {
+		assertFalse(onNetbsd());
+	}
+
+	@Test
 	@DisabledOnOs(WINDOWS)
 	void windows() {
 		assertFalse(onWindows());
@@ -114,7 +122,8 @@ class DisabledOnOsIntegrationTests {
 	@Test
 	@DisabledOnOs(OTHER)
 	void other() {
-		assertTrue(onAix() || onFreebsd() || onLinux() || onMac() || onOpenbsd() || onSolaris() || onWindows());
+		assertTrue(
+			onAix() || onFreebsd() || onLinux() || onMac() || onNetbsd() || onOpenbsd() || onSolaris() || onWindows());
 	}
 
 	@Test

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/condition/DisabledOnOsIntegrationTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/condition/DisabledOnOsIntegrationTests.java
@@ -15,6 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onAix;
 import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onArchitecture;
+import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onDragonflybsd;
 import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onFreebsd;
 import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onLinux;
 import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onMac;
@@ -23,6 +24,7 @@ import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onOpen
 import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onSolaris;
 import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onWindows;
 import static org.junit.jupiter.api.condition.OS.AIX;
+import static org.junit.jupiter.api.condition.OS.DRAGONFLYBSD;
 import static org.junit.jupiter.api.condition.OS.FREEBSD;
 import static org.junit.jupiter.api.condition.OS.LINUX;
 import static org.junit.jupiter.api.condition.OS.MAC;
@@ -59,7 +61,7 @@ class DisabledOnOsIntegrationTests {
 	}
 
 	@Test
-	@DisabledOnOs(value = { AIX, FREEBSD, LINUX, MAC, NETBSD, OPENBSD, WINDOWS, SOLARIS,
+	@DisabledOnOs(value = { AIX, DRAGONFLYBSD, FREEBSD, LINUX, MAC, NETBSD, OPENBSD, WINDOWS, SOLARIS,
 			OTHER }, disabledReason = "Disabled on every OS")
 	void disabledOnEveryOs() {
 		fail("should be disabled");
@@ -69,6 +71,12 @@ class DisabledOnOsIntegrationTests {
 	@DisabledOnOs(AIX)
 	void aix() {
 		assertFalse(onAix());
+	}
+
+	@Test
+	@DisabledOnOs(DRAGONFLYBSD)
+	void dragonflybsd() {
+		assertFalse(onDragonflybsd());
 	}
 
 	@Test
@@ -122,8 +130,8 @@ class DisabledOnOsIntegrationTests {
 	@Test
 	@DisabledOnOs(OTHER)
 	void other() {
-		assertTrue(
-			onAix() || onFreebsd() || onLinux() || onMac() || onNetbsd() || onOpenbsd() || onSolaris() || onWindows());
+		assertTrue(onAix() || onDragonflybsd() || onFreebsd() || onLinux() || onMac() || onNetbsd() || onOpenbsd()
+				|| onSolaris() || onWindows());
 	}
 
 	@Test

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/condition/EnabledOnOsConditionTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/condition/EnabledOnOsConditionTests.java
@@ -15,6 +15,7 @@ import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onArch
 import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onFreebsd;
 import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onLinux;
 import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onMac;
+import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onNetbsd;
 import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onOpenbsd;
 import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onSolaris;
 import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onWindows;
@@ -129,6 +130,15 @@ class EnabledOnOsConditionTests extends AbstractExecutionConditionTests {
 	}
 
 	/**
+	 * @see EnabledOnOsIntegrationTests#netbsd()
+	 */
+	@Test
+	void netbsd() {
+		evaluateCondition();
+		assertEnabledOnCurrentOsIf(onNetbsd());
+	}
+
+	/**
 	 * @see EnabledOnOsIntegrationTests#windows()
 	 */
 	@Test
@@ -152,8 +162,8 @@ class EnabledOnOsConditionTests extends AbstractExecutionConditionTests {
 	@Test
 	void other() {
 		evaluateCondition();
-		assertEnabledOnCurrentOsIf(
-			!(onAix() || onFreebsd() || onLinux() || onMac() || onOpenbsd() || onSolaris() || onWindows()));
+		assertEnabledOnCurrentOsIf(!(onAix() || onFreebsd() || onLinux() || onMac() || onNetbsd() || onOpenbsd()
+				|| onSolaris() || onWindows()));
 		assertCustomDisabledReasonIs("Disabled on almost every OS");
 	}
 

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/condition/EnabledOnOsConditionTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/condition/EnabledOnOsConditionTests.java
@@ -12,6 +12,7 @@ package org.junit.jupiter.api.condition;
 
 import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onAix;
 import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onArchitecture;
+import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onDragonflybsd;
 import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onFreebsd;
 import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onLinux;
 import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onMac;
@@ -82,6 +83,15 @@ class EnabledOnOsConditionTests extends AbstractExecutionConditionTests {
 	void aix() {
 		evaluateCondition();
 		assertEnabledOnCurrentOsIf(onAix());
+	}
+
+	/**
+	 * @see EnabledOnOsIntegrationTests#dragonflybsd()
+	 */
+	@Test
+	void dragonflybsd() {
+		evaluateCondition();
+		assertEnabledOnCurrentOsIf(onDragonflybsd());
 	}
 
 	/**
@@ -162,8 +172,8 @@ class EnabledOnOsConditionTests extends AbstractExecutionConditionTests {
 	@Test
 	void other() {
 		evaluateCondition();
-		assertEnabledOnCurrentOsIf(!(onAix() || onFreebsd() || onLinux() || onMac() || onNetbsd() || onOpenbsd()
-				|| onSolaris() || onWindows()));
+		assertEnabledOnCurrentOsIf(!(onAix() || onDragonflybsd() || onFreebsd() || onLinux() || onMac() || onNetbsd()
+				|| onOpenbsd() || onSolaris() || onWindows()));
 		assertCustomDisabledReasonIs("Disabled on almost every OS");
 	}
 

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/condition/EnabledOnOsIntegrationTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/condition/EnabledOnOsIntegrationTests.java
@@ -13,6 +13,7 @@ package org.junit.jupiter.api.condition;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.condition.OS.AIX;
+import static org.junit.jupiter.api.condition.OS.DRAGONFLYBSD;
 import static org.junit.jupiter.api.condition.OS.FREEBSD;
 import static org.junit.jupiter.api.condition.OS.LINUX;
 import static org.junit.jupiter.api.condition.OS.MAC;
@@ -53,7 +54,7 @@ class EnabledOnOsIntegrationTests {
 	}
 
 	@Test
-	@EnabledOnOs({ AIX, FREEBSD, LINUX, MAC, NETBSD, OPENBSD, WINDOWS, SOLARIS, OTHER })
+	@EnabledOnOs({ AIX, DRAGONFLYBSD, FREEBSD, LINUX, MAC, NETBSD, OPENBSD, WINDOWS, SOLARIS, OTHER })
 	void enabledOnEveryOs() {
 	}
 
@@ -61,6 +62,12 @@ class EnabledOnOsIntegrationTests {
 	@EnabledOnOs(AIX)
 	void aix() {
 		assertTrue(onAix());
+	}
+
+	@Test
+	@EnabledOnOs(DRAGONFLYBSD)
+	void dragonflybsd() {
+		assertTrue(onDragonflybsd());
 	}
 
 	@Test
@@ -114,8 +121,8 @@ class EnabledOnOsIntegrationTests {
 	@Test
 	@EnabledOnOs(value = OTHER, disabledReason = "Disabled on almost every OS")
 	void other() {
-		assertFalse(
-			onAix() || onFreebsd() || onLinux() || onMac() || onNetbsd() || onOpenbsd() || onSolaris() || onWindows());
+		assertFalse(onAix() || onDragonflybsd() || onFreebsd() || onLinux() || onMac() || onNetbsd() || onOpenbsd()
+				|| onSolaris() || onWindows());
 	}
 
 	@Test
@@ -174,6 +181,10 @@ class EnabledOnOsIntegrationTests {
 
 	static boolean onAix() {
 		return OS_NAME.contains("aix");
+	}
+
+	static boolean onDragonflybsd() {
+		return OS_NAME.contains("dragonflybsd");
 	}
 
 	static boolean onArchitecture(String arch) {

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/condition/EnabledOnOsIntegrationTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/condition/EnabledOnOsIntegrationTests.java
@@ -16,6 +16,7 @@ import static org.junit.jupiter.api.condition.OS.AIX;
 import static org.junit.jupiter.api.condition.OS.FREEBSD;
 import static org.junit.jupiter.api.condition.OS.LINUX;
 import static org.junit.jupiter.api.condition.OS.MAC;
+import static org.junit.jupiter.api.condition.OS.NETBSD;
 import static org.junit.jupiter.api.condition.OS.OPENBSD;
 import static org.junit.jupiter.api.condition.OS.OTHER;
 import static org.junit.jupiter.api.condition.OS.SOLARIS;
@@ -52,7 +53,7 @@ class EnabledOnOsIntegrationTests {
 	}
 
 	@Test
-	@EnabledOnOs({ AIX, FREEBSD, LINUX, MAC, OPENBSD, WINDOWS, SOLARIS, OTHER })
+	@EnabledOnOs({ AIX, FREEBSD, LINUX, MAC, NETBSD, OPENBSD, WINDOWS, SOLARIS, OTHER })
 	void enabledOnEveryOs() {
 	}
 
@@ -93,6 +94,12 @@ class EnabledOnOsIntegrationTests {
 	}
 
 	@Test
+	@EnabledOnOs(NETBSD)
+	void netbsd() {
+		assertTrue(onNetbsd());
+	}
+
+	@Test
 	@EnabledOnOs(WINDOWS)
 	void windows() {
 		assertTrue(onWindows());
@@ -107,7 +114,8 @@ class EnabledOnOsIntegrationTests {
 	@Test
 	@EnabledOnOs(value = OTHER, disabledReason = "Disabled on almost every OS")
 	void other() {
-		assertFalse(onAix() || onFreebsd() || onLinux() || onMac() || onOpenbsd() || onSolaris() || onWindows());
+		assertFalse(
+			onAix() || onFreebsd() || onLinux() || onMac() || onNetbsd() || onOpenbsd() || onSolaris() || onWindows());
 	}
 
 	@Test
@@ -182,6 +190,10 @@ class EnabledOnOsIntegrationTests {
 
 	static boolean onMac() {
 		return OS_NAME.contains("mac");
+	}
+
+	static boolean onNetbsd() {
+		return OS_NAME.contains("netbsd");
 	}
 
 	static boolean onOpenbsd() {

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/condition/OSTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/condition/OSTests.java
@@ -42,6 +42,12 @@ class OSTests {
 		}
 
 		@ParameterizedTest
+		@ValueSource(strings = { "DRAGONFLYBSD", "DragonFlyBSD" })
+		void dragonflybsd(String name) {
+			assertEquals(OS.DRAGONFLYBSD, OS.parse(name));
+		}
+
+		@ParameterizedTest
 		@ValueSource(strings = { "FREEBSD", "FreeBSD" })
 		void freebsd(String name) {
 			assertEquals(OS.FREEBSD, OS.parse(name));

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/condition/OSTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/condition/OSTests.java
@@ -66,6 +66,12 @@ class OSTests {
 		}
 
 		@ParameterizedTest
+		@ValueSource(strings = { "NETBSD", "NetBSD" })
+		void netbsd(String name) {
+			assertEquals(OS.NETBSD, OS.parse(name));
+		}
+
+		@ParameterizedTest
 		@ValueSource(strings = { "SOLARIS", "SunOS" })
 		void solaris(String name) {
 			assertEquals(OS.SOLARIS, OS.parse(name));


### PR DESCRIPTION
## Overview

My cross-platform project supports NetBSD and DragonFly BSD and I'd like to be able to use the annotations rather than conditionals. I followed the same format used for FreeBSD and OpenBSD in #2821.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

### Definition of Done
- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit-framework#continuous-integration-builds) pass