### PR TITLE
Reproduce System properties not restored after ParameterizedTest

### DIFF
--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/util/SystemPropertiesExtensionTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/util/SystemPropertiesExtensionTests.java
@@ -44,6 +44,8 @@ import org.junit.jupiter.api.extension.ExtensionConfigurationException;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.engine.AbstractJupiterTestEngineTests;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.junit.platform.testkit.engine.EngineExecutionResults;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoSettings;
@@ -64,13 +66,25 @@ class SystemPropertiesExtensionTests extends AbstractJupiterTestEngineTests {
 
 	@AfterAll
 	static void globalTearDown() {
+		// First check if all properties have been restored to their original values
+		assertThat(System.getProperty("A")).isEqualTo("old A");
+		assertThat(System.getProperty("B")).isEqualTo("old B");
+		assertThat(System.getProperty("C")).isEqualTo("old C");
+		assertThat(System.getProperty("clear envvar D")).isNull();
+		assertThat(System.getProperty("clear envvar E")).isNull();
+		assertThat(System.getProperty("clear envvar F")).isNull();
+
+		// Cleanup
 		System.clearProperty("A");
 		System.clearProperty("B");
 		System.clearProperty("C");
 
-		assertThat(System.getProperty("clear prop D")).isNull();
-		assertThat(System.getProperty("clear prop E")).isNull();
-		assertThat(System.getProperty("clear prop F")).isNull();
+		assertThat(System.getProperty("A")).isNull();
+		assertThat(System.getProperty("B")).isNull();
+		assertThat(System.getProperty("C")).isNull();
+		assertThat(System.getProperty("clear envvar D")).isNull();
+		assertThat(System.getProperty("clear envvar E")).isNull();
+		assertThat(System.getProperty("clear envvar F")).isNull();
 	}
 
 	@Nested
@@ -674,6 +688,90 @@ class SystemPropertiesExtensionTests extends AbstractJupiterTestEngineTests {
 				assertThat(System.getProperty("RestoreAll")).isNull(); // Should be restored
 			}
 
+		}
+
+	}
+
+	@Nested
+	@DisplayName("properties are restored after ParameterizedTest")
+	class RestoreAfterParameterizedTest {
+
+		// This reproduces the system properties not being reset when set as part of a ParameterizedTest.
+		// These test all set only their 'own' system property and check ALL system properties.
+		// This will show in the test output which of the properties was not reset and thus give a clear
+		// indication which test actually did not work correctly.
+		// So the effect is that the BAD test does not fail, all the tests that are run AFTER this BAD test will fail.
+		// How many depends on the (random) order the tests are executed in. In any case the finish check will fail.
+
+		private static final String PROP_NORMAL_TEST = "Normal Test PROP Variable";
+		private static final String PROP_PARAM_TEST = "ParameterizedTest PROP Variable";
+		private static final String PROP_PARAM_WITH_RESTORE_TEST = "ParameterizedTest With Restore PROP Variable";
+		private static final String PROP_ORIG_VALUE = "Original Value";
+		private static final String PROP_CHANGED_VALUE = "Changed Value";
+
+		// For these tests we need very explicit reporting about which variable is incorrect.
+		private static void assertSystemProperty(String propName, String propValue) {
+			assertThat(System.getProperty(propName)).as(
+				"System property \"" + propName + "\" should be \"" + propValue + "\".").isEqualTo(propValue);
+		}
+
+		private static void assertSystemPropertyIsNull(String propName) {
+			assertThat(System.getProperty(propName)).as(
+				"System property \"" + propName + "\" should be NULL.").isNull();
+		}
+
+		@BeforeAll
+		public static void setup() {
+			System.setProperty(PROP_NORMAL_TEST, PROP_ORIG_VALUE);
+			System.setProperty(PROP_PARAM_TEST, PROP_ORIG_VALUE);
+			System.setProperty(PROP_PARAM_WITH_RESTORE_TEST, PROP_ORIG_VALUE);
+			assertSystemProperty(PROP_NORMAL_TEST, PROP_ORIG_VALUE);
+			assertSystemProperty(PROP_PARAM_TEST, PROP_ORIG_VALUE);
+			assertSystemProperty(PROP_PARAM_WITH_RESTORE_TEST, PROP_ORIG_VALUE);
+		}
+
+		@AfterAll
+		public static void finish() {
+			assertSystemProperty(PROP_NORMAL_TEST, PROP_ORIG_VALUE);
+			assertSystemProperty(PROP_PARAM_TEST, PROP_ORIG_VALUE);
+			assertSystemProperty(PROP_PARAM_WITH_RESTORE_TEST, PROP_ORIG_VALUE);
+
+			System.clearProperty(PROP_NORMAL_TEST);
+			System.clearProperty(PROP_PARAM_TEST);
+			System.clearProperty(PROP_PARAM_WITH_RESTORE_TEST);
+
+			assertSystemPropertyIsNull(PROP_NORMAL_TEST);
+			assertSystemPropertyIsNull(PROP_PARAM_TEST);
+			assertSystemPropertyIsNull(PROP_PARAM_WITH_RESTORE_TEST);
+		}
+
+		@Test
+		@SetSystemProperty(key = PROP_NORMAL_TEST, value = PROP_CHANGED_VALUE)
+		void testNormal() {
+			assertSystemProperty(PROP_NORMAL_TEST, PROP_CHANGED_VALUE);
+			assertSystemProperty(PROP_PARAM_TEST, PROP_ORIG_VALUE);
+			assertSystemProperty(PROP_PARAM_WITH_RESTORE_TEST, PROP_ORIG_VALUE);
+		}
+
+		@ParameterizedTest(name = "ParameterizedTest WITHOUT RestoreSystemProperties ({0})")
+		@ValueSource(ints = { 1 })
+		@SetSystemProperty(key = PROP_PARAM_TEST, value = PROP_CHANGED_VALUE)
+		void testParamWithoutRestore(int dummy) {
+			assertThat(dummy).isEqualTo(1);
+			assertSystemProperty(PROP_NORMAL_TEST, PROP_ORIG_VALUE);
+			assertSystemProperty(PROP_PARAM_TEST, PROP_CHANGED_VALUE);
+			assertSystemProperty(PROP_PARAM_WITH_RESTORE_TEST, PROP_ORIG_VALUE);
+		}
+
+		@ParameterizedTest(name = "ParameterizedTest WITH RestoreSystemProperties ({0})")
+		@ValueSource(ints = { 1 })
+		@SetSystemProperty(key = PROP_PARAM_WITH_RESTORE_TEST, value = PROP_CHANGED_VALUE)
+		@RestoreSystemProperties
+		void testParamWithRestore(int dummy) {
+			assertThat(dummy).isEqualTo(1);
+			assertSystemProperty(PROP_NORMAL_TEST, PROP_ORIG_VALUE);
+			assertSystemProperty(PROP_PARAM_TEST, PROP_ORIG_VALUE);
+			assertSystemProperty(PROP_PARAM_WITH_RESTORE_TEST, PROP_CHANGED_VALUE);
 		}
 
 	}


### PR DESCRIPTION
This is just a few tests to reproduce https://github.com/junit-team/junit-framework/issues/5717

Because this does not yet fix the issue this currently will always fail the build.


---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://docs.junit.org/snapshot/) and [Release Notes](https://docs.junit.org/snapshot/release-notes.html)
