### PR TITLE
Pass `--no-fonts` to `javadoc` convention

### DIFF
--- a/gradle/plugins/common/src/main/kotlin/junitbuild.javadoc-conventions.gradle.kts
+++ b/gradle/plugins/common/src/main/kotlin/junitbuild.javadoc-conventions.gradle.kts
@@ -31,6 +31,7 @@ tasks.javadoc {
 			addBooleanOption("Xdoclint:all,-missing", true)
 			addBooleanOption("html5", true)
 			addBooleanOption("Werror", true)
+			addBooleanOption("-no-fonts", true)
 			addMultilineStringsOption("tag").value = listOf(
 				"apiNote:a:API Note:",
 				"implNote:a:Implementation Note:"
@@ -52,6 +53,10 @@ tasks.javadoc {
 					file.writeText(updatedContent)
 				}
 			}
+			// TODO Remove invalid import of `dejavu.css` due to `javadoc --no-fonts`
+			//	filesMatching("**/stylesheet.css") {
+			//	filter { line -> if (line.startsWith("@import url('fonts/")) null else line }
+			//	}
 	}
 }
 

--- a/gradle/plugins/common/src/main/kotlin/junitbuild.javadoc-conventions.gradle.kts
+++ b/gradle/plugins/common/src/main/kotlin/junitbuild.javadoc-conventions.gradle.kts
@@ -45,18 +45,20 @@ tasks.javadoc {
 	val targetUrl = "https://docs.junit.org/${version.toString().replace("-SNAPSHOT", "")}"
 	doLast {
 		destinationDir!!.walkTopDown()
-			.filter { it.extension == "html" }
 			.forEach { file ->
-				val content = file.readText()
-				if (content.contains(sourceUrl)) {
-					val updatedContent = content.replace(sourceUrl, targetUrl)
-					file.writeText(updatedContent)
+				if (file.extension == "html") {
+					val content = file.readText()
+					if (content.contains(sourceUrl)) {
+						val updatedContent = content.replace(sourceUrl, targetUrl)
+						file.writeText(updatedContent)
+					}
+				} else if (file.name == "stylesheet.css") {
+					// Remove invalid import of `dejavu.css` due to `javadoc --no-fonts`
+					val filteredLines = file.readLines()
+						.filter { !it.startsWith("@import url('fonts/") }
+					file.toPath().writeLines(filteredLines)
 				}
 			}
-			// TODO Remove invalid import of `dejavu.css` due to `javadoc --no-fonts`
-			//	filesMatching("**/stylesheet.css") {
-			//	filter { line -> if (line.startsWith("@import url('fonts/")) null else line }
-			//	}
 	}
 }
 


### PR DESCRIPTION
Please review this change to exclude font files from generated API documentation.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://docs.junit.org/snapshot/) and [Release Notes](https://docs.junit.org/snapshot/release-notes.html)
