### PR TITLE
Close Socket in testPlanExecutionStarted

### DIFF
--- a/junit-platform-reporting/src/main/java/org/junit/platform/reporting/open/xml/OpenTestReportGeneratingListener.java
+++ b/junit-platform-reporting/src/main/java/org/junit/platform/reporting/open/xml/OpenTestReportGeneratingListener.java
@@ -150,9 +150,10 @@ public class OpenTestReportGeneratingListener implements TestExecutionListener {
 		return config.get(SOCKET_PROPERTY_NAME, Integer::valueOf) //
 				.map(port -> {
 					try {
-						Socket socket = new Socket(InetAddress.getLoopbackAddress(), port);
-						Writer writer = new OutputStreamWriter(socket.getOutputStream(), StandardCharsets.UTF_8);
-						return Events.createDocumentWriter(namespaceRegistry, writer);
+						try (Socket socket = new Socket(InetAddress.getLoopbackAddress(), port)) {
+							Writer writer = new OutputStreamWriter(socket.getOutputStream(), StandardCharsets.UTF_8);
+							return Events.createDocumentWriter(namespaceRegistry, writer);
+						}
 					}
 					catch (Exception e) {
 						throw new JUnitException("Failed to connect to socket on port " + port, e);


### PR DESCRIPTION
While tracing testPlanExecutionStarted in junit-platform-reporting/src/main/java/org/junit/platform/reporting/open/xml/OpenTestReportGeneratingListener.java I noticed what might be an issue: The resource opened there can leak if testPlanExecutionStarted exits on an error path. this patch moves the allocation into try-with-resources so cleanup happens on every exit path. Let me know if the approach doesn’t fit.

Happy to revise the approach or close this if it doesn’t fit — you know the codebase far better than I do.