### PR TITLE
Restore original SetSystemProperty values in a ParameterizedTest

### DIFF
--- a/documentation/modules/ROOT/partials/release-notes/release-notes-6.1.1.adoc
+++ b/documentation/modules/ROOT/partials/release-notes/release-notes-6.1.1.adoc
@@ -35,7 +35,7 @@ repository on GitHub.
 [[v6.1.1-junit-jupiter-bug-fixes]]
 ==== Bug Fixes
 
-* ❓
+* Restore original values set by `@SetSystemProperty` when used with a `@ParameterizedTest`.
 
 [[v6.1.1-junit-jupiter-deprecations-and-breaking-changes]]
 ==== Deprecations and Breaking Changes

--- a/documentation/modules/ROOT/partials/release-notes/release-notes-6.2.0-M1.adoc
+++ b/documentation/modules/ROOT/partials/release-notes/release-notes-6.2.0-M1.adoc
@@ -41,7 +41,7 @@ repository on GitHub.
 [[v6.2.0-M1-junit-jupiter-bug-fixes]]
 ==== Bug Fixes
 
-* Restore original values set by `@SetSystemProperty` when used with a `@ParameterizedTest`.
+* ❓
 
 [[v6.2.0-M1-junit-jupiter-deprecations-and-breaking-changes]]
 ==== Deprecations and Breaking Changes

--- a/documentation/modules/ROOT/partials/release-notes/release-notes-6.2.0-M1.adoc
+++ b/documentation/modules/ROOT/partials/release-notes/release-notes-6.2.0-M1.adoc
@@ -38,7 +38,7 @@ repository on GitHub.
 [[v6.2.0-M1-junit-jupiter-bug-fixes]]
 ==== Bug Fixes
 
-* ❓
+* Restore original values set by `@SetSystemProperty` when used with a `@ParameterizedTest`.
 
 [[v6.2.0-M1-junit-jupiter-deprecations-and-breaking-changes]]
 ==== Deprecations and Breaking Changes

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/util/SystemPropertiesExtension.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/util/SystemPropertiesExtension.java
@@ -108,10 +108,10 @@ final class SystemPropertiesExtension
 				.findFirst();
 	}
 
-	private void clearAndSetEntries(ExtensionContext originalContext, ExtensionContext incrementContext,
+	private void clearAndSetEntries(ExtensionContext originalContext, ExtensionContext currentContext,
 			boolean doIncrementalBackup) {
 
-		incrementContext.getElement().ifPresent(element -> {
+		currentContext.getElement().ifPresent(element -> {
 			var entriesToClear = findEntriesToClear(element);
 			var entriesToSet = findEntriesToSet(element);
 			preventClearAndSetSameEntries(element, entriesToClear, entriesToSet.keySet());
@@ -122,7 +122,7 @@ final class SystemPropertiesExtension
 
 			// Only backup original values if we didn't already do bulk storage of the original state
 			if (doIncrementalBackup) {
-				storeIncrementalBackup(originalContext, incrementContext, entriesToClear, entriesToSet.keySet());
+				storeIncrementalBackup(originalContext, currentContext, entriesToClear, entriesToSet.keySet());
 			}
 
 			// For consistency don't use Properties::setProperty or System.setProperty here

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/util/SystemPropertiesExtension.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/util/SystemPropertiesExtension.java
@@ -241,7 +241,7 @@ final class SystemPropertiesExtension
 	private Optional<EntriesBackup> findIncrementalBackup(ExtensionContext originalContext,
 			ExtensionContext incrementContext) {
 		var key = getStoreKey(originalContext, incrementContext, BackupType.INCREMENTAL);
-		EntriesBackup entriesBackup = getStore(originalContext).get(key, EntriesBackup.class);
+		var entriesBackup = getStore(originalContext).get(key, EntriesBackup.class);
 		return Optional.ofNullable(entriesBackup);
 	}
 

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/util/SystemPropertiesExtension.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/util/SystemPropertiesExtension.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionConfigurationException;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.platform.commons.util.ToStringBuilder;
 
 /**
  * {@code Extension} which provides support for the following annotations.
@@ -98,7 +99,7 @@ final class SystemPropertiesExtension
 
 		// we have to apply the annotations from the outermost to the innermost context.
 		forEachInReverseOrder(allContexts,
-			currentContext -> clearAndSetEntries(currentContext, originalContext, restoreAnnotationContext.isEmpty()));
+			currentContext -> clearAndSetEntries(originalContext, currentContext, restoreAnnotationContext.isEmpty()));
 	}
 
 	private Optional<ExtensionContext> findFirstRestoreAnnotationContext(List<ExtensionContext> contexts) {
@@ -107,10 +108,9 @@ final class SystemPropertiesExtension
 				.findFirst();
 	}
 
-	private void clearAndSetEntries(ExtensionContext currentContext, ExtensionContext originalContext,
-			boolean doIncrementalBackup) {
+	private void clearAndSetEntries(ExtensionContext originalContext, ExtensionContext incrementContext, boolean doIncrementalBackup) {
 
-		currentContext.getElement().ifPresent(element -> {
+		incrementContext.getElement().ifPresent(element -> {
 			var entriesToClear = findEntriesToClear(element);
 			var entriesToSet = findEntriesToSet(element);
 			preventClearAndSetSameEntries(element, entriesToClear, entriesToSet.keySet());
@@ -121,7 +121,7 @@ final class SystemPropertiesExtension
 
 			// Only backup original values if we didn't already do bulk storage of the original state
 			if (doIncrementalBackup) {
-				storeIncrementalBackup(originalContext, entriesToClear, entriesToSet.keySet());
+				storeIncrementalBackup(originalContext, incrementContext, entriesToClear, entriesToSet.keySet());
 			}
 
 			// For consistency don't use Properties::setProperty or System.setProperty here
@@ -175,14 +175,14 @@ final class SystemPropertiesExtension
 					));
 	}
 
-	private void storeIncrementalBackup(ExtensionContext context, Collection<String> entriesToClear,
-			Collection<String> entriesToSet) {
+	private void storeIncrementalBackup(ExtensionContext context, ExtensionContext incrementContext,
+			Collection<String> entriesToClear, Collection<String> entriesToSet) {
 		var backup = new EntriesBackup(entriesToClear, entriesToSet);
-		getStore(context).put(getStoreKey(context, BackupType.INCREMENTAL), backup);
+		getStore(context).put(getStoreKey(context, incrementContext, BackupType.INCREMENTAL), backup);
 	}
 
 	private void storeCompleteBackup(ExtensionContext context, Properties backup) {
-		getStore(context).put(getStoreKey(context, BackupType.COMPLETE), backup);
+		getStore(context).put(getStoreKey(context, context, BackupType.COMPLETE), backup);
 	}
 
 	/**
@@ -204,7 +204,7 @@ final class SystemPropertiesExtension
 	}
 
 	private @Nullable Properties getCompleteBackup(ExtensionContext context) {
-		var key = getStoreKey(context, BackupType.COMPLETE);
+		var key = getStoreKey(context, context, BackupType.COMPLETE);
 		return getStore(context).get(key, Properties.class);
 	}
 
@@ -222,14 +222,9 @@ final class SystemPropertiesExtension
 		// Try a complete restore first
 		if (!restoreOriginalCompleteBackup(originalContext)) {
 			// A complete backup is not available, so restore incrementally from innermost to outermost
-			findAllExtensionContexts(originalContext).forEach(__ -> restoreOriginalIncrementalBackup(originalContext));
-		}
-	}
-
-	private void restoreOriginalIncrementalBackup(ExtensionContext originalContext) {
-		var backup = getIncrementalBackup(originalContext);
-		if (backup != null) {
-			backup.restoreBackup();
+			findAllExtensionContexts(originalContext) //
+					.forEach(currentContext -> findIncrementalBackup(originalContext, currentContext) //
+							.ifPresent(EntriesBackup::restoreBackup));
 		}
 	}
 
@@ -242,20 +237,22 @@ final class SystemPropertiesExtension
 		return contexts;
 	}
 
-	private @Nullable EntriesBackup getIncrementalBackup(ExtensionContext originalContext) {
-		var key = getStoreKey(originalContext, BackupType.INCREMENTAL);
-		return getStore(originalContext).get(key, EntriesBackup.class);
+	private Optional<EntriesBackup> findIncrementalBackup(ExtensionContext originalContext,
+			ExtensionContext incrementContext) {
+		var key = getStoreKey(originalContext, incrementContext, BackupType.INCREMENTAL);
+		EntriesBackup entriesBackup = getStore(originalContext).get(key, EntriesBackup.class);
+		return Optional.ofNullable(entriesBackup);
 	}
 
 	private ExtensionContext.Store getStore(ExtensionContext context) {
 		return context.getStore(ExtensionContext.Namespace.create(getClass()));
 	}
 
-	private StoreKey getStoreKey(ExtensionContext context, BackupType type) {
-		return new StoreKey(context.getUniqueId(), type);
+	private StoreKey getStoreKey(ExtensionContext context, ExtensionContext incrementContext, BackupType type) {
+		return new StoreKey(context.getUniqueId(), incrementContext.getUniqueId(), type);
 	}
 
-	private record StoreKey(String uniqueId, BackupType type) {
+	private record StoreKey(String id, String incrementId, BackupType type) {
 	}
 
 	private enum BackupType {
@@ -295,6 +292,14 @@ final class SystemPropertiesExtension
 			var properties = System.getProperties();
 			entriesToClear.forEach(properties::remove);
 			properties.putAll(entriesToSet);
+		}
+
+		@Override
+		public String toString() {
+			return new ToStringBuilder(this) //
+					.append("entriesToClear", this.entriesToClear) //
+					.append("entriesToSet", this.entriesToSet) //
+					.toString();
 		}
 	}
 

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/util/SystemPropertiesExtension.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/util/SystemPropertiesExtension.java
@@ -108,7 +108,8 @@ final class SystemPropertiesExtension
 				.findFirst();
 	}
 
-	private void clearAndSetEntries(ExtensionContext originalContext, ExtensionContext incrementContext, boolean doIncrementalBackup) {
+	private void clearAndSetEntries(ExtensionContext originalContext, ExtensionContext incrementContext,
+			boolean doIncrementalBackup) {
 
 		incrementContext.getElement().ifPresent(element -> {
 			var entriesToClear = findEntriesToClear(element);

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/util/SystemPropertiesExtensionTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/util/SystemPropertiesExtensionTests.java
@@ -445,6 +445,30 @@ class SystemPropertiesExtensionTests extends AbstractJupiterTestEngineTests {
 				assertThat(System.getProperty("B")).isEqualTo("new B");
 			}
 
+			@Nested
+			@SetSystemProperty(key = "A", value = "1")
+			@DisplayName("a sparsely annotated class structure")
+			class DeeplyNestedClass {
+
+				@Nested
+				@DisplayName("system properties should be restored to deeply nested class when they are not provided in deeper nested class")
+				class DeeperNestedClass {
+
+					@Test
+					@SetSystemProperty(key = "A", value = "3")
+					@DisplayName("change the property so that it can be restored")
+					void test(){
+						assertThat(System.getProperty("A")).isEqualTo("3");
+					}
+				}
+
+				@AfterAll
+				static void afterAll(){
+					assertThat(System.getProperty("A")).isEqualTo("1");
+				}
+
+			}
+
 		}
 
 		@Nested
@@ -695,13 +719,6 @@ class SystemPropertiesExtensionTests extends AbstractJupiterTestEngineTests {
 	@Nested
 	@DisplayName("properties are restored after ParameterizedTest")
 	class RestoreAfterParameterizedTest {
-
-		// This reproduces the system properties not being reset when set as part of a ParameterizedTest.
-		// These test all set only their 'own' system property and check ALL system properties.
-		// This will show in the test output which of the properties was not reset and thus give a clear
-		// indication which test actually did not work correctly.
-		// So the effect is that the BAD test does not fail, all the tests that are run AFTER this BAD test will fail.
-		// How many depends on the (random) order the tests are executed in. In any case the finish check will fail.
 
 		private static final String PROP_NORMAL_TEST = "Normal Test PROP Variable";
 		private static final String PROP_PARAM_TEST = "ParameterizedTest PROP Variable";

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/util/SystemPropertiesExtensionTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/util/SystemPropertiesExtensionTests.java
@@ -44,6 +44,8 @@ import org.junit.jupiter.api.extension.ExtensionConfigurationException;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.engine.AbstractJupiterTestEngineTests;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.junit.platform.testkit.engine.EngineExecutionResults;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoSettings;
@@ -64,13 +66,25 @@ class SystemPropertiesExtensionTests extends AbstractJupiterTestEngineTests {
 
 	@AfterAll
 	static void globalTearDown() {
+		// First check if all properties have been restored to their original values
+		assertThat(System.getProperty("A")).isEqualTo("old A");
+		assertThat(System.getProperty("B")).isEqualTo("old B");
+		assertThat(System.getProperty("C")).isEqualTo("old C");
+		assertThat(System.getProperty("clear envvar D")).isNull();
+		assertThat(System.getProperty("clear envvar E")).isNull();
+		assertThat(System.getProperty("clear envvar F")).isNull();
+
+		// Cleanup
 		System.clearProperty("A");
 		System.clearProperty("B");
 		System.clearProperty("C");
 
-		assertThat(System.getProperty("clear prop D")).isNull();
-		assertThat(System.getProperty("clear prop E")).isNull();
-		assertThat(System.getProperty("clear prop F")).isNull();
+		assertThat(System.getProperty("A")).isNull();
+		assertThat(System.getProperty("B")).isNull();
+		assertThat(System.getProperty("C")).isNull();
+		assertThat(System.getProperty("clear envvar D")).isNull();
+		assertThat(System.getProperty("clear envvar E")).isNull();
+		assertThat(System.getProperty("clear envvar F")).isNull();
 	}
 
 	@Nested
@@ -674,6 +688,90 @@ class SystemPropertiesExtensionTests extends AbstractJupiterTestEngineTests {
 				assertThat(System.getProperty("RestoreAll")).isNull(); // Should be restored
 			}
 
+		}
+
+	}
+
+	@Nested
+	@DisplayName("properties are restored after ParameterizedTest")
+	class RestoreAfterParameterizedTest {
+
+		// This reproduces the system properties not being reset when set as part of a ParameterizedTest.
+		// These test all set only their 'own' system property and check ALL system properties.
+		// This will show in the test output which of the properties was not reset and thus give a clear
+		// indication which test actually did not work correctly.
+		// So the effect is that the BAD test does not fail, all the tests that are run AFTER this BAD test will fail.
+		// How many depends on the (random) order the tests are executed in. In any case the finish check will fail.
+
+		private static final String PROP_NORMAL_TEST = "Normal Test PROP Variable";
+		private static final String PROP_PARAM_TEST = "ParameterizedTest PROP Variable";
+		private static final String PROP_PARAM_WITH_RESTORE_TEST = "ParameterizedTest With Restore PROP Variable";
+		private static final String PROP_ORIG_VALUE = "Original Value";
+		private static final String PROP_CHANGED_VALUE = "Changed Value";
+
+		// For these tests we need very explicit reporting about which variable is incorrect.
+		private static void assertSystemProperty(String propName, String propValue) {
+			assertThat(System.getProperty(propName)).as(
+				"System property \"" + propName + "\" should be \"" + propValue + "\".").isEqualTo(propValue);
+		}
+
+		private static void assertSystemPropertyIsNull(String propName) {
+			assertThat(System.getProperty(propName)).as(
+				"System property \"" + propName + "\" should be NULL.").isNull();
+		}
+
+		@BeforeAll
+		public static void setup() {
+			System.setProperty(PROP_NORMAL_TEST, PROP_ORIG_VALUE);
+			System.setProperty(PROP_PARAM_TEST, PROP_ORIG_VALUE);
+			System.setProperty(PROP_PARAM_WITH_RESTORE_TEST, PROP_ORIG_VALUE);
+			assertSystemProperty(PROP_NORMAL_TEST, PROP_ORIG_VALUE);
+			assertSystemProperty(PROP_PARAM_TEST, PROP_ORIG_VALUE);
+			assertSystemProperty(PROP_PARAM_WITH_RESTORE_TEST, PROP_ORIG_VALUE);
+		}
+
+		@AfterAll
+		public static void finish() {
+			assertSystemProperty(PROP_NORMAL_TEST, PROP_ORIG_VALUE);
+			assertSystemProperty(PROP_PARAM_TEST, PROP_ORIG_VALUE);
+			assertSystemProperty(PROP_PARAM_WITH_RESTORE_TEST, PROP_ORIG_VALUE);
+
+			System.clearProperty(PROP_NORMAL_TEST);
+			System.clearProperty(PROP_PARAM_TEST);
+			System.clearProperty(PROP_PARAM_WITH_RESTORE_TEST);
+
+			assertSystemPropertyIsNull(PROP_NORMAL_TEST);
+			assertSystemPropertyIsNull(PROP_PARAM_TEST);
+			assertSystemPropertyIsNull(PROP_PARAM_WITH_RESTORE_TEST);
+		}
+
+		@Test
+		@SetSystemProperty(key = PROP_NORMAL_TEST, value = PROP_CHANGED_VALUE)
+		void testNormal() {
+			assertSystemProperty(PROP_NORMAL_TEST, PROP_CHANGED_VALUE);
+			assertSystemProperty(PROP_PARAM_TEST, PROP_ORIG_VALUE);
+			assertSystemProperty(PROP_PARAM_WITH_RESTORE_TEST, PROP_ORIG_VALUE);
+		}
+
+		@ParameterizedTest(name = "ParameterizedTest WITHOUT RestoreSystemProperties ({0})")
+		@ValueSource(ints = { 1 })
+		@SetSystemProperty(key = PROP_PARAM_TEST, value = PROP_CHANGED_VALUE)
+		void testParamWithoutRestore(int dummy) {
+			assertThat(dummy).isEqualTo(1);
+			assertSystemProperty(PROP_NORMAL_TEST, PROP_ORIG_VALUE);
+			assertSystemProperty(PROP_PARAM_TEST, PROP_CHANGED_VALUE);
+			assertSystemProperty(PROP_PARAM_WITH_RESTORE_TEST, PROP_ORIG_VALUE);
+		}
+
+		@ParameterizedTest(name = "ParameterizedTest WITH RestoreSystemProperties ({0})")
+		@ValueSource(ints = { 1 })
+		@SetSystemProperty(key = PROP_PARAM_WITH_RESTORE_TEST, value = PROP_CHANGED_VALUE)
+		@RestoreSystemProperties
+		void testParamWithRestore(int dummy) {
+			assertThat(dummy).isEqualTo(1);
+			assertSystemProperty(PROP_NORMAL_TEST, PROP_ORIG_VALUE);
+			assertSystemProperty(PROP_PARAM_TEST, PROP_ORIG_VALUE);
+			assertSystemProperty(PROP_PARAM_WITH_RESTORE_TEST, PROP_CHANGED_VALUE);
 		}
 
 	}

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/util/SystemPropertiesExtensionTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/util/SystemPropertiesExtensionTests.java
@@ -457,14 +457,22 @@ class SystemPropertiesExtensionTests extends AbstractJupiterTestEngineTests {
 					@Test
 					@SetSystemProperty(key = "A", value = "3")
 					@DisplayName("change the property so that it can be restored")
-					void test(){
+					void changePropertyForRestore() {
 						assertThat(System.getProperty("A")).isEqualTo("3");
+					}
+
+					@Test
+					@SetSystemProperty(key = "A", value = "3")
+					@DisplayName("change the property programmatically so that it can be restored")
+					void programmaticallyChangePropertyForRestore() {
+						System.setProperty("B", "mutated B");
 					}
 				}
 
 				@AfterAll
-				static void afterAll(){
+				static void afterAll() {
 					assertThat(System.getProperty("A")).isEqualTo("1");
+					assertThat(System.getProperty("B")).isEqualTo("new B");
 				}
 
 			}

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/util/SystemPropertiesExtensionTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/util/SystemPropertiesExtensionTests.java
@@ -448,11 +448,11 @@ class SystemPropertiesExtensionTests extends AbstractJupiterTestEngineTests {
 			@Nested
 			@SetSystemProperty(key = "A", value = "1")
 			@DisplayName("a sparsely annotated class structure")
-			class DeeplyNestedClass {
+			class SparselyAnnotatedStructure {
 
 				@Nested
-				@DisplayName("system properties should be restored to deeply nested class when they are not provided in deeper nested class")
-				class DeeperNestedClass {
+				@DisplayName("system properties should be restored to values from the parent when they are not provided by this class")
+				class WithoutSystemPropertyAnnotations {
 
 					@Test
 					@SetSystemProperty(key = "A", value = "3")
@@ -465,7 +465,7 @@ class SystemPropertiesExtensionTests extends AbstractJupiterTestEngineTests {
 					@SetSystemProperty(key = "A", value = "3")
 					@DisplayName("change the property programmatically so that it can be restored")
 					void programmaticallyChangePropertyForRestore() {
-						System.setProperty("B", "mutated B");
+						System.setProperty("B", "changed B");
 					}
 				}
 


### PR DESCRIPTION
Restore original SetSystemProperty values in a ParameterizedTest

The system properties extension would for each context and all its
ancestors process the system property annotations. After applying each
context it would also create an incremental backup. But it would only
store the latest backup.

This is a problem when parametrized tests are used. The ancestral
context includes the test method element twice:

```
0 = {Optional@5653} "Optional[void RestoreAfterParameterizedTest.testParamWithoutRestore(int)]"
1 = {Optional@5654} "Optional[void RestoreAfterParameterizedTest.testParamWithoutRestore(int)]"
2 = {Optional@5655} "Optional[class SystemPropertiesExtensionTests$RestoreAfterParameterizedTest]"
3 = {Optional@5656} "Optional[class SystemPropertiesExtensionTests]"
4 = {Optional@4689} "Optional.empty"
 ``` 

As such the system  property will be backed up, modified, the modified
value will be backed up again and then modified (idempotent). Because
only the last incremental backup is stored, the original value is
never restored.
 
This could be solved by either:
 
 a) Only processing the original context and none of its ancestors.
 b) Using a compound key of the original context and its current ancestor.
 
Option a mostly works, but will not properly restore programmatically
modified keys when nested tests are sparsely annotated. So it must be
option b.

Fixes: #5717
Supersedes: #5718

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://docs.junit.org/snapshot/) and [Release Notes](https://docs.junit.org/snapshot/release-notes.html)
