### PR TITLE
Allow system properties abstraction

### DIFF
--- a/documentation/antora.yml
+++ b/documentation/antora.yml
@@ -175,6 +175,7 @@ asciidoc:
     RestoreSystemProperties: '{javadoc-root}/org.junit.jupiter.api/org/junit/jupiter/api/util/RestoreSystemProperties.html[@RestoreSystemProperties]'
     ReadsSystemProperty: '{javadoc-root}/org.junit.jupiter.api/org/junit/jupiter/api/util/ReadsSystemProperty.html[@ReadsSystemProperty]'
     WritesSystemProperty: '{javadoc-root}/org.junit.jupiter.api/org/junit/jupiter/api/util/WritesSystemProperty.html[@WritesSystemProperty]'
+    AbstractSystemPropertiesExtension: '{javadoc-root}/org.junit.jupiter.api/org/junit/jupiter/api/util/AbstractSystemPropertiesExtension.html[@AbstractSystemPropertiesExtension]'
     # Jupiter Parallel API
     Execution: '{javadoc-root}/org.junit.jupiter.api/org/junit/jupiter/api/parallel/Execution.html[@Execution]'
     Isolated: '{javadoc-root}/org.junit.jupiter.api/org/junit/jupiter/api/parallel/Isolated.html[@Isolated]'

--- a/documentation/modules/ROOT/pages/writing-tests/built-in-extensions.adoc
+++ b/documentation/modules/ROOT/pages/writing-tests/built-in-extensions.adoc
@@ -905,3 +905,16 @@ need to be annotated with the respective annotation:
 
 Tests annotated in this way will never execute in parallel with tests annotated with
 `@ClearSystemProperty`, `@SetSystemProperty`, or `@RestoreSystemProperties`.
+
+
+[[system-properties-extensibility]]
+=== System Property extensibility
+
+If you want to have customized annotations, that will for example limit keys to some enum values, you can use
+{AbstractSystemPropertiesExtension} as a base of your extension. With this abstraction you need to provide 3 class types:
+
+ - annotation used to set system property
+ - annotation used to clear system property
+ - annotation used to restore system properties.
+
+Annotations provided by those functions should be annotated with {WritesSystemProperty}.

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/util/AbstractSystemPropertiesExtension.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/util/AbstractSystemPropertiesExtension.java
@@ -1,0 +1,344 @@
+/*
+ * Copyright 2015-2026 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.api.util;
+
+import static java.util.stream.Collectors.toSet;
+import static org.junit.platform.commons.support.AnnotationSupport.findRepeatableAnnotations;
+import static org.junit.platform.commons.support.AnnotationSupport.isAnnotated;
+import static org.junit.platform.commons.util.CollectionUtils.forEachInReverseOrder;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedElement;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.apiguardian.api.API;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionConfigurationException;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * Abstract {@code Extension} which provides support for system properties-related annotations:
+ *
+ * <ul>
+ * <li>SET - annotation used to set system property, e.g. {@link SetSystemProperty @SetSystemProperty}</li>
+ * <li>CLEAR - annotation used to clear system property, e.g. {@link ClearSystemProperty @ClearSystemProperty}</li>
+ * <li>RESTORE - annotation used to restore all system properties, e.g. {@link RestoreSystemProperties @RestoreSystemProperties}</li>
+ * </ul>
+ *
+ * @since 6.2
+ */
+@API(since = "6.2", status = API.Status.EXPERIMENTAL)
+public abstract class AbstractSystemPropertiesExtension<SET extends Annotation, CLEAR extends Annotation, RESTORE extends Annotation>
+		implements BeforeEachCallback, AfterEachCallback, BeforeAllCallback, AfterAllCallback {
+
+	/**
+	 * Defines the annotation used to set a system property.
+	 * @since 6.2
+	 */
+	abstract Class<SET> setPropertyAnnotation();
+
+	/**
+	 * Defines the annotation used to restore system properties.
+	 * @since 6.2
+	 */
+	abstract Class<RESTORE> restoreAnnotation();
+
+	/**
+	 * Defines the annotation used to clear a system property.
+	 * @since 6.2
+	 */
+	abstract Class<CLEAR> clearAnnotation();
+
+	/**
+	 * Gets the system property name from {@link SET} annotation.
+	 * @since 6.2
+	 */
+	abstract String setAnnotationKey(SET annotation);
+
+	/**
+	 * Gets the system property value from {@link SET} annotation.
+	 * @since 6.2
+	 */
+	abstract String setAnnotationValue(SET annotation);
+
+	/**
+	 * Gets the system property name from {@link CLEAR} annotation.
+	 * @since 6.2
+	 */
+	abstract String clearAnnotationKey(CLEAR annotation);
+
+	protected AbstractSystemPropertiesExtension() {
+		// no-op
+	}
+
+	/**
+	 * Prepare for entering a context that must be restorable.
+	 *
+	 * <p>The context is prepared by pre-emptively swapping out the current
+	 * System properties with a snapshot. The original system properties are
+	 * restored after the test.
+	 *
+	 * @return the original {@link System#getProperties} object
+	 */
+	Properties prepareToEnterRestorableContext(ExtensionContext context) {
+		var current = System.getProperties();
+		var clone = JupiterPropertyUtils.cloneWithoutDefaults(context, current);
+		System.setProperties(clone);
+		return current;
+	}
+
+	/**
+	 * Prepare to exit a restorable context.
+	 *
+	 * <p>The entry environment will be restored to the state passed in as {@code Properties}.
+	 *
+	 * @param properties a non-null {@code Properties} that contains all entries
+	 * of the entry environment
+	 */
+	void prepareToExitRestorableContext(Properties properties) {
+		System.setProperties(properties);
+	}
+
+	@Override
+	public void beforeAll(ExtensionContext context) {
+		applyForAllContexts(context);
+	}
+
+	@Override
+	public void beforeEach(ExtensionContext context) {
+		applyForAllContexts(context);
+	}
+
+	private void applyForAllContexts(ExtensionContext originalContext) {
+		var allContexts = findAllExtensionContexts(originalContext);
+
+		var restoreAnnotationContext = findFirstRestoreAnnotationContext(allContexts);
+		restoreAnnotationContext.ifPresent(annotatedElementContext -> {
+			var properties = this.prepareToEnterRestorableContext(annotatedElementContext);
+			storeCompleteBackup(originalContext, properties);
+		});
+
+		// we have to apply the annotations from the outermost to the innermost context.
+		forEachInReverseOrder(allContexts,
+			currentContext -> clearAndSetEntries(currentContext, originalContext, restoreAnnotationContext.isEmpty()));
+	}
+
+	private Optional<ExtensionContext> findFirstRestoreAnnotationContext(List<ExtensionContext> contexts) {
+		return contexts.stream() //
+				.filter(context -> isAnnotated(context.getElement(), restoreAnnotation())) //
+				.findFirst();
+	}
+
+	private void clearAndSetEntries(ExtensionContext currentContext, ExtensionContext originalContext,
+			boolean doIncrementalBackup) {
+
+		currentContext.getElement().ifPresent(element -> {
+			var entriesToClear = findEntriesToClear(element);
+			var entriesToSet = findEntriesToSet(element);
+			preventClearAndSetSameEntries(element, entriesToClear, entriesToSet.keySet());
+
+			if (entriesToClear.isEmpty() && entriesToSet.isEmpty()) {
+				return;
+			}
+
+			// Only backup original values if we didn't already do bulk storage of the original state
+			if (doIncrementalBackup) {
+				storeIncrementalBackup(originalContext, entriesToClear, entriesToSet.keySet());
+			}
+
+			// For consistency don't use Properties::setProperty or System.setProperty here
+			var properties = System.getProperties();
+			entriesToClear.forEach(properties::remove);
+			properties.putAll(entriesToSet);
+		});
+	}
+
+	private Set<String> findEntriesToClear(AnnotatedElement element) {
+		return findRepeatableAnnotations(element, clearAnnotation()).stream() //
+				.map(this::clearAnnotationKey) //
+				// already distinct due to findRepeatableAnnotations
+				.collect(toSet());
+	}
+
+	private Map<String, String> findEntriesToSet(AnnotatedElement element) {
+		var entries = new HashMap<String, String>();
+		var duplicatePropertyNames = new HashSet<String>();
+
+		findRepeatableAnnotations(element, setPropertyAnnotation()) //
+				.forEach(annotation -> {
+					var key = setAnnotationKey(annotation);
+					if (entries.put(key, setAnnotationValue(annotation)) != null) {
+						duplicatePropertyNames.add(key);
+					}
+				});
+
+		requireUniqueEntries(element, duplicatePropertyNames);
+		return entries;
+	}
+
+	private void preventClearAndSetSameEntries(AnnotatedElement element, Set<String> entriesToClear,
+			Set<String> entriesToSet) {
+		requireUniqueEntries(element, //
+			entriesToClear.stream() //
+					.filter(entriesToSet::contains) //
+					.collect(toSet()));
+	}
+
+	private static void requireUniqueEntries(AnnotatedElement annotatedElement, Set<String> duplicatePropertNames) {
+		if (duplicatePropertNames.isEmpty()) {
+			return;
+		}
+		throw new ExtensionConfigurationException(
+			"SystemPropertyExtension was configured to set/clear %s [%s] more than once by [%s]." //
+					.formatted( //
+						duplicatePropertNames.size() == 1 ? "property" : "properties", //
+						String.join(", ", duplicatePropertNames), //
+						annotatedElement //
+					));
+	}
+
+	private void storeIncrementalBackup(ExtensionContext context, Collection<String> entriesToClear,
+			Collection<String> entriesToSet) {
+		var backup = new EntriesBackup(entriesToClear, entriesToSet);
+		getStore(context).put(getStoreKey(context, BackupType.INCREMENTAL), backup);
+	}
+
+	private void storeCompleteBackup(ExtensionContext context, Properties backup) {
+		getStore(context).put(getStoreKey(context, BackupType.COMPLETE), backup);
+	}
+
+	/**
+	 * Restore the complete original state of the entries as they were prior to
+	 * this {@code ExtensionContext}, if the complete state was initially stored
+	 * in a before all/each event.
+	 *
+	 * @param context the {@code ExtensionContext} which may have a bulk backup stored
+	 * @return true if a complete backup exists and was used to restore, false if not
+	 */
+	private boolean restoreOriginalCompleteBackup(ExtensionContext context) {
+		var backup = getCompleteBackup(context);
+		if (backup != null) {
+			prepareToExitRestorableContext(backup);
+			return true;
+		}
+		// No complete backup - false will let the caller know to continue w/ an incremental restore
+		return false;
+	}
+
+	private @Nullable Properties getCompleteBackup(ExtensionContext context) {
+		var key = getStoreKey(context, BackupType.COMPLETE);
+		return getStore(context).get(key, Properties.class);
+	}
+
+	@Override
+	public void afterEach(ExtensionContext context) {
+		restoreForAllContexts(context);
+	}
+
+	@Override
+	public void afterAll(ExtensionContext context) {
+		restoreForAllContexts(context);
+	}
+
+	private void restoreForAllContexts(ExtensionContext originalContext) {
+		// Try a complete restore first
+		if (!restoreOriginalCompleteBackup(originalContext)) {
+			// A complete backup is not available, so restore incrementally from innermost to outermost
+			findAllExtensionContexts(originalContext).forEach(__ -> restoreOriginalIncrementalBackup(originalContext));
+		}
+	}
+
+	private void restoreOriginalIncrementalBackup(ExtensionContext originalContext) {
+		var backup = getIncrementalBackup(originalContext);
+		if (backup != null) {
+			backup.restoreBackup();
+		}
+	}
+
+	private static List<ExtensionContext> findAllExtensionContexts(ExtensionContext context) {
+		var contexts = new ArrayList<ExtensionContext>();
+		do {
+			contexts.add(context);
+			context = context.getParent().orElse(null);
+		} while (context != null);
+		return contexts;
+	}
+
+	private @Nullable EntriesBackup getIncrementalBackup(ExtensionContext originalContext) {
+		var key = getStoreKey(originalContext, BackupType.INCREMENTAL);
+		return getStore(originalContext).get(key, EntriesBackup.class);
+	}
+
+	private ExtensionContext.Store getStore(ExtensionContext context) {
+		return context.getStore(ExtensionContext.Namespace.create(getClass()));
+	}
+
+	private StoreKey getStoreKey(ExtensionContext context, BackupType type) {
+		return new StoreKey(context.getUniqueId(), type);
+	}
+
+	private record StoreKey(String uniqueId, BackupType type) {
+	}
+
+	private enum BackupType {
+		/**
+		 * Store entry is for an incremental backup object.
+		 */
+		INCREMENTAL,
+		/**
+		 * Store entry is for a complete backup object.
+		 */
+		COMPLETE
+	}
+
+	private static final class EntriesBackup {
+
+		private final Set<String> entriesToClear = new HashSet<>();
+		private final Map<String, Object> entriesToSet = new HashMap<>();
+
+		EntriesBackup(Collection<String> entriesToClear, Collection<String> entriesToSet) {
+			var properties = System.getProperties();
+			Stream.concat(entriesToClear.stream(), entriesToSet.stream()).forEach(entry -> {
+				// Do not use Properties::getProperty or System.getProperty here, since
+				// this would prevent backing up non-string values.
+				Object backup = properties.get(entry);
+				if (backup == null) {
+					this.entriesToClear.add(entry);
+				}
+				else {
+					this.entriesToSet.put(entry, backup);
+				}
+			});
+		}
+
+		void restoreBackup() {
+			// We can't use Properties::setProperty or System.setProperty here, since
+			// this would prevent restoring non-string values.
+			var properties = System.getProperties();
+			entriesToClear.forEach(properties::remove);
+			properties.putAll(entriesToSet);
+		}
+	}
+
+}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/util/AbstractSystemPropertiesExtension.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/util/AbstractSystemPropertiesExtension.java
@@ -56,37 +56,37 @@ public abstract class AbstractSystemPropertiesExtension<SET extends Annotation, 
 	 * Defines the annotation used to set a system property.
 	 * @since 6.2
 	 */
-	abstract Class<SET> setPropertyAnnotation();
+	protected abstract Class<SET> setPropertyAnnotation();
 
 	/**
 	 * Defines the annotation used to restore system properties.
 	 * @since 6.2
 	 */
-	abstract Class<RESTORE> restoreAnnotation();
+	protected abstract Class<RESTORE> restoreAnnotation();
 
 	/**
 	 * Defines the annotation used to clear a system property.
 	 * @since 6.2
 	 */
-	abstract Class<CLEAR> clearAnnotation();
+	protected abstract Class<CLEAR> clearAnnotation();
 
 	/**
 	 * Gets the system property name from {@link SET} annotation.
 	 * @since 6.2
 	 */
-	abstract String setAnnotationKey(SET annotation);
+	protected abstract String setAnnotationKey(SET annotation);
 
 	/**
 	 * Gets the system property value from {@link SET} annotation.
 	 * @since 6.2
 	 */
-	abstract String setAnnotationValue(SET annotation);
+	protected abstract String setAnnotationValue(SET annotation);
 
 	/**
 	 * Gets the system property name from {@link CLEAR} annotation.
 	 * @since 6.2
 	 */
-	abstract String clearAnnotationKey(CLEAR annotation);
+	protected abstract String clearAnnotationKey(CLEAR annotation);
 
 	protected AbstractSystemPropertiesExtension() {
 		// no-op

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/util/SystemPropertiesExtension.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/util/SystemPropertiesExtension.java
@@ -40,17 +40,17 @@ final class SystemPropertiesExtension
 	}
 
 	@Override
-	String setAnnotationKey(SetSystemProperty annotation) {
+	protected String setAnnotationKey(SetSystemProperty annotation) {
 		return annotation.key();
 	}
 
 	@Override
-	String setAnnotationValue(SetSystemProperty annotation) {
+	protected String setAnnotationValue(SetSystemProperty annotation) {
 		return annotation.value();
 	}
 
 	@Override
-	String clearAnnotationKey(ClearSystemProperty annotation) {
+	protected String clearAnnotationKey(ClearSystemProperty annotation) {
 		return annotation.key();
 	}
 

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/util/SystemPropertiesExtension.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/util/SystemPropertiesExtension.java
@@ -10,31 +10,6 @@
 
 package org.junit.jupiter.api.util;
 
-import static java.util.stream.Collectors.toSet;
-import static org.junit.platform.commons.support.AnnotationSupport.findRepeatableAnnotations;
-import static org.junit.platform.commons.support.AnnotationSupport.isAnnotated;
-import static org.junit.platform.commons.util.CollectionUtils.forEachInReverseOrder;
-
-import java.lang.reflect.AnnotatedElement;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Properties;
-import java.util.Set;
-import java.util.stream.Stream;
-
-import org.jspecify.annotations.Nullable;
-import org.junit.jupiter.api.extension.AfterAllCallback;
-import org.junit.jupiter.api.extension.AfterEachCallback;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
-import org.junit.jupiter.api.extension.BeforeEachCallback;
-import org.junit.jupiter.api.extension.ExtensionConfigurationException;
-import org.junit.jupiter.api.extension.ExtensionContext;
-
 /**
  * {@code Extension} which provides support for the following annotations.
  *
@@ -47,255 +22,36 @@ import org.junit.jupiter.api.extension.ExtensionContext;
  * @since 6.1
  */
 final class SystemPropertiesExtension
-		implements BeforeEachCallback, AfterEachCallback, BeforeAllCallback, AfterAllCallback {
+		extends AbstractSystemPropertiesExtension<SetSystemProperty, ClearSystemProperty, RestoreSystemProperties> {
 
-	/**
-	 * Prepare for entering a context that must be restorable.
-	 *
-	 * <p>The context is prepared by pre-emptively swapping out the current
-	 * System properties with a snapshot. The original system properties are
-	 * restored after the test.
-	 *
-	 * @return the original {@link System#getProperties} object
-	 */
-	Properties prepareToEnterRestorableContext(ExtensionContext context) {
-		var current = System.getProperties();
-		var clone = JupiterPropertyUtils.cloneWithoutDefaults(context, current);
-		System.setProperties(clone);
-		return current;
-	}
-
-	/**
-	 * Prepare to exit a restorable context.
-	 *
-	 * <p>The entry environment will be restored to the state passed in as {@code Properties}.
-	 *
-	 * @param properties a non-null {@code Properties} that contains all entries
-	 * of the entry environment
-	 */
-	void prepareToExitRestorableContext(Properties properties) {
-		System.setProperties(properties);
+	@Override
+	protected Class<SetSystemProperty> setPropertyAnnotation() {
+		return SetSystemProperty.class;
 	}
 
 	@Override
-	public void beforeAll(ExtensionContext context) {
-		applyForAllContexts(context);
+	protected Class<RestoreSystemProperties> restoreAnnotation() {
+		return RestoreSystemProperties.class;
 	}
 
 	@Override
-	public void beforeEach(ExtensionContext context) {
-		applyForAllContexts(context);
-	}
-
-	private void applyForAllContexts(ExtensionContext originalContext) {
-		var allContexts = findAllExtensionContexts(originalContext);
-
-		var restoreAnnotationContext = findFirstRestoreAnnotationContext(allContexts);
-		restoreAnnotationContext.ifPresent(annotatedElementContext -> {
-			var properties = this.prepareToEnterRestorableContext(annotatedElementContext);
-			storeCompleteBackup(originalContext, properties);
-		});
-
-		// we have to apply the annotations from the outermost to the innermost context.
-		forEachInReverseOrder(allContexts,
-			currentContext -> clearAndSetEntries(currentContext, originalContext, restoreAnnotationContext.isEmpty()));
-	}
-
-	private Optional<ExtensionContext> findFirstRestoreAnnotationContext(List<ExtensionContext> contexts) {
-		return contexts.stream() //
-				.filter(context -> isAnnotated(context.getElement(), RestoreSystemProperties.class)) //
-				.findFirst();
-	}
-
-	private void clearAndSetEntries(ExtensionContext currentContext, ExtensionContext originalContext,
-			boolean doIncrementalBackup) {
-
-		currentContext.getElement().ifPresent(element -> {
-			var entriesToClear = findEntriesToClear(element);
-			var entriesToSet = findEntriesToSet(element);
-			preventClearAndSetSameEntries(element, entriesToClear, entriesToSet.keySet());
-
-			if (entriesToClear.isEmpty() && entriesToSet.isEmpty()) {
-				return;
-			}
-
-			// Only backup original values if we didn't already do bulk storage of the original state
-			if (doIncrementalBackup) {
-				storeIncrementalBackup(originalContext, entriesToClear, entriesToSet.keySet());
-			}
-
-			// For consistency don't use Properties::setProperty or System.setProperty here
-			var properties = System.getProperties();
-			entriesToClear.forEach(properties::remove);
-			properties.putAll(entriesToSet);
-		});
-	}
-
-	private Set<String> findEntriesToClear(AnnotatedElement element) {
-		return findRepeatableAnnotations(element, ClearSystemProperty.class).stream() //
-				.map(ClearSystemProperty::key) //
-				// already distinct due to findRepeatableAnnotations
-				.collect(toSet());
-	}
-
-	private Map<String, String> findEntriesToSet(AnnotatedElement element) {
-		var entries = new HashMap<String, String>();
-		var duplicatePropertyNames = new HashSet<String>();
-
-		findRepeatableAnnotations(element, SetSystemProperty.class) //
-				.forEach(annotation -> {
-					var key = annotation.key();
-					if (entries.put(key, annotation.value()) != null) {
-						duplicatePropertyNames.add(key);
-					}
-				});
-
-		requireUniqueEntries(element, duplicatePropertyNames);
-		return entries;
-	}
-
-	private void preventClearAndSetSameEntries(AnnotatedElement element, Set<String> entriesToClear,
-			Set<String> entriesToSet) {
-		requireUniqueEntries(element, //
-			entriesToClear.stream() //
-					.filter(entriesToSet::contains) //
-					.collect(toSet()));
-	}
-
-	private static void requireUniqueEntries(AnnotatedElement annotatedElement, Set<String> duplicatePropertNames) {
-		if (duplicatePropertNames.isEmpty()) {
-			return;
-		}
-		throw new ExtensionConfigurationException(
-			"SystemPropertyExtension was configured to set/clear %s [%s] more than once by [%s]." //
-					.formatted( //
-						duplicatePropertNames.size() == 1 ? "property" : "properties", //
-						String.join(", ", duplicatePropertNames), //
-						annotatedElement //
-					));
-	}
-
-	private void storeIncrementalBackup(ExtensionContext context, Collection<String> entriesToClear,
-			Collection<String> entriesToSet) {
-		var backup = new EntriesBackup(entriesToClear, entriesToSet);
-		getStore(context).put(getStoreKey(context, BackupType.INCREMENTAL), backup);
-	}
-
-	private void storeCompleteBackup(ExtensionContext context, Properties backup) {
-		getStore(context).put(getStoreKey(context, BackupType.COMPLETE), backup);
-	}
-
-	/**
-	 * Restore the complete original state of the entries as they were prior to
-	 * this {@code ExtensionContext}, if the complete state was initially stored
-	 * in a before all/each event.
-	 *
-	 * @param context the {@code ExtensionContext} which may have a bulk backup stored
-	 * @return true if a complete backup exists and was used to restore, false if not
-	 */
-	private boolean restoreOriginalCompleteBackup(ExtensionContext context) {
-		var backup = getCompleteBackup(context);
-		if (backup != null) {
-			prepareToExitRestorableContext(backup);
-			return true;
-		}
-		// No complete backup - false will let the caller know to continue w/ an incremental restore
-		return false;
-	}
-
-	private @Nullable Properties getCompleteBackup(ExtensionContext context) {
-		var key = getStoreKey(context, BackupType.COMPLETE);
-		return getStore(context).get(key, Properties.class);
+	protected Class<ClearSystemProperty> clearAnnotation() {
+		return ClearSystemProperty.class;
 	}
 
 	@Override
-	public void afterEach(ExtensionContext context) {
-		restoreForAllContexts(context);
+	String setAnnotationKey(SetSystemProperty annotation) {
+		return annotation.key();
 	}
 
 	@Override
-	public void afterAll(ExtensionContext context) {
-		restoreForAllContexts(context);
+	String setAnnotationValue(SetSystemProperty annotation) {
+		return annotation.value();
 	}
 
-	private void restoreForAllContexts(ExtensionContext originalContext) {
-		// Try a complete restore first
-		if (!restoreOriginalCompleteBackup(originalContext)) {
-			// A complete backup is not available, so restore incrementally from innermost to outermost
-			findAllExtensionContexts(originalContext).forEach(__ -> restoreOriginalIncrementalBackup(originalContext));
-		}
-	}
-
-	private void restoreOriginalIncrementalBackup(ExtensionContext originalContext) {
-		var backup = getIncrementalBackup(originalContext);
-		if (backup != null) {
-			backup.restoreBackup();
-		}
-	}
-
-	private static List<ExtensionContext> findAllExtensionContexts(ExtensionContext context) {
-		var contexts = new ArrayList<ExtensionContext>();
-		do {
-			contexts.add(context);
-			context = context.getParent().orElse(null);
-		} while (context != null);
-		return contexts;
-	}
-
-	private @Nullable EntriesBackup getIncrementalBackup(ExtensionContext originalContext) {
-		var key = getStoreKey(originalContext, BackupType.INCREMENTAL);
-		return getStore(originalContext).get(key, EntriesBackup.class);
-	}
-
-	private ExtensionContext.Store getStore(ExtensionContext context) {
-		return context.getStore(ExtensionContext.Namespace.create(getClass()));
-	}
-
-	private StoreKey getStoreKey(ExtensionContext context, BackupType type) {
-		return new StoreKey(context.getUniqueId(), type);
-	}
-
-	private record StoreKey(String uniqueId, BackupType type) {
-	}
-
-	private enum BackupType {
-		/**
-		 * Store entry is for an incremental backup object.
-		 */
-		INCREMENTAL,
-		/**
-		 * Store entry is for a complete backup object.
-		 */
-		COMPLETE
-	}
-
-	private static final class EntriesBackup {
-
-		private final Set<String> entriesToClear = new HashSet<>();
-		private final Map<String, Object> entriesToSet = new HashMap<>();
-
-		EntriesBackup(Collection<String> entriesToClear, Collection<String> entriesToSet) {
-			var properties = System.getProperties();
-			Stream.concat(entriesToClear.stream(), entriesToSet.stream()).forEach(entry -> {
-				// Do not use Properties::getProperty or System.getProperty here, since
-				// this would prevent backing up non-string values.
-				Object backup = properties.get(entry);
-				if (backup == null) {
-					this.entriesToClear.add(entry);
-				}
-				else {
-					this.entriesToSet.put(entry, backup);
-				}
-			});
-		}
-
-		void restoreBackup() {
-			// We can't use Properties::setProperty or System.setProperty here, since
-			// this would prevent restoring non-string values.
-			var properties = System.getProperties();
-			entriesToClear.forEach(properties::remove);
-			properties.putAll(entriesToSet);
-		}
+	@Override
+	String clearAnnotationKey(ClearSystemProperty annotation) {
+		return annotation.key();
 	}
 
 }

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/util/SystemPropertiesExtensionViaCustomAnnotationTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/util/SystemPropertiesExtensionViaCustomAnnotationTests.java
@@ -1,0 +1,780 @@
+/*
+ * Copyright 2015-2026 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.api.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
+import static org.junit.jupiter.api.util.SystemPropertiesExtensionViaCustomAnnotationTests.Property.A;
+import static org.junit.jupiter.api.util.SystemPropertiesExtensionViaCustomAnnotationTests.Property.B;
+import static org.junit.jupiter.api.util.SystemPropertiesExtensionViaCustomAnnotationTests.Property.C;
+import static org.junit.jupiter.api.util.SystemPropertiesExtensionViaCustomAnnotationTests.Property.D;
+import static org.junit.jupiter.api.util.SystemPropertiesExtensionViaCustomAnnotationTests.Property.E;
+import static org.junit.jupiter.api.util.SystemPropertiesExtensionViaCustomAnnotationTests.Property.F;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectMethod;
+import static org.junit.platform.testkit.engine.EventConditions.event;
+import static org.junit.platform.testkit.engine.EventConditions.finishedSuccessfully;
+import static org.junit.platform.testkit.engine.EventConditions.finishedWithFailure;
+import static org.junit.platform.testkit.engine.EventConditions.test;
+import static org.junit.platform.testkit.engine.TestExecutionResultConditions.instanceOf;
+import static org.junit.platform.testkit.engine.TestExecutionResultConditions.message;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.Properties;
+
+import org.jspecify.annotations.NonNull;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.ClassOrderer;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestClassOrder;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionConfigurationException;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.engine.AbstractJupiterTestEngineTests;
+import org.junit.platform.testkit.engine.EngineExecutionResults;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoSettings;
+
+@DisplayName("Customized System Properties Extension")
+@SuppressWarnings("ClassEscapesDefinedScope")
+class SystemPropertiesExtensionViaCustomAnnotationTests extends AbstractJupiterTestEngineTests {
+
+	enum Property {
+		A, B, C, D, E, F
+	}
+	@Retention(RetentionPolicy.RUNTIME)
+	@Target({ ElementType.METHOD, ElementType.TYPE })
+	@Inherited
+	@Repeatable(SetProp.SetProps.class)
+	@WritesSystemProperty
+	@ExtendWith(CustomSystemPropertiesExtension.class)
+	@interface SetProp {
+		Property key();
+
+		String value();
+		@Retention(RetentionPolicy.RUNTIME)
+		@Target({ ElementType.METHOD, ElementType.TYPE })
+		@Inherited
+		@WritesSystemProperty
+		@interface SetProps {
+			SetProp[] value();
+		}
+	}
+	@Retention(RetentionPolicy.RUNTIME)
+	@Target({ ElementType.METHOD, ElementType.TYPE })
+	@Inherited
+	@Repeatable(ClearProp.ClearProps.class)
+	@WritesSystemProperty
+	@ExtendWith(CustomSystemPropertiesExtension.class)
+	@interface ClearProp {
+		Property key();
+
+		@Retention(RetentionPolicy.RUNTIME)
+		@Target({ ElementType.METHOD, ElementType.TYPE })
+		@Inherited
+		@WritesSystemProperty
+		@interface ClearProps {
+			ClearProp[] value();
+		}
+	}
+	final static class CustomSystemPropertiesExtension
+			extends AbstractSystemPropertiesExtension<SetProp, ClearProp, RestoreSystemProperties> {
+
+		protected @NonNull Class<SetProp> setPropertyAnnotation() {
+			return SetProp.class;
+		}
+
+		protected @NonNull Class<RestoreSystemProperties> restoreAnnotation() {
+			return RestoreSystemProperties.class;
+		}
+
+		protected @NonNull Class<ClearProp> clearAnnotation() {
+			return ClearProp.class;
+		}
+
+		@Override
+		@NonNull
+		String setAnnotationKey(SetProp annotation) {
+			return annotation.key().name();
+		}
+
+		@Override
+		@NonNull
+		String setAnnotationValue(SetProp annotation) {
+			return annotation.value();
+		}
+
+		@Override
+		@NonNull
+		String clearAnnotationKey(ClearProp annotation) {
+			return annotation.key().name();
+		}
+
+	}
+
+	@BeforeAll
+	static void globalSetUp() {
+		System.setProperty(A.name(), "old A");
+		System.setProperty(B.name(), "old B");
+		System.setProperty(C.name(), "old C");
+
+		System.clearProperty(D.name());
+		System.clearProperty(E.name());
+		System.clearProperty(F.name());
+	}
+
+	@AfterAll
+	static void globalTearDown() {
+		System.clearProperty(A.name());
+		System.clearProperty(B.name());
+		System.clearProperty(C.name());
+
+		assertThat(System.getProperty("clear prop D")).isNull();
+		assertThat(System.getProperty(E.name())).isNull();
+		assertThat(System.getProperty(F.name())).isNull();
+	}
+
+	@Nested
+	@DisplayName("with @ClearProp")
+	@ClearProp(key = A)
+	class ClearPropTests {
+
+		@Test
+		@DisplayName("should clear system property")
+		@ClearProp(key = B)
+		void shouldClearProp() {
+			assertThat(System.getProperty(A.name())).isNull();
+			assertThat(System.getProperty(B.name())).isNull();
+			assertThat(System.getProperty(C.name())).isEqualTo("old C");
+
+			assertThat(System.getProperty("clear prop D")).isNull();
+			assertThat(System.getProperty(E.name())).isNull();
+			assertThat(System.getProperty(F.name())).isNull();
+		}
+
+		@Test
+		@DisplayName("should be repeatable")
+		@ClearProp(key = B)
+		@ClearProp(key = C)
+		void shouldBeRepeatable() {
+			assertThat(System.getProperty(A.name())).isNull();
+			assertThat(System.getProperty(B.name())).isNull();
+			assertThat(System.getProperty(C.name())).isNull();
+
+			assertThat(System.getProperty(D.name())).isNull();
+			assertThat(System.getProperty(E.name())).isNull();
+			assertThat(System.getProperty(F.name())).isNull();
+		}
+
+	}
+
+	@Nested
+	@DisplayName("with @SetProp")
+	@SetProp(key = A, value = "new A")
+	class SetPropTests {
+
+		@Test
+		@DisplayName("should set system property to value")
+		@SetProp(key = B, value = "new B")
+		void shouldSetPropToValue() {
+			assertThat(System.getProperty(A.name())).isEqualTo("new A");
+			assertThat(System.getProperty(B.name())).isEqualTo("new B");
+			assertThat(System.getProperty(C.name())).isEqualTo("old C");
+
+			assertThat(System.getProperty("clear prop D")).isNull();
+			assertThat(System.getProperty(E.name())).isNull();
+			assertThat(System.getProperty(F.name())).isNull();
+		}
+
+		@Test
+		@DisplayName("should be repeatable")
+		@SetProp(key = B, value = "new B")
+		@SetProp(key = D, value = "new D")
+		void shouldBeRepeatable() {
+			assertThat(System.getProperty(A.name())).isEqualTo("new A");
+			assertThat(System.getProperty(B.name())).isEqualTo("new B");
+			assertThat(System.getProperty(C.name())).isEqualTo("old C");
+
+			assertThat(System.getProperty("clear prop D")).isEqualTo("new D");
+			assertThat(System.getProperty(E.name())).isNull();
+			assertThat(System.getProperty(F.name())).isNull();
+		}
+
+	}
+
+	@Nested
+	@DisplayName("with both @ClearProp and @SetProp")
+	@ClearProp(key = A)
+	@SetProp(key = D, value = "new D")
+	class CombinedClearAndSetTests {
+
+		@Test
+		@DisplayName("should be combinable")
+		@ClearProp(key = B)
+		@SetProp(key = E, value = "new E")
+		void clearAndSetPropShouldBeCombinable() {
+			assertThat(System.getProperty(A.name())).isNull();
+			assertThat(System.getProperty(B.name())).isNull();
+			assertThat(System.getProperty(C.name())).isEqualTo("old C");
+
+			assertThat(System.getProperty("clear prop D")).isEqualTo("new D");
+			assertThat(System.getProperty(E.name())).isEqualTo("new E");
+			assertThat(System.getProperty(F.name())).isNull();
+		}
+
+		@Test
+		@DisplayName("method level should overwrite class level")
+		@ClearProp(key = D)
+		@SetProp(key = A, value = "new A")
+		void methodLevelShouldOverwriteClassLevel() {
+			assertThat(System.getProperty(A.name())).isEqualTo("new A");
+			assertThat(System.getProperty(B.name())).isEqualTo("old B");
+			assertThat(System.getProperty(C.name())).isEqualTo("old C");
+
+			assertThat(System.getProperty("clear prop D")).isNull();
+			assertThat(System.getProperty(E.name())).isNull();
+			assertThat(System.getProperty(F.name())).isNull();
+		}
+
+		@Test
+		@DisplayName("method level should not clash (in terms of duplicate entries) with class level")
+		@SetProp(key = A, value = "new A")
+		void methodLevelShouldNotClashWithClassLevel() {
+			assertThat(System.getProperty(A.name())).isEqualTo("new A");
+			assertThat(System.getProperty(B.name())).isEqualTo("old B");
+			assertThat(System.getProperty(C.name())).isEqualTo("old C");
+			assertThat(System.getProperty("clear prop D")).isEqualTo("new D");
+
+			assertThat(System.getProperty(E.name())).isNull();
+			assertThat(System.getProperty(F.name())).isNull();
+		}
+
+	}
+
+	@Nested
+	@DisplayName("with Set, Clear, and Restore")
+	@WritesSystemProperty // Many of these tests write, many also access
+	@Execution(SAME_THREAD) // Uses instance state
+	@TestInstance(TestInstance.Lifecycle.PER_CLASS) // Uses instance state
+	@TestClassOrder(ClassOrderer.OrderAnnotation.class)
+	class CombinedClearSetRestoreTests {
+
+		Properties initialState; // Stateful
+
+		@BeforeAll
+		void beforeAll() {
+			initialState = System.getProperties();
+		}
+
+		@Nested
+		@Order(1)
+		@DisplayName("Set, Clear & Restore on class")
+		@ClearProp(key = A)
+		@SetProp(key = D, value = "new D")
+		@RestoreSystemProperties
+		@TestMethodOrder(OrderAnnotation.class)
+		@TestInstance(TestInstance.Lifecycle.PER_CLASS) // Uses instance state
+		class SetClearRestoreOnClass {
+
+			@AfterAll
+			void afterAll() {
+				System.setProperties(new Properties()); // Really blow it up after this class
+			}
+
+			@Test
+			@Order(1)
+			@DisplayName("Set, Clear on method w/ direct set Sys Prop")
+			@ClearProp(key = B)
+			@SetProp(key = E, value = "new E")
+			void clearSetRestoreShouldBeCombinable() {
+				assertThat(System.getProperties()).withFailMessage(
+					"Restore should swap out the Sys Properties instance").isNotSameAs(initialState);
+
+				// Direct modification - shouldn't be visible in next test
+				System.setProperty("Restore", "Restore Me");
+				System.getProperties().put("XYZ", this);
+
+				assertThat(System.getProperty("Restore")).isEqualTo("Restore Me");
+				assertThat(System.getProperties().get("XYZ")).isSameAs(this);
+
+				// All the others
+				assertThat(System.getProperty(A.name())).isNull();
+				assertThat(System.getProperty(B.name())).isNull();
+				assertThat(System.getProperty(C.name())).isEqualTo("old C");
+
+				assertThat(System.getProperty("clear prop D")).isEqualTo("new D");
+				assertThat(System.getProperty(E.name())).isEqualTo("new E");
+				assertThat(System.getProperty(F.name())).isNull();
+			}
+
+			@Test
+			@DisplayName("Restore from class should restore direct mods")
+			@Order(2)
+			void restoreShouldHaveRevertedDirectModification() {
+				assertThat(System.getProperty("Restore")).isNull();
+				assertThat(System.getProperties().get("XYZ")).isNull();
+			}
+
+		}
+
+		@Nested
+		@Order(2)
+		@DisplayName("Prior nested class changes should be restored}")
+		class priorNestedChangesRestored {
+
+			@Test
+			@DisplayName("Restore from class should restore direct mods")
+			void restoreShouldHaveRevertedDirectModification() {
+				assertThat(System.getProperties()).isSameAs(initialState);
+			}
+
+		}
+
+		@Nested
+		@Order(3)
+		@DisplayName("Set & Clear on class, Restore on method")
+		@ClearProp(key = A)
+		@SetProp(key = D, value = "new D")
+		@TestMethodOrder(OrderAnnotation.class)
+		@TestInstance(TestInstance.Lifecycle.PER_CLASS) // Uses instance state
+		class SetAndClearOnClass {
+
+			Properties initialState; // Stateful
+
+			@BeforeAll
+			void beforeAll() {
+				initialState = System.getProperties();
+			}
+
+			@Test
+			@Order(1)
+			@DisplayName("Set, Clear & Restore on method w/ direct set Sys Prop")
+			@ClearProp(key = B)
+			@SetProp(key = E, value = "new E")
+			@RestoreSystemProperties
+			void clearSetRestoreShouldBeCombinable() {
+				assertThat(System.getProperties()).withFailMessage(
+					"Restore should swap out the Sys Properties instance").isNotSameAs(initialState);
+
+				// Direct modification - shouldn't be visible in the next test
+				System.setProperty("Restore", "Restore Me");
+				System.getProperties().put("XYZ", this);
+
+				// All the others
+				assertThat(System.getProperty(A.name())).isNull();
+				assertThat(System.getProperty(B.name())).isNull();
+				assertThat(System.getProperty(C.name())).isEqualTo("old C");
+
+				assertThat(System.getProperty("clear prop D")).isEqualTo("new D");
+				assertThat(System.getProperty(E.name())).isEqualTo("new E");
+				assertThat(System.getProperty(F.name())).isNull();
+			}
+
+			@Test
+			@DisplayName("Restore from prior method should restore direct mods")
+			@Order(2)
+			void restoreShouldHaveRevertedDirectModification() {
+				assertThat(System.getProperty("Restore")).isNull();
+				assertThat(System.getProperties().get("XYZ")).isNull();
+				assertThat(System.getProperties()).isSameAs(initialState);
+			}
+
+		}
+
+	}
+
+	@Nested
+	@DisplayName("@RestoreSystemProperties individual methods tests")
+	@WritesSystemProperty // Many of these tests write, many also access
+	class RestoreSystemPropertiesUnitTests {
+
+		SystemPropertiesExtension spe;
+
+		@BeforeEach
+		void beforeEach() {
+			spe = new SystemPropertiesExtension();
+		}
+
+		@Nested
+		@DisplayName("Attributes of RestoreSystemProperties Annotation")
+		class BasicAttributesOfRestoreSystemProperties {
+
+			@Test
+			@DisplayName("Restore annotation has correct markers")
+			void restoreHasCorrectMarkers() {
+				assertThat(RestoreSystemProperties.class).hasAnnotations(Inherited.class, WritesSystemProperty.class);
+			}
+
+			@Test
+			@DisplayName("Restore annotation has correct retention")
+			void restoreHasCorrectRetention() {
+				assertThat(RestoreSystemProperties.class.getAnnotation(Retention.class).value()).isEqualTo(
+					RetentionPolicy.RUNTIME);
+			}
+
+			@Test
+			@DisplayName("Restore annotation has correct targets")
+			void restoreHasCorrectTargets() {
+				assertThat(RestoreSystemProperties.class.getAnnotation(Target.class).value()).containsExactlyInAnyOrder(
+					ElementType.METHOD, ElementType.TYPE);
+			}
+
+		}
+
+		@Nested
+		@DisplayName("RestorableContext Workflow Tests")
+		@MockitoSettings
+		class RestorableContextWorkflowTests {
+
+			@Mock
+			ExtensionContext context;
+
+			@Test
+			@DisplayName("Workflow of RestorableContext")
+			void workflowOfRestorableContexts() {
+				Properties initialState = System.getProperties(); //This is a live reference
+
+				try {
+					Properties returnedFromPrepareToEnter = spe.prepareToEnterRestorableContext(context);
+					Properties postPrepareToEnterSysProps = System.getProperties();
+					spe.prepareToExitRestorableContext(initialState);
+					Properties postPrepareToExitSysProps = System.getProperties();
+
+					assertThat(returnedFromPrepareToEnter) //
+							.withFailMessage(
+								"prepareToEnterRestorableContext should return actual original or deep copy") //
+							.isSameAs(initialState);
+
+					assertThat(returnedFromPrepareToEnter) //
+							.withFailMessage("prepareToEnterRestorableContext should replace the actual Sys Props") //
+							.isNotSameAs(postPrepareToEnterSysProps);
+
+					assertThat(postPrepareToEnterSysProps).isEqualTo(initialState);
+
+					assertThat(postPrepareToExitSysProps).isSameAs(initialState);
+
+				}
+				finally {
+					System.setProperties(initialState); // Ensure complete recovery
+				}
+			}
+
+		}
+
+	}
+
+	@Nested
+	@DisplayName("with nested classes")
+	@ClearProp(key = A)
+	@SetProp(key = B, value = "new B")
+	class NestedSystemPropertyTests {
+
+		@Nested
+		@TestMethodOrder(OrderAnnotation.class)
+		@DisplayName("without SystemProperty annotations")
+		class NestedClass {
+
+			@Test
+			@Order(1)
+			@ReadsSystemProperty
+			@DisplayName("system properties should be set from enclosed class when they are not provided in nested")
+			void shouldSetPropFromEnclosedClass() {
+				assertThat(System.getProperty(A.name())).isNull();
+				assertThat(System.getProperty(B.name())).isEqualTo("new B");
+			}
+
+			@Test
+			@Order(2)
+			@ReadsSystemProperty
+			@DisplayName("system properties should be set from enclosed class after restore")
+			void shouldSetPropFromEnclosedClassAfterRestore() {
+				assertThat(System.getProperty(A.name())).isNull();
+				assertThat(System.getProperty(B.name())).isEqualTo("new B");
+			}
+
+		}
+
+		@Nested
+		@SetProp(key = B, value = "newer B")
+		@DisplayName("with @SetProp annotation")
+		class AnnotatedNestedClass {
+
+			@Test
+			@ReadsSystemProperty
+			@DisplayName("system property should be set from nested class when it is provided")
+			void shouldSetPropFromNestedClass() {
+				assertThat(System.getProperty(B.name())).isEqualTo("newer B");
+			}
+
+			@Test
+			@SetProp(key = B, value = "newest B")
+			@DisplayName("system property should be set from method when it is provided")
+			void shouldSetPropFromMethodOfNestedClass() {
+				assertThat(System.getProperty(B.name())).isEqualTo("newest B");
+			}
+
+		}
+
+	}
+
+	@Nested
+	@SetProp(key = A, value = "new A")
+	@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+	class ResettingSystemPropertyTests {
+
+		@Nested
+		@SetProp(key = A, value = "newer A")
+		@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+		class ResettingSystemPropertyAfterEachNestedTests {
+
+			@BeforeEach
+			void changeShouldBeVisible() {
+				// We already see "newest A" because BeforeEachCallBack is invoked before @BeforeEach
+				// See https://junit.org/junit5/docs/current/user-guide/#extensions-execution-order-overview
+				assertThat(System.getProperty(A.name())).isEqualTo("newest A");
+			}
+
+			@Test
+			@SetProp(key = A, value = "newest A")
+			void setForTestMethod() {
+				assertThat(System.getProperty(A.name())).isEqualTo("newest A");
+			}
+
+			@AfterEach
+			@ReadsSystemProperty
+			void resetAfterTestMethodExecution() {
+				// We still see "newest A" because AfterEachCallBack is invoked after @AfterEach
+				// See https://junit.org/junit5/docs/current/user-guide/#extensions-execution-order-overview
+				assertThat(System.getProperty(A.name())).isEqualTo("newest A");
+			}
+
+		}
+
+		@Nested
+		@SetProp(key = A, value = "newer A")
+		@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+		class ResettingSystemPropertyAfterAllNestedTests {
+
+			@BeforeAll
+			void changeShouldBeVisible() {
+				assertThat(System.getProperty(A.name())).isEqualTo("newer A");
+			}
+
+			@Test
+			@SetProp(key = A, value = "newest A")
+			void setForTestMethod() {
+				assertThat(System.getProperty(A.name())).isEqualTo("newest A");
+			}
+
+			@AfterAll
+			@ReadsSystemProperty
+			void resetAfterTestMethodExecution() {
+				assertThat(System.getProperty(A.name())).isEqualTo("newer A");
+			}
+
+		}
+
+		@AfterAll
+		@ReadsSystemProperty
+		void resetAfterTestContainerExecution() {
+			assertThat(System.getProperty(A.name())).isEqualTo("new A");
+		}
+
+	}
+
+	@Nested
+	@DisplayName("with incorrect configuration")
+	class ConfigurationFailureTests {
+
+		@Test
+		@DisplayName("should fail when clear and set same system property")
+		void shouldFailWhenClearAndSetSameSystemProperty() {
+			EngineExecutionResults results = executeTests(selectMethod(MethodLevelInitializationFailureTestCases.class,
+				"shouldFailWhenClearAndSetSameSystemProperty"));
+			results.testEvents().assertThatEvents().haveAtMost(1,
+				finishedWithFailure(instanceOf(ExtensionConfigurationException.class),
+					message(it -> it.contains("@DefaultTimeZone not configured correctly."))));
+		}
+
+		@Test
+		@DisplayName("should not fail when clear same system property twice")
+		void shouldNotFailWhenClearSameSystemPropertyTwice() {
+			EngineExecutionResults results = executeTests(selectMethod(MethodLevelInitializationFailureTestCases.class,
+				"shouldFailWhenClearSameSystemPropertyTwice"));
+
+			results.testEvents().assertThatEvents().haveExactly(1, event(test(), finishedSuccessfully()));
+		}
+
+		@Test
+		@DisplayName("should fail when set same system property twice")
+		void shouldFailWhenSetSameSystemPropertyTwice() {
+			EngineExecutionResults results = executeTests(selectMethod(MethodLevelInitializationFailureTestCases.class,
+				"shouldFailWhenSetSameSystemPropertyTwice"));
+			results.testEvents().assertThatEvents().haveAtMost(1,
+				finishedWithFailure(instanceOf(ExtensionConfigurationException.class)));
+		}
+
+	}
+
+	static class MethodLevelInitializationFailureTestCases {
+
+		@Test
+		@DisplayName("clearing and setting the same property")
+		@ClearProp(key = A)
+		@SetProp(key = A, value = "new A")
+		void shouldFailWhenClearAndSetSameSystemProperty() {
+		}
+
+		@Test
+		@ClearProp(key = A)
+		@ClearProp(key = A)
+		void shouldFailWhenClearSameSystemPropertyTwice() {
+		}
+
+		@Test
+		@SetProp(key = A, value = "new A")
+		@SetProp(key = A, value = "new B")
+		void shouldFailWhenSetSameSystemPropertyTwice() {
+		}
+
+	}
+
+	@Nested
+	@DisplayName("Clear and Set with inheritance")
+	class InheritanceClearAndSetTests extends InheritanceClearAndSetBaseTest {
+
+		@Test
+		@DisplayName("should inherit clear and set annotations")
+		void shouldInheritClearAndSetProperty() {
+			assertThat(System.getProperty(A.name())).isNull();
+			assertThat(System.getProperty(B.name())).isNull();
+			assertThat(System.getProperty("clear prop D")).isEqualTo("new D");
+			assertThat(System.getProperty(E.name())).isEqualTo("new E");
+		}
+
+	}
+
+	@Nested
+	@DisplayName("Clear, Set, and Restore with inheritance")
+	@TestMethodOrder(OrderAnnotation.class)
+	@TestClassOrder(ClassOrderer.OrderAnnotation.class)
+	@Execution(SAME_THREAD) // Uses instance state
+	@TestInstance(TestInstance.Lifecycle.PER_CLASS) // Uses instance state
+	class InheritanceClearSetRestoreTests extends InheritanceClearSetRestoreBaseTest {
+
+		Properties initialState; // Stateful
+
+		@BeforeAll
+		void beforeAll() {
+			initialState = System.getProperties();
+		}
+
+		@Test
+		@Order(1)
+		@DisplayName("should inherit clear and set annotations")
+		void shouldInheritClearSetRestore() {
+			// Direct modification - shouldn't be visible in the next test
+			System.setProperty("Restore", "Restore Me");
+			System.getProperties().put("XYZ", this);
+
+			assertThat(System.getProperty(A.name())).isNull(); // The rest are checked elsewhere
+		}
+
+		@Test
+		@Order(2)
+		@DisplayName("Restore from class should restore direct mods")
+		void restoreShouldHaveRevertedDirectModification() {
+			assertThat(System.getProperty("Restore")).isNull();
+			assertThat(System.getProperties().get("XYZ")).isNull();
+			assertThat(System.getProperties()) //
+					.withFailMessage("Restore should swap out the Sys Properties instance") //
+					.isNotSameAs(initialState);
+			assertThat(System.getProperties()).isEqualTo(initialState);
+		}
+
+		@Nested
+		@Order(1)
+		@DisplayName("Set props to ensure inherited restore")
+		@TestMethodOrder(OrderAnnotation.class)
+		@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+		class SetSomeValuesToRestore {
+
+			@AfterAll
+			void afterAll() {
+				System.setProperty("RestoreAll", "Restore Me"); // This should also be restored
+			}
+
+			@Test
+			@Order(1)
+			@DisplayName("Inherit values and restore behavior")
+			void shouldInheritInNestedClass() {
+				assertThat(System.getProperty(A.name())).isNull();
+
+				// Shouldn't be visible in the next test
+				System.setProperty("Restore", "Restore Me");
+			}
+
+			@Test
+			@Order(2)
+			@DisplayName("Verify restore behavior bt methods")
+			void verifyRestoreBetweenMethods() {
+				assertThat(System.getProperty("Restore")).isNull();
+			}
+
+		}
+
+		@Nested
+		@Order(2)
+		@DisplayName("Verify props are restored")
+		@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+		class VerifyValuesAreRestored {
+
+			@Test
+			@DisplayName("Inherit values and restore behavior")
+			void shouldInheritInNestedClass() {
+				assertThat(System.getProperty("RestoreAll")).isNull(); // Should be restored
+			}
+
+		}
+
+	}
+
+	@ClearProp(key = A)
+	@ClearProp(key = B)
+	@SetProp(key = D, value = "new D")
+	@SetProp(key = E, value = "new E")
+	static class InheritanceClearAndSetBaseTest {
+
+	}
+
+	@ClearProp(key = A)
+	@ClearProp(key = B)
+	@SetProp(key = D, value = "new D")
+	@SetProp(key = E, value = "new E")
+	@RestoreSystemProperties
+	static class InheritanceClearSetRestoreBaseTest {
+	}
+
+}

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/util/SystemPropertiesExtensionViaCustomAnnotationTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/util/SystemPropertiesExtensionViaCustomAnnotationTests.java
@@ -12,12 +12,12 @@ package org.junit.jupiter.api.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
-import static org.junit.jupiter.api.util.SystemPropertiesExtensionViaCustomAnnotationTests.Property.A;
-import static org.junit.jupiter.api.util.SystemPropertiesExtensionViaCustomAnnotationTests.Property.B;
-import static org.junit.jupiter.api.util.SystemPropertiesExtensionViaCustomAnnotationTests.Property.C;
-import static org.junit.jupiter.api.util.SystemPropertiesExtensionViaCustomAnnotationTests.Property.D;
-import static org.junit.jupiter.api.util.SystemPropertiesExtensionViaCustomAnnotationTests.Property.E;
-import static org.junit.jupiter.api.util.SystemPropertiesExtensionViaCustomAnnotationTests.Property.F;
+import static org.junit.jupiter.api.util.testannotations.Property.A;
+import static org.junit.jupiter.api.util.testannotations.Property.B;
+import static org.junit.jupiter.api.util.testannotations.Property.C;
+import static org.junit.jupiter.api.util.testannotations.Property.D;
+import static org.junit.jupiter.api.util.testannotations.Property.E;
+import static org.junit.jupiter.api.util.testannotations.Property.F;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectMethod;
 import static org.junit.platform.testkit.engine.EventConditions.event;
 import static org.junit.platform.testkit.engine.EventConditions.finishedSuccessfully;
@@ -28,13 +28,11 @@ import static org.junit.platform.testkit.engine.TestExecutionResultConditions.me
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;
-import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.util.Properties;
 
-import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -48,91 +46,18 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestClassOrder;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestMethodOrder;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionConfigurationException;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.util.testannotations.ClearProp;
+import org.junit.jupiter.api.util.testannotations.SetProp;
 import org.junit.jupiter.engine.AbstractJupiterTestEngineTests;
 import org.junit.platform.testkit.engine.EngineExecutionResults;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoSettings;
 
 @DisplayName("Customized System Properties Extension")
-@SuppressWarnings("ClassEscapesDefinedScope")
 class SystemPropertiesExtensionViaCustomAnnotationTests extends AbstractJupiterTestEngineTests {
-
-	enum Property {
-		A, B, C, D, E, F
-	}
-	@Retention(RetentionPolicy.RUNTIME)
-	@Target({ ElementType.METHOD, ElementType.TYPE })
-	@Inherited
-	@Repeatable(SetProp.SetProps.class)
-	@WritesSystemProperty
-	@ExtendWith(CustomSystemPropertiesExtension.class)
-	@interface SetProp {
-		Property key();
-
-		String value();
-		@Retention(RetentionPolicy.RUNTIME)
-		@Target({ ElementType.METHOD, ElementType.TYPE })
-		@Inherited
-		@WritesSystemProperty
-		@interface SetProps {
-			SetProp[] value();
-		}
-	}
-	@Retention(RetentionPolicy.RUNTIME)
-	@Target({ ElementType.METHOD, ElementType.TYPE })
-	@Inherited
-	@Repeatable(ClearProp.ClearProps.class)
-	@WritesSystemProperty
-	@ExtendWith(CustomSystemPropertiesExtension.class)
-	@interface ClearProp {
-		Property key();
-
-		@Retention(RetentionPolicy.RUNTIME)
-		@Target({ ElementType.METHOD, ElementType.TYPE })
-		@Inherited
-		@WritesSystemProperty
-		@interface ClearProps {
-			ClearProp[] value();
-		}
-	}
-	final static class CustomSystemPropertiesExtension
-			extends AbstractSystemPropertiesExtension<SetProp, ClearProp, RestoreSystemProperties> {
-
-		protected @NonNull Class<SetProp> setPropertyAnnotation() {
-			return SetProp.class;
-		}
-
-		protected @NonNull Class<RestoreSystemProperties> restoreAnnotation() {
-			return RestoreSystemProperties.class;
-		}
-
-		protected @NonNull Class<ClearProp> clearAnnotation() {
-			return ClearProp.class;
-		}
-
-		@Override
-		@NonNull
-		String setAnnotationKey(SetProp annotation) {
-			return annotation.key().name();
-		}
-
-		@Override
-		@NonNull
-		String setAnnotationValue(SetProp annotation) {
-			return annotation.value();
-		}
-
-		@Override
-		@NonNull
-		String clearAnnotationKey(ClearProp annotation) {
-			return annotation.key().name();
-		}
-
-	}
 
 	@BeforeAll
 	static void globalSetUp() {
@@ -217,7 +142,7 @@ class SystemPropertiesExtensionViaCustomAnnotationTests extends AbstractJupiterT
 			assertThat(System.getProperty(B.name())).isEqualTo("new B");
 			assertThat(System.getProperty(C.name())).isEqualTo("old C");
 
-			assertThat(System.getProperty("clear prop D")).isEqualTo("new D");
+			assertThat(System.getProperty(D.name())).isEqualTo("new D");
 			assertThat(System.getProperty(E.name())).isNull();
 			assertThat(System.getProperty(F.name())).isNull();
 		}
@@ -239,7 +164,7 @@ class SystemPropertiesExtensionViaCustomAnnotationTests extends AbstractJupiterT
 			assertThat(System.getProperty(B.name())).isNull();
 			assertThat(System.getProperty(C.name())).isEqualTo("old C");
 
-			assertThat(System.getProperty("clear prop D")).isEqualTo("new D");
+			assertThat(System.getProperty(D.name())).isEqualTo("new D");
 			assertThat(System.getProperty(E.name())).isEqualTo("new E");
 			assertThat(System.getProperty(F.name())).isNull();
 		}
@@ -265,7 +190,7 @@ class SystemPropertiesExtensionViaCustomAnnotationTests extends AbstractJupiterT
 			assertThat(System.getProperty(A.name())).isEqualTo("new A");
 			assertThat(System.getProperty(B.name())).isEqualTo("old B");
 			assertThat(System.getProperty(C.name())).isEqualTo("old C");
-			assertThat(System.getProperty("clear prop D")).isEqualTo("new D");
+			assertThat(System.getProperty(D.name())).isEqualTo("new D");
 
 			assertThat(System.getProperty(E.name())).isNull();
 			assertThat(System.getProperty(F.name())).isNull();
@@ -324,7 +249,7 @@ class SystemPropertiesExtensionViaCustomAnnotationTests extends AbstractJupiterT
 				assertThat(System.getProperty(B.name())).isNull();
 				assertThat(System.getProperty(C.name())).isEqualTo("old C");
 
-				assertThat(System.getProperty("clear prop D")).isEqualTo("new D");
+				assertThat(System.getProperty(D.name())).isEqualTo("new D");
 				assertThat(System.getProperty(E.name())).isEqualTo("new E");
 				assertThat(System.getProperty(F.name())).isNull();
 			}
@@ -387,7 +312,7 @@ class SystemPropertiesExtensionViaCustomAnnotationTests extends AbstractJupiterT
 				assertThat(System.getProperty(B.name())).isNull();
 				assertThat(System.getProperty(C.name())).isEqualTo("old C");
 
-				assertThat(System.getProperty("clear prop D")).isEqualTo("new D");
+				assertThat(System.getProperty(D.name())).isEqualTo("new D");
 				assertThat(System.getProperty(E.name())).isEqualTo("new E");
 				assertThat(System.getProperty(F.name())).isNull();
 			}
@@ -670,7 +595,7 @@ class SystemPropertiesExtensionViaCustomAnnotationTests extends AbstractJupiterT
 		void shouldInheritClearAndSetProperty() {
 			assertThat(System.getProperty(A.name())).isNull();
 			assertThat(System.getProperty(B.name())).isNull();
-			assertThat(System.getProperty("clear prop D")).isEqualTo("new D");
+			assertThat(System.getProperty(D.name())).isEqualTo("new D");
 			assertThat(System.getProperty(E.name())).isEqualTo("new E");
 		}
 

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/util/testannotations/ClearProp.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/util/testannotations/ClearProp.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2015-2026 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package org.junit.jupiter.api.util.testannotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.util.WritesSystemProperty;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.METHOD, ElementType.TYPE })
+@Inherited
+@Repeatable(ClearProp.ClearProps.class)
+@WritesSystemProperty
+@ExtendWith(CustomSystemPropertiesExtension.class)
+public @interface ClearProp {
+	Property key();
+
+	@Retention(RetentionPolicy.RUNTIME)
+	@Target({ ElementType.METHOD, ElementType.TYPE })
+	@Inherited
+	@WritesSystemProperty
+	@interface ClearProps {
+		ClearProp[] value();
+	}
+}

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/util/testannotations/CustomSystemPropertiesExtension.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/util/testannotations/CustomSystemPropertiesExtension.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2015-2026 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package org.junit.jupiter.api.util.testannotations;
+
+import org.jspecify.annotations.NonNull;
+import org.junit.jupiter.api.util.AbstractSystemPropertiesExtension;
+import org.junit.jupiter.api.util.RestoreSystemProperties;
+
+public final class CustomSystemPropertiesExtension
+		extends AbstractSystemPropertiesExtension<SetProp, ClearProp, RestoreSystemProperties> {
+
+	public @NonNull Class<SetProp> setPropertyAnnotation() {
+		return SetProp.class;
+	}
+
+	public @NonNull Class<RestoreSystemProperties> restoreAnnotation() {
+		return RestoreSystemProperties.class;
+	}
+
+	public @NonNull Class<ClearProp> clearAnnotation() {
+		return ClearProp.class;
+	}
+
+	@Override
+	public @NonNull String setAnnotationKey(SetProp annotation) {
+		return annotation.key().name();
+	}
+
+	@Override
+	public @NonNull String setAnnotationValue(SetProp annotation) {
+		return annotation.value();
+	}
+
+	@Override
+	public @NonNull String clearAnnotationKey(ClearProp annotation) {
+		return annotation.key().name();
+	}
+
+}

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/util/testannotations/Property.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/util/testannotations/Property.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2015-2026 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package org.junit.jupiter.api.util.testannotations;
+
+public enum Property {
+	A, B, C, D, E, F
+}

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/util/testannotations/SetProp.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/util/testannotations/SetProp.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2015-2026 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package org.junit.jupiter.api.util.testannotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.util.WritesSystemProperty;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.METHOD, ElementType.TYPE })
+@Inherited
+@Repeatable(SetProp.SetProps.class)
+@WritesSystemProperty
+@ExtendWith(CustomSystemPropertiesExtension.class)
+public @interface SetProp {
+	Property key();
+
+	String value();
+
+	@Retention(RetentionPolicy.RUNTIME)
+	@Target({ ElementType.METHOD, ElementType.TYPE })
+	@Inherited
+	@WritesSystemProperty
+	@interface SetProps {
+		SetProp[] value();
+	}
+}


### PR DESCRIPTION
This PR allows building abstractions very similar to SystemPropertiesExtension.

The use case in my case is related to Hazelcast (#hazelcast/hazelcast), where we have our class wrapper for ClusterProperties - `ClusterProperty`. Cluster properties can be set via system properties.

It's common to see then patterns like `System.setProperty(SOME_PROPERTY.name(), "value")` in the code. We are now slowly migrating to JUnit 5 and it would be awesome if we could use `@SetSystemProperty` - however, Java does not allow us to call `.name()` method in annotation.

With this PR merged we will be able to make similar annotations like:
```java
@SetClusterProperty(LOGGING_TYPE, "log4j2")
```

Obviously it is possible to make such extensions right now, however it will duplicate existing extension - I'd even say, only changes will be other annotation names. I think there will be more places where libraries would like to have derivatives of the SetSystemProperty & Co. annotations.

Notes to reviewers:
- `AbstractSystemPropertiesExtension` is mostly a copy of old `SystemPropertiesExtension`
- new `SystemPropertiesExtension` implements `AbstractSystemPropertiesExtension` with current and standard set of annotations
- There is a test added `SystemPropertiesExtensionViaCustomAnnotationTests`, which is also mostly copied from `SystemPropertiesExtensionTests`, testing new abstraction and showing the usage.
- Please let me know if documentation added is enough. I didn't write too much as it's only a technical abstraction, that I think everybody will see quickly how it works, but I am not sure.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://docs.junit.org/snapshot/) and [Release Notes](https://docs.junit.org/snapshot/release-notes.html)
