### PR TITLE
Add JRE.JAVA_28 enum constant and build against JDK 28 EA

### DIFF
--- a/.github/workflows/_cross-version.yml
+++ b/.github/workflows/_cross-version.yml
@@ -18,6 +18,8 @@ jobs:
           type: ga
         - version: 27
           type: ea
+        - version: 28
+          type: ea
         - version: 26
           type: ea
           release: leyden

--- a/documentation/modules/ROOT/partials/release-notes/release-notes-6.2.0-M1.adoc
+++ b/documentation/modules/ROOT/partials/release-notes/release-notes-6.2.0-M1.adoc
@@ -31,6 +31,8 @@ repository on GitHub.
   closing it in test code which can lead to test failures that are hard to diagnose.
 * When using a third-party engine that uses the `junit-` prefix a discovery issue is
   emitted.
+* `JAVA_28` has been added to the `JRE` enum for use with `JRE`-based execution
+  conditions.
 
 [[v6.2.0-M1-junit-jupiter]]
 === JUnit Jupiter

--- a/gradle/base/code-generator-model/src/main/resources/jre.yaml
+++ b/gradle/base/code-generator-model/src/main/resources/jre.yaml
@@ -34,3 +34,5 @@
   since: '5.13.2'
 - version: 27
   since: '6.1'
+- version: 28
+  since: '6.2'

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/condition/EnabledForJreRangeConditionTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/condition/EnabledForJreRangeConditionTests.java
@@ -199,7 +199,7 @@ class EnabledForJreRangeConditionTests extends AbstractExecutionConditionTests {
 	void min20() {
 		evaluateCondition();
 		assertEnabledOnCurrentJreIf(onJava20() || onJava21() || onJava22() || onJava23() || onJava24() || onJava25()
-				|| onJava26() || onJava27() || onOtherVersion());
+				|| onJava26() || onJava27() || onJava28() || onOtherVersion());
 	}
 
 	/**

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/condition/EnabledForJreRangeConditionTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/condition/EnabledForJreRangeConditionTests.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.condition.JavaVersionPredicates.onJava24;
 import static org.junit.jupiter.api.condition.JavaVersionPredicates.onJava25;
 import static org.junit.jupiter.api.condition.JavaVersionPredicates.onJava26;
 import static org.junit.jupiter.api.condition.JavaVersionPredicates.onJava27;
+import static org.junit.jupiter.api.condition.JavaVersionPredicates.onJava28;
 import static org.junit.jupiter.api.condition.JavaVersionPredicates.onKnownVersion;
 import static org.junit.jupiter.api.condition.JavaVersionPredicates.onOtherVersion;
 import static org.junit.platform.commons.test.PreconditionAssertions.assertPreconditionViolationFor;
@@ -307,7 +308,7 @@ class EnabledForJreRangeConditionTests extends AbstractExecutionConditionTests {
 	void minVersion21MaxVersionMaxInteger() {
 		evaluateCondition();
 		assertEnabledOnCurrentJreIf(onJava21() || onJava22() || onJava23() || onJava24() || onJava25() || onJava26()
-				|| onJava27() || onOtherVersion());
+				|| onJava27() || onJava28() || onOtherVersion());
 	}
 
 	/**


### PR DESCRIPTION
OpenJDK JDK 28 Early-Access Builds are available at https://jdk.java.net/28/

- [x] Add 28 to JRE Enum
- [x] Add JDK 28 ea latest to Cross-Version Test Matrix

Closes #5737 

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://docs.junit.org/snapshot/) and [Release Notes](https://docs.junit.org/snapshot/release-notes.html)
