### PR TITLE
Store one partial backup for each SystemPropertiesExtension context

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/util/SystemPropertiesExtension.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/util/SystemPropertiesExtension.java
@@ -53,83 +53,71 @@ final class SystemPropertiesExtension
 		var modification = SystemPropertiesModification.create(allContexts);
 
 		// Please do not refactor out the common parts.
-		findFirstRestoreAnnotationContext(allContexts) //
-				.ifPresentOrElse(
+		var backup = findFirstRestoreAnnotationContext(allContexts) //
+				.<Backup> map(restoreAnnotationContext -> {
 					// Do a complete backup of the properties
-					restoreAnnotationContext -> {
-						var properties = System.getProperties();
-						storeCompleteBackup(context, properties);
-						var clonedProperties = cloneWithoutDefaults(restoreAnnotationContext, properties);
-						modification.applyTo(clonedProperties);
-						System.setProperties(clonedProperties);
-					},
+					var properties = System.getProperties();
+					var clonedProperties = cloneWithoutDefaults(restoreAnnotationContext, properties);
+					modification.applyTo(clonedProperties);
+					System.setProperties(clonedProperties);
+					return new Backup.Complete(properties);
+				}).orElseGet(() -> {
 					// Backup only the modified properties
-					() -> {
-						var properties = System.getProperties();
-						storePartialBackup(context, modification.createInverseApplyTo(properties));
-						modification.applyTo(properties);
-					});
-	}
+					var properties = System.getProperties();
+					var partialBackup = new Backup.Partial(modification.createInverseApplyTo(properties));
+					modification.applyTo(properties);
+					return partialBackup;
+				});
 
-	private void storeCompleteBackup(ExtensionContext context, Properties backup) {
-		getStore(context).put(createStoreKey(context, BackupType.COMPLETE), backup);
-	}
-
-	private void storePartialBackup(ExtensionContext context, SystemPropertiesModification backup) {
-		getStore(context).put(createStoreKey(context, BackupType.PARTIAL), backup);
+		storeBackup(context, backup);
 	}
 
 	@Override
 	public void afterEach(ExtensionContext context) {
-		restoreForAllContexts(context);
+		restoreBackup(context);
 	}
 
 	@Override
 	public void afterAll(ExtensionContext context) {
-		restoreForAllContexts(context);
+		restoreBackup(context);
 	}
 
-	private void restoreForAllContexts(ExtensionContext context) {
-		// Try a complete restore first
-		findCompleteBackup(context) //
-				.ifPresentOrElse(System::setProperties, //
-					// A complete backup is not available, so use partial backup
-					() -> findPartialBackup(context) //
-							.ifPresent(backup -> backup.applyTo(System.getProperties())));
+	private void restoreBackup(ExtensionContext context) {
+		findBackup(context).ifPresent(Backup::restore);
 	}
 
-	private Optional<Properties> findCompleteBackup(ExtensionContext context) {
-		var key = createStoreKey(context, BackupType.COMPLETE);
-		var backup = getStore(context).get(key, Properties.class);
+	private void storeBackup(ExtensionContext context, Backup backup) {
+		getStore(context).put(context.getUniqueId(), backup);
+	}
+
+	private Optional<Backup> findBackup(ExtensionContext context) {
+		var backup = getStore(context).get(context.getUniqueId(), Backup.class);
 		return Optional.ofNullable(backup);
-	}
-
-	private Optional<SystemPropertiesModification> findPartialBackup(ExtensionContext context) {
-		var key = createStoreKey(context, BackupType.PARTIAL);
-		var backup = getStore(context).get(key, SystemPropertiesModification.class);
-		return Optional.ofNullable(backup);
-	}
-
-	private StoreKey createStoreKey(ExtensionContext context, BackupType type) {
-		return new StoreKey(context.getUniqueId(), type);
 	}
 
 	private ExtensionContext.Store getStore(ExtensionContext context) {
 		return context.getStore(ExtensionContext.Namespace.create(getClass()));
 	}
 
-	private record StoreKey(String id, BackupType type) {
-	}
+	private sealed interface Backup {
 
-	private enum BackupType {
-		/**
-		 * Store entry is for a partial backup object.
-		 */
-		PARTIAL,
-		/**
-		 * Store entry is for a complete backup object.
-		 */
-		COMPLETE
+		void restore();
+
+		/// Partial backup
+		record Partial(SystemPropertiesModification inverseModification) implements Backup {
+			@Override
+			public void restore() {
+				inverseModification.applyTo(System.getProperties());
+			}
+		}
+
+		/// Complete backup
+		record Complete(Properties originalProperties) implements Backup {
+			@Override
+			public void restore() {
+				System.setProperties(originalProperties);
+			}
+		}
 	}
 
 	private static List<ExtensionContext> findAllExtensionContexts(ExtensionContext context) {

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/util/SystemPropertiesExtension.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/util/SystemPropertiesExtension.java
@@ -10,29 +10,19 @@
 
 package org.junit.jupiter.api.util;
 
-import static java.util.stream.Collectors.toSet;
 import static org.junit.jupiter.api.util.JupiterPropertyUtils.cloneWithoutDefaults;
-import static org.junit.platform.commons.support.AnnotationSupport.findRepeatableAnnotations;
 import static org.junit.platform.commons.support.AnnotationSupport.isAnnotated;
-import static org.junit.platform.commons.util.CollectionUtils.forEachInReverseOrder;
 
-import java.lang.reflect.AnnotatedElement;
 import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
-import java.util.Set;
 
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
-import org.junit.jupiter.api.extension.ExtensionConfigurationException;
 import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.platform.commons.util.ToStringBuilder;
 
 /**
  * {@code Extension} which provides support for the following annotations.
@@ -60,7 +50,7 @@ final class SystemPropertiesExtension
 
 	private void applyForAllContexts(ExtensionContext context) {
 		var allContexts = findAllExtensionContexts(context);
-		var modification = DeferredPropertyModification.create(allContexts);
+		var modification = SystemPropertiesModification.create(allContexts);
 
 		// Please do not refactor out the common parts.
 		findFirstRestoreAnnotationContext(allContexts) //
@@ -85,7 +75,7 @@ final class SystemPropertiesExtension
 		getStore(context).put(createStoreKey(context, BackupType.COMPLETE), backup);
 	}
 
-	private void storePartialBackup(ExtensionContext context, DeferredPropertyModification backup) {
+	private void storePartialBackup(ExtensionContext context, SystemPropertiesModification backup) {
 		getStore(context).put(createStoreKey(context, BackupType.PARTIAL), backup);
 	}
 
@@ -114,9 +104,9 @@ final class SystemPropertiesExtension
 		return Optional.ofNullable(backup);
 	}
 
-	private Optional<DeferredPropertyModification> findPartialBackup(ExtensionContext context) {
+	private Optional<SystemPropertiesModification> findPartialBackup(ExtensionContext context) {
 		var key = createStoreKey(context, BackupType.PARTIAL);
-		var backup = getStore(context).get(key, DeferredPropertyModification.class);
+		var backup = getStore(context).get(key, SystemPropertiesModification.class);
 		return Optional.ofNullable(backup);
 	}
 
@@ -140,132 +130,6 @@ final class SystemPropertiesExtension
 		 * Store entry is for a complete backup object.
 		 */
 		COMPLETE
-	}
-
-	/**
-	 * A sequence of deferred modification applied to a
-	 * {@link Properties} object represented as a single modification.
-	 */
-	private static class DeferredPropertyModification {
-		private static final Object REMOVED = new Object();
-		private final Map<String, Object> changes = new HashMap<>();
-
-		void clearProperty(String key) {
-			changes.put(key, REMOVED);
-		}
-
-		void setProperty(String key, Object value) {
-			changes.put(key, value);
-		}
-
-		void applyTo(Properties properties) {
-			changes.forEach((key, value) -> {
-				// For consistency don't use Properties::setProperty here
-				if (REMOVED.equals(value)) {
-					properties.remove(key);
-				}
-				else {
-					properties.put(key, value);
-				}
-			});
-		}
-
-		/**
-		 * Creates the inverse of calling {@link #applyTo(Properties)} such
-		 * that {@code modification.applyTo(properties); inverse.applyTo(properties);}
-		 * has no observable effect.
-		 */
-		DeferredPropertyModification createInverseApplyTo(Properties properties) {
-			DeferredPropertyModification inverse = new DeferredPropertyModification();
-			changes.keySet().forEach(key -> {
-				// Do not use Properties::getProperty here, since this would
-				// prevent backing up non-string values.
-				Object backup = properties.get(key);
-				if (backup == null) {
-					inverse.clearProperty(key);
-				}
-				else {
-					inverse.setProperty(key, backup);
-				}
-			});
-			return inverse;
-		}
-
-		@Override
-		public String toString() {
-			var builder = new ToStringBuilder(DeferredPropertyModification.class);
-			this.changes.forEach((key, value) -> {
-				if (REMOVED.equals(value)) {
-					builder.append(key, null);
-				}
-				else {
-					builder.append(key, value);
-				}
-			});
-			return builder.toString();
-		}
-
-		static DeferredPropertyModification create(List<ExtensionContext> allContexts) {
-			var modification = new DeferredPropertyModification();
-			// we have to apply the annotations from the outermost to the innermost context.
-			forEachInReverseOrder(allContexts, currentContext -> currentContext.getElement().ifPresent(element -> {
-				var entriesToClear = findEntriesToClear(element);
-				var entriesToSet = findEntriesToSet(element);
-
-				if (entriesToClear.isEmpty() && entriesToSet.isEmpty()) {
-					return;
-				}
-
-				requireNoClearAndSetSameEntries(element, entriesToClear, entriesToSet.keySet());
-				entriesToClear.forEach(modification::clearProperty);
-				entriesToSet.forEach(modification::setProperty);
-			}));
-			return modification;
-		}
-
-		private static Set<String> findEntriesToClear(AnnotatedElement element) {
-			return findRepeatableAnnotations(element, ClearSystemProperty.class).stream() //
-					.map(ClearSystemProperty::key) //
-					// already distinct due to findRepeatableAnnotations
-					.collect(toSet());
-		}
-
-		private static Map<String, String> findEntriesToSet(AnnotatedElement element) {
-			var entries = new HashMap<String, String>();
-			var duplicatePropertyNames = new HashSet<String>();
-
-			findRepeatableAnnotations(element, SetSystemProperty.class) //
-					.forEach(annotation -> {
-						var key = annotation.key();
-						if (entries.put(key, annotation.value()) != null) {
-							duplicatePropertyNames.add(key);
-						}
-					});
-
-			requireUniqueEntries(element, duplicatePropertyNames);
-			return entries;
-		}
-
-		private static void requireNoClearAndSetSameEntries(AnnotatedElement element, Set<String> entriesToClear,
-				Set<String> entriesToSet) {
-			requireUniqueEntries(element, //
-				entriesToClear.stream() //
-						.filter(entriesToSet::contains) //
-						.collect(toSet()));
-		}
-
-		private static void requireUniqueEntries(AnnotatedElement annotatedElement, Set<String> duplicatePropertNames) {
-			if (duplicatePropertNames.isEmpty()) {
-				return;
-			}
-			throw new ExtensionConfigurationException(
-				"SystemPropertyExtension was configured to set/clear %s [%s] more than once by [%s]." //
-						.formatted( //
-							duplicatePropertNames.size() == 1 ? "property" : "properties", //
-							String.join(", ", duplicatePropertNames), //
-							annotatedElement //
-						));
-		}
 	}
 
 	private static List<ExtensionContext> findAllExtensionContexts(ExtensionContext context) {

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/util/SystemPropertiesExtension.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/util/SystemPropertiesExtension.java
@@ -11,13 +11,13 @@
 package org.junit.jupiter.api.util;
 
 import static java.util.stream.Collectors.toSet;
+import static org.junit.jupiter.api.util.JupiterPropertyUtils.cloneWithoutDefaults;
 import static org.junit.platform.commons.support.AnnotationSupport.findRepeatableAnnotations;
 import static org.junit.platform.commons.support.AnnotationSupport.isAnnotated;
 import static org.junit.platform.commons.util.CollectionUtils.forEachInReverseOrder;
 
 import java.lang.reflect.AnnotatedElement;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -25,16 +25,13 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
-import java.util.stream.Stream;
 
-import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionConfigurationException;
 import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.platform.commons.util.ToStringBuilder;
 
 /**
  * {@code Extension} which provides support for the following annotations.
@@ -50,34 +47,6 @@ import org.junit.platform.commons.util.ToStringBuilder;
 final class SystemPropertiesExtension
 		implements BeforeEachCallback, AfterEachCallback, BeforeAllCallback, AfterAllCallback {
 
-	/**
-	 * Prepare for entering a context that must be restorable.
-	 *
-	 * <p>The context is prepared by pre-emptively swapping out the current
-	 * System properties with a snapshot. The original system properties are
-	 * restored after the test.
-	 *
-	 * @return the original {@link System#getProperties} object
-	 */
-	Properties prepareToEnterRestorableContext(ExtensionContext context) {
-		var current = System.getProperties();
-		var clone = JupiterPropertyUtils.cloneWithoutDefaults(context, current);
-		System.setProperties(clone);
-		return current;
-	}
-
-	/**
-	 * Prepare to exit a restorable context.
-	 *
-	 * <p>The entry environment will be restored to the state passed in as {@code Properties}.
-	 *
-	 * @param properties a non-null {@code Properties} that contains all entries
-	 * of the entry environment
-	 */
-	void prepareToExitRestorableContext(Properties properties) {
-		System.setProperties(properties);
-	}
-
 	@Override
 	public void beforeAll(ExtensionContext context) {
 		applyForAllContexts(context);
@@ -88,18 +57,27 @@ final class SystemPropertiesExtension
 		applyForAllContexts(context);
 	}
 
-	private void applyForAllContexts(ExtensionContext originalContext) {
-		var allContexts = findAllExtensionContexts(originalContext);
+	private void applyForAllContexts(ExtensionContext context) {
+		var allContexts = findAllExtensionContexts(context);
+		var modification = createDeferredPropertyModification(allContexts);
 
-		var restoreAnnotationContext = findFirstRestoreAnnotationContext(allContexts);
-		restoreAnnotationContext.ifPresent(annotatedElementContext -> {
-			var properties = this.prepareToEnterRestorableContext(annotatedElementContext);
-			storeCompleteBackup(originalContext, properties);
-		});
-
-		// we have to apply the annotations from the outermost to the innermost context.
-		forEachInReverseOrder(allContexts,
-			currentContext -> clearAndSetEntries(originalContext, currentContext, restoreAnnotationContext.isEmpty()));
+		// Please do not refactor out the common parts.
+		findFirstRestoreAnnotationContext(allContexts) //
+				.ifPresentOrElse(
+					// Do a complete backup of the properties
+					restoreAnnotationContext -> {
+						var properties = System.getProperties();
+						storeCompleteBackup(context, properties);
+						var clonedProperties = cloneWithoutDefaults(restoreAnnotationContext, properties);
+						modification.applyTo(clonedProperties);
+						System.setProperties(clonedProperties);
+					},
+					// Backup only the modified properties
+					() -> {
+						var properties = System.getProperties();
+						storePartialBackup(context, modification.createInverseApplyTo(properties));
+						modification.applyTo(properties);
+					});
 	}
 
 	private Optional<ExtensionContext> findFirstRestoreAnnotationContext(List<ExtensionContext> contexts) {
@@ -108,28 +86,22 @@ final class SystemPropertiesExtension
 				.findFirst();
 	}
 
-	private void clearAndSetEntries(ExtensionContext originalContext, ExtensionContext currentContext,
-			boolean doIncrementalBackup) {
-
-		currentContext.getElement().ifPresent(element -> {
+	private DeferredPropertyModification createDeferredPropertyModification(List<ExtensionContext> allContexts) {
+		var modification = new DeferredPropertyModification();
+		// we have to apply the annotations from the outermost to the innermost context.
+		forEachInReverseOrder(allContexts, currentContext -> currentContext.getElement().ifPresent(element -> {
 			var entriesToClear = findEntriesToClear(element);
 			var entriesToSet = findEntriesToSet(element);
-			preventClearAndSetSameEntries(element, entriesToClear, entriesToSet.keySet());
 
 			if (entriesToClear.isEmpty() && entriesToSet.isEmpty()) {
 				return;
 			}
 
-			// Only backup original values if we didn't already do bulk storage of the original state
-			if (doIncrementalBackup) {
-				storeIncrementalBackup(originalContext, currentContext, entriesToClear, entriesToSet.keySet());
-			}
-
-			// For consistency don't use Properties::setProperty or System.setProperty here
-			var properties = System.getProperties();
-			entriesToClear.forEach(properties::remove);
-			properties.putAll(entriesToSet);
-		});
+			preventClearAndSetSameEntries(element, entriesToClear, entriesToSet.keySet());
+			entriesToClear.forEach(modification::clearProperty);
+			entriesToSet.forEach(modification::setProperty);
+		}));
+		return modification;
 	}
 
 	private Set<String> findEntriesToClear(AnnotatedElement element) {
@@ -176,37 +148,18 @@ final class SystemPropertiesExtension
 					));
 	}
 
-	private void storeIncrementalBackup(ExtensionContext context, ExtensionContext incrementContext,
-			Collection<String> entriesToClear, Collection<String> entriesToSet) {
-		var backup = new EntriesBackup(entriesToClear, entriesToSet);
-		getStore(context).put(getStoreKey(context, incrementContext, BackupType.INCREMENTAL), backup);
+	private void storePartialBackup(ExtensionContext context, DeferredPropertyModification backup) {
+		getStore(context).put(createStoreKey(context, BackupType.PARTIAL), backup);
 	}
 
 	private void storeCompleteBackup(ExtensionContext context, Properties backup) {
-		getStore(context).put(getStoreKey(context, context, BackupType.COMPLETE), backup);
+		getStore(context).put(createStoreKey(context, BackupType.COMPLETE), backup);
 	}
 
-	/**
-	 * Restore the complete original state of the entries as they were prior to
-	 * this {@code ExtensionContext}, if the complete state was initially stored
-	 * in a before all/each event.
-	 *
-	 * @param context the {@code ExtensionContext} which may have a bulk backup stored
-	 * @return true if a complete backup exists and was used to restore, false if not
-	 */
-	private boolean restoreOriginalCompleteBackup(ExtensionContext context) {
-		var backup = getCompleteBackup(context);
-		if (backup != null) {
-			prepareToExitRestorableContext(backup);
-			return true;
-		}
-		// No complete backup - false will let the caller know to continue w/ an incremental restore
-		return false;
-	}
-
-	private @Nullable Properties getCompleteBackup(ExtensionContext context) {
-		var key = getStoreKey(context, context, BackupType.COMPLETE);
-		return getStore(context).get(key, Properties.class);
+	private Optional<Properties> findCompleteBackup(ExtensionContext context) {
+		var key = createStoreKey(context, BackupType.COMPLETE);
+		var backup = getStore(context).get(key, Properties.class);
+		return Optional.ofNullable(backup);
 	}
 
 	@Override
@@ -219,14 +172,13 @@ final class SystemPropertiesExtension
 		restoreForAllContexts(context);
 	}
 
-	private void restoreForAllContexts(ExtensionContext originalContext) {
+	private void restoreForAllContexts(ExtensionContext context) {
 		// Try a complete restore first
-		if (!restoreOriginalCompleteBackup(originalContext)) {
-			// A complete backup is not available, so restore incrementally from innermost to outermost
-			findAllExtensionContexts(originalContext) //
-					.forEach(currentContext -> findIncrementalBackup(originalContext, currentContext) //
-							.ifPresent(EntriesBackup::restoreBackup));
-		}
+		findCompleteBackup(context) //
+				.ifPresentOrElse(System::setProperties, //
+					// A complete backup is not available, so use partial backup
+					() -> findPartialBackup(context) //
+							.ifPresent(backup -> backup.applyTo(System.getProperties())));
 	}
 
 	private static List<ExtensionContext> findAllExtensionContexts(ExtensionContext context) {
@@ -238,70 +190,81 @@ final class SystemPropertiesExtension
 		return contexts;
 	}
 
-	private Optional<EntriesBackup> findIncrementalBackup(ExtensionContext originalContext,
-			ExtensionContext incrementContext) {
-		var key = getStoreKey(originalContext, incrementContext, BackupType.INCREMENTAL);
-		var entriesBackup = getStore(originalContext).get(key, EntriesBackup.class);
-		return Optional.ofNullable(entriesBackup);
+	private Optional<DeferredPropertyModification> findPartialBackup(ExtensionContext context) {
+		var key = createStoreKey(context, BackupType.PARTIAL);
+		var backup = getStore(context).get(key, DeferredPropertyModification.class);
+		return Optional.ofNullable(backup);
 	}
 
 	private ExtensionContext.Store getStore(ExtensionContext context) {
 		return context.getStore(ExtensionContext.Namespace.create(getClass()));
 	}
 
-	private StoreKey getStoreKey(ExtensionContext context, ExtensionContext incrementContext, BackupType type) {
-		return new StoreKey(context.getUniqueId(), incrementContext.getUniqueId(), type);
+	private StoreKey createStoreKey(ExtensionContext context, BackupType type) {
+		return new StoreKey(context.getUniqueId(), type);
 	}
 
-	private record StoreKey(String id, String incrementId, BackupType type) {
+	private record StoreKey(String id, BackupType type) {
 	}
 
 	private enum BackupType {
 		/**
-		 * Store entry is for an incremental backup object.
+		 * Store entry is for a partial backup object.
 		 */
-		INCREMENTAL,
+		PARTIAL,
 		/**
 		 * Store entry is for a complete backup object.
 		 */
 		COMPLETE
 	}
 
-	private static final class EntriesBackup {
+	/**
+	 * A sequence of deferred modification applied to a
+	 * {@link Properties} object represented as a single modification.
+	 */
+	private static class DeferredPropertyModification {
+		private static final Object REMOVED = new Object();
+		private final Map<String, Object> changes = new HashMap<>();
 
-		private final Set<String> entriesToClear = new HashSet<>();
-		private final Map<String, Object> entriesToSet = new HashMap<>();
+		void clearProperty(String key) {
+			changes.put(key, REMOVED);
+		}
 
-		EntriesBackup(Collection<String> entriesToClear, Collection<String> entriesToSet) {
-			var properties = System.getProperties();
-			Stream.concat(entriesToClear.stream(), entriesToSet.stream()).forEach(entry -> {
-				// Do not use Properties::getProperty or System.getProperty here, since
-				// this would prevent backing up non-string values.
-				Object backup = properties.get(entry);
-				if (backup == null) {
-					this.entriesToClear.add(entry);
+		void setProperty(String key, Object value) {
+			changes.put(key, value);
+		}
+
+		void applyTo(Properties properties) {
+			changes.forEach((key, value) -> {
+				// For consistency don't use Properties::setProperty here
+				if (REMOVED.equals(value)) {
+					properties.remove(key);
 				}
 				else {
-					this.entriesToSet.put(entry, backup);
+					properties.put(key, value);
 				}
 			});
 		}
 
-		void restoreBackup() {
-			// We can't use Properties::setProperty or System.setProperty here, since
-			// this would prevent restoring non-string values.
-			var properties = System.getProperties();
-			entriesToClear.forEach(properties::remove);
-			properties.putAll(entriesToSet);
-		}
-
-		@Override
-		public String toString() {
-			return new ToStringBuilder(this) //
-					.append("entriesToClear", this.entriesToClear) //
-					.append("entriesToSet", this.entriesToSet) //
-					.toString();
+		/**
+		 * Creates the inverse of calling {@link #applyTo(Properties)} such
+		 * that {@code modification.applyTo(properties); inverse.applyTo(properties);}
+		 * has no observable effect.
+		 */
+		DeferredPropertyModification createInverseApplyTo(Properties properties) {
+			DeferredPropertyModification inverse = new DeferredPropertyModification();
+			changes.keySet().forEach(key -> {
+				// Do not use Properties::getProperty here, since this would
+				// prevent backing up non-string values.
+				Object backup = properties.get(key);
+				if (backup == null) {
+					inverse.clearProperty(key);
+				}
+				else {
+					inverse.setProperty(key, backup);
+				}
+			});
+			return inverse;
 		}
 	}
-
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/util/SystemPropertiesExtension.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/util/SystemPropertiesExtension.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionConfigurationException;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.platform.commons.util.ToStringBuilder;
 
 /**
  * {@code Extension} which provides support for the following annotations.
@@ -102,7 +103,7 @@ final class SystemPropertiesExtension
 		// Try a complete restore first
 		findCompleteBackup(context) //
 				.ifPresentOrElse(System::setProperties, //
-						// A complete backup is not available, so use partial backup
+					// A complete backup is not available, so use partial backup
 					() -> findPartialBackup(context) //
 							.ifPresent(backup -> backup.applyTo(System.getProperties())));
 	}
@@ -188,6 +189,20 @@ final class SystemPropertiesExtension
 				}
 			});
 			return inverse;
+		}
+
+		@Override
+		public String toString() {
+			var builder = new ToStringBuilder(DeferredPropertyModification.class);
+			this.changes.forEach((key, value) -> {
+				if (REMOVED.equals(value)) {
+					builder.append(key, null);
+				}
+				else {
+					builder.append(key, value);
+				}
+			});
+			return builder.toString();
 		}
 
 		static DeferredPropertyModification create(List<ExtensionContext> allContexts) {

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/util/SystemPropertiesExtension.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/util/SystemPropertiesExtension.java
@@ -59,7 +59,7 @@ final class SystemPropertiesExtension
 
 	private void applyForAllContexts(ExtensionContext context) {
 		var allContexts = findAllExtensionContexts(context);
-		var modification = createDeferredPropertyModification(allContexts);
+		var modification = DeferredPropertyModification.create(allContexts);
 
 		// Please do not refactor out the common parts.
 		findFirstRestoreAnnotationContext(allContexts) //
@@ -80,86 +80,12 @@ final class SystemPropertiesExtension
 					});
 	}
 
-	private Optional<ExtensionContext> findFirstRestoreAnnotationContext(List<ExtensionContext> contexts) {
-		return contexts.stream() //
-				.filter(context -> isAnnotated(context.getElement(), RestoreSystemProperties.class)) //
-				.findFirst();
-	}
-
-	private DeferredPropertyModification createDeferredPropertyModification(List<ExtensionContext> allContexts) {
-		var modification = new DeferredPropertyModification();
-		// we have to apply the annotations from the outermost to the innermost context.
-		forEachInReverseOrder(allContexts, currentContext -> currentContext.getElement().ifPresent(element -> {
-			var entriesToClear = findEntriesToClear(element);
-			var entriesToSet = findEntriesToSet(element);
-
-			if (entriesToClear.isEmpty() && entriesToSet.isEmpty()) {
-				return;
-			}
-
-			preventClearAndSetSameEntries(element, entriesToClear, entriesToSet.keySet());
-			entriesToClear.forEach(modification::clearProperty);
-			entriesToSet.forEach(modification::setProperty);
-		}));
-		return modification;
-	}
-
-	private Set<String> findEntriesToClear(AnnotatedElement element) {
-		return findRepeatableAnnotations(element, ClearSystemProperty.class).stream() //
-				.map(ClearSystemProperty::key) //
-				// already distinct due to findRepeatableAnnotations
-				.collect(toSet());
-	}
-
-	private Map<String, String> findEntriesToSet(AnnotatedElement element) {
-		var entries = new HashMap<String, String>();
-		var duplicatePropertyNames = new HashSet<String>();
-
-		findRepeatableAnnotations(element, SetSystemProperty.class) //
-				.forEach(annotation -> {
-					var key = annotation.key();
-					if (entries.put(key, annotation.value()) != null) {
-						duplicatePropertyNames.add(key);
-					}
-				});
-
-		requireUniqueEntries(element, duplicatePropertyNames);
-		return entries;
-	}
-
-	private void preventClearAndSetSameEntries(AnnotatedElement element, Set<String> entriesToClear,
-			Set<String> entriesToSet) {
-		requireUniqueEntries(element, //
-			entriesToClear.stream() //
-					.filter(entriesToSet::contains) //
-					.collect(toSet()));
-	}
-
-	private static void requireUniqueEntries(AnnotatedElement annotatedElement, Set<String> duplicatePropertNames) {
-		if (duplicatePropertNames.isEmpty()) {
-			return;
-		}
-		throw new ExtensionConfigurationException(
-			"SystemPropertyExtension was configured to set/clear %s [%s] more than once by [%s]." //
-					.formatted( //
-						duplicatePropertNames.size() == 1 ? "property" : "properties", //
-						String.join(", ", duplicatePropertNames), //
-						annotatedElement //
-					));
-	}
-
-	private void storePartialBackup(ExtensionContext context, DeferredPropertyModification backup) {
-		getStore(context).put(createStoreKey(context, BackupType.PARTIAL), backup);
-	}
-
 	private void storeCompleteBackup(ExtensionContext context, Properties backup) {
 		getStore(context).put(createStoreKey(context, BackupType.COMPLETE), backup);
 	}
 
-	private Optional<Properties> findCompleteBackup(ExtensionContext context) {
-		var key = createStoreKey(context, BackupType.COMPLETE);
-		var backup = getStore(context).get(key, Properties.class);
-		return Optional.ofNullable(backup);
+	private void storePartialBackup(ExtensionContext context, DeferredPropertyModification backup) {
+		getStore(context).put(createStoreKey(context, BackupType.PARTIAL), backup);
 	}
 
 	@Override
@@ -176,18 +102,15 @@ final class SystemPropertiesExtension
 		// Try a complete restore first
 		findCompleteBackup(context) //
 				.ifPresentOrElse(System::setProperties, //
-					// A complete backup is not available, so use partial backup
+						// A complete backup is not available, so use partial backup
 					() -> findPartialBackup(context) //
 							.ifPresent(backup -> backup.applyTo(System.getProperties())));
 	}
 
-	private static List<ExtensionContext> findAllExtensionContexts(ExtensionContext context) {
-		var contexts = new ArrayList<ExtensionContext>();
-		do {
-			contexts.add(context);
-			context = context.getParent().orElse(null);
-		} while (context != null);
-		return contexts;
+	private Optional<Properties> findCompleteBackup(ExtensionContext context) {
+		var key = createStoreKey(context, BackupType.COMPLETE);
+		var backup = getStore(context).get(key, Properties.class);
+		return Optional.ofNullable(backup);
 	}
 
 	private Optional<DeferredPropertyModification> findPartialBackup(ExtensionContext context) {
@@ -196,12 +119,12 @@ final class SystemPropertiesExtension
 		return Optional.ofNullable(backup);
 	}
 
-	private ExtensionContext.Store getStore(ExtensionContext context) {
-		return context.getStore(ExtensionContext.Namespace.create(getClass()));
-	}
-
 	private StoreKey createStoreKey(ExtensionContext context, BackupType type) {
 		return new StoreKey(context.getUniqueId(), type);
+	}
+
+	private ExtensionContext.Store getStore(ExtensionContext context) {
+		return context.getStore(ExtensionContext.Namespace.create(getClass()));
 	}
 
 	private record StoreKey(String id, BackupType type) {
@@ -266,5 +189,82 @@ final class SystemPropertiesExtension
 			});
 			return inverse;
 		}
+
+		static DeferredPropertyModification create(List<ExtensionContext> allContexts) {
+			var modification = new DeferredPropertyModification();
+			// we have to apply the annotations from the outermost to the innermost context.
+			forEachInReverseOrder(allContexts, currentContext -> currentContext.getElement().ifPresent(element -> {
+				var entriesToClear = findEntriesToClear(element);
+				var entriesToSet = findEntriesToSet(element);
+
+				if (entriesToClear.isEmpty() && entriesToSet.isEmpty()) {
+					return;
+				}
+
+				requireNoClearAndSetSameEntries(element, entriesToClear, entriesToSet.keySet());
+				entriesToClear.forEach(modification::clearProperty);
+				entriesToSet.forEach(modification::setProperty);
+			}));
+			return modification;
+		}
+
+		private static Set<String> findEntriesToClear(AnnotatedElement element) {
+			return findRepeatableAnnotations(element, ClearSystemProperty.class).stream() //
+					.map(ClearSystemProperty::key) //
+					// already distinct due to findRepeatableAnnotations
+					.collect(toSet());
+		}
+
+		private static Map<String, String> findEntriesToSet(AnnotatedElement element) {
+			var entries = new HashMap<String, String>();
+			var duplicatePropertyNames = new HashSet<String>();
+
+			findRepeatableAnnotations(element, SetSystemProperty.class) //
+					.forEach(annotation -> {
+						var key = annotation.key();
+						if (entries.put(key, annotation.value()) != null) {
+							duplicatePropertyNames.add(key);
+						}
+					});
+
+			requireUniqueEntries(element, duplicatePropertyNames);
+			return entries;
+		}
+
+		private static void requireNoClearAndSetSameEntries(AnnotatedElement element, Set<String> entriesToClear,
+				Set<String> entriesToSet) {
+			requireUniqueEntries(element, //
+				entriesToClear.stream() //
+						.filter(entriesToSet::contains) //
+						.collect(toSet()));
+		}
+
+		private static void requireUniqueEntries(AnnotatedElement annotatedElement, Set<String> duplicatePropertNames) {
+			if (duplicatePropertNames.isEmpty()) {
+				return;
+			}
+			throw new ExtensionConfigurationException(
+				"SystemPropertyExtension was configured to set/clear %s [%s] more than once by [%s]." //
+						.formatted( //
+							duplicatePropertNames.size() == 1 ? "property" : "properties", //
+							String.join(", ", duplicatePropertNames), //
+							annotatedElement //
+						));
+		}
+	}
+
+	private static List<ExtensionContext> findAllExtensionContexts(ExtensionContext context) {
+		var contexts = new ArrayList<ExtensionContext>();
+		do {
+			contexts.add(context);
+			context = context.getParent().orElse(null);
+		} while (context != null);
+		return contexts;
+	}
+
+	private static Optional<ExtensionContext> findFirstRestoreAnnotationContext(List<ExtensionContext> contexts) {
+		return contexts.stream() //
+				.filter(context -> isAnnotated(context.getElement(), RestoreSystemProperties.class)) //
+				.findFirst();
 	}
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/util/SystemPropertiesModification.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/util/SystemPropertiesModification.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.api.util;
+
+import static java.util.stream.Collectors.toSet;
+import static org.junit.platform.commons.support.AnnotationSupport.findRepeatableAnnotations;
+import static org.junit.platform.commons.util.CollectionUtils.forEachInReverseOrder;
+
+import java.lang.reflect.AnnotatedElement;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
+import org.junit.jupiter.api.extension.ExtensionConfigurationException;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.platform.commons.util.ToStringBuilder;
+
+/**
+ * A sequence of modifications applied to a {@link Properties}
+ * object represented as a single modification.
+ */
+class SystemPropertiesModification {
+	private static final Object REMOVED = new Object();
+	private final Map<String, Object> changes = new HashMap<>();
+
+	private SystemPropertiesModification() {
+		/* no-op */
+	}
+
+	private void clearProperty(String key) {
+		changes.put(key, REMOVED);
+	}
+
+	private void setProperty(String key, Object value) {
+		changes.put(key, value);
+	}
+
+	void applyTo(Properties properties) {
+		changes.forEach((key, value) -> {
+			// For consistency don't use Properties::setProperty here
+			if (REMOVED.equals(value)) {
+				properties.remove(key);
+			}
+			else {
+				properties.put(key, value);
+			}
+		});
+	}
+
+	/**
+	 * Creates the inverse of calling {@link #applyTo(Properties)} such
+	 * that {@code modification.applyTo(properties); inverse.applyTo(properties);}
+	 * has no observable effect.
+	 */
+	SystemPropertiesModification createInverseApplyTo(Properties properties) {
+		SystemPropertiesModification inverse = new SystemPropertiesModification();
+		changes.keySet().forEach(key -> {
+			// Do not use Properties::getProperty here, since this would
+			// prevent backing up non-string values.
+			Object backup = properties.get(key);
+			if (backup == null) {
+				inverse.clearProperty(key);
+			}
+			else {
+				inverse.setProperty(key, backup);
+			}
+		});
+		return inverse;
+	}
+
+	@Override
+	public String toString() {
+		var builder = new ToStringBuilder(SystemPropertiesModification.class);
+		this.changes.forEach((key, value) -> {
+			if (REMOVED.equals(value)) {
+				builder.append(key, null);
+			}
+			else {
+				builder.append(key, value);
+			}
+		});
+		return builder.toString();
+	}
+
+	static SystemPropertiesModification create(List<ExtensionContext> allContexts) {
+		var modification = new SystemPropertiesModification();
+		// we have to apply the annotations from the outermost to the innermost context.
+		forEachInReverseOrder(allContexts, currentContext -> currentContext.getElement().ifPresent(element -> {
+			var entriesToClear = findEntriesToClear(element);
+			var entriesToSet = findEntriesToSet(element);
+
+			if (entriesToClear.isEmpty() && entriesToSet.isEmpty()) {
+				return;
+			}
+
+			requireNoClearAndSetSameEntries(element, entriesToClear, entriesToSet.keySet());
+			entriesToClear.forEach(modification::clearProperty);
+			entriesToSet.forEach(modification::setProperty);
+		}));
+		return modification;
+	}
+
+	private static Set<String> findEntriesToClear(AnnotatedElement element) {
+		return findRepeatableAnnotations(element, ClearSystemProperty.class).stream() //
+				.map(ClearSystemProperty::key) //
+				// already distinct due to findRepeatableAnnotations
+				.collect(toSet());
+	}
+
+	private static Map<String, String> findEntriesToSet(AnnotatedElement element) {
+		var entries = new HashMap<String, String>();
+		var duplicatePropertyNames = new HashSet<String>();
+
+		findRepeatableAnnotations(element, SetSystemProperty.class) //
+				.forEach(annotation -> {
+					var key = annotation.key();
+					if (entries.put(key, annotation.value()) != null) {
+						duplicatePropertyNames.add(key);
+					}
+				});
+
+		requireUniqueEntries(element, duplicatePropertyNames);
+		return entries;
+	}
+
+	private static void requireNoClearAndSetSameEntries(AnnotatedElement element, Set<String> entriesToClear,
+			Set<String> entriesToSet) {
+		requireUniqueEntries(element, //
+			entriesToClear.stream() //
+					.filter(entriesToSet::contains) //
+					.collect(toSet()));
+	}
+
+	private static void requireUniqueEntries(AnnotatedElement annotatedElement, Set<String> duplicatePropertNames) {
+		if (duplicatePropertNames.isEmpty()) {
+			return;
+		}
+		throw new ExtensionConfigurationException(
+			"SystemPropertyExtension was configured to set/clear %s [%s] more than once by [%s]." //
+					.formatted( //
+						duplicatePropertNames.size() == 1 ? "property" : "properties", //
+						String.join(", ", duplicatePropertNames), //
+						annotatedElement //
+					));
+	}
+}

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/util/SystemPropertiesExtensionTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/util/SystemPropertiesExtensionTests.java
@@ -41,14 +41,11 @@ import org.junit.jupiter.api.TestClassOrder;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtensionConfigurationException;
-import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.engine.AbstractJupiterTestEngineTests;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.junit.platform.testkit.engine.EngineExecutionResults;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoSettings;
 
 @DisplayName("System Properties Extension")
 class SystemPropertiesExtensionTests extends AbstractJupiterTestEngineTests {
@@ -373,47 +370,6 @@ class SystemPropertiesExtensionTests extends AbstractJupiterTestEngineTests {
 			}
 
 		}
-
-		@Nested
-		@DisplayName("RestorableContext Workflow Tests")
-		@MockitoSettings
-		class RestorableContextWorkflowTests {
-
-			@Mock
-			ExtensionContext context;
-
-			@Test
-			@DisplayName("Workflow of RestorableContext")
-			void workflowOfRestorableContexts() {
-				Properties initialState = System.getProperties(); //This is a live reference
-
-				try {
-					Properties returnedFromPrepareToEnter = spe.prepareToEnterRestorableContext(context);
-					Properties postPrepareToEnterSysProps = System.getProperties();
-					spe.prepareToExitRestorableContext(initialState);
-					Properties postPrepareToExitSysProps = System.getProperties();
-
-					assertThat(returnedFromPrepareToEnter) //
-							.withFailMessage(
-								"prepareToEnterRestorableContext should return actual original or deep copy") //
-							.isSameAs(initialState);
-
-					assertThat(returnedFromPrepareToEnter) //
-							.withFailMessage("prepareToEnterRestorableContext should replace the actual Sys Props") //
-							.isNotSameAs(postPrepareToEnterSysProps);
-
-					assertThat(postPrepareToEnterSysProps).isEqualTo(initialState);
-
-					assertThat(postPrepareToExitSysProps).isSameAs(initialState);
-
-				}
-				finally {
-					System.setProperties(initialState); // Ensure complete recovery
-				}
-			}
-
-		}
-
 	}
 
 	@Nested


### PR DESCRIPTION
The current implementation of the SystemPropertiesExtension stores an incremental backup for each ancestral context. Additionally, when first introduced the class was designed for extension resulting in quite some unnecessary indirection. Both make the implementation rather hard to understand.

By collecting all the mutations in a deferred application we only need a single backup for each context. Additionally, the deferred application of mutations can be used to create the inverse operation which can be stored as a partial backup.

When combined with the removal of the unnecessary indirection this reduces the `applyForAllContexts` and `restoreForAllContexts` to an rather uncomplicated if-else.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
