### PR TITLE
Remove blanket outputDirectoryCreator from SuiteEngineTests

### DIFF
--- a/platform-tests/src/test/java/org/junit/platform/suite/engine/SuiteEngineTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/suite/engine/SuiteEngineTests.java
@@ -72,6 +72,7 @@ import org.junit.platform.suite.engine.testcases.JUnit4TestsTestCase;
 import org.junit.platform.suite.engine.testcases.MultipleTestsTestCase;
 import org.junit.platform.suite.engine.testcases.SingleFailingTestTestCase;
 import org.junit.platform.suite.engine.testcases.SingleTestTestCase;
+import org.junit.platform.suite.engine.testcases.SingleTestWithTestReporterTestCase;
 import org.junit.platform.suite.engine.testcases.TaggedTestTestCase;
 import org.junit.platform.suite.engine.testsuites.AbstractSuite;
 import org.junit.platform.suite.engine.testsuites.BlankSuiteDisplayNameSuite;
@@ -93,6 +94,7 @@ import org.junit.platform.suite.engine.testsuites.SelectByIdentifierSuite;
 import org.junit.platform.suite.engine.testsuites.SelectClassesSuite;
 import org.junit.platform.suite.engine.testsuites.SelectMethodsSuite;
 import org.junit.platform.suite.engine.testsuites.SelectorProcessingErrorTestSuite;
+import org.junit.platform.suite.engine.testsuites.SingleTestWithTestReporterSuite;
 import org.junit.platform.suite.engine.testsuites.SuiteDisplayNameSuite;
 import org.junit.platform.suite.engine.testsuites.SuiteSuite;
 import org.junit.platform.suite.engine.testsuites.SuiteWithErroneousTestSuite;
@@ -112,9 +114,8 @@ class SuiteEngineTests {
 	@ValueSource(classes = { SelectClassesSuite.class, InheritedSuite.class })
 	void selectClasses(Class<?> suiteClass) {
 		// @formatter:off
-		EngineTestKit.Builder testKit = EngineTestKit.engine(ENGINE_ID)
-				.selectors(selectClass(suiteClass))
-				.outputDirectoryCreator(hierarchicalOutputDirectoryCreator(outputDir));
+		var testKit = EngineTestKit.engine(ENGINE_ID)
+				.selectors(selectClass(suiteClass));
 
 		assertThat(testKit.discover().getDiscoveryIssues())
 				.isEmpty();
@@ -314,7 +315,6 @@ class SuiteEngineTests {
 		// @formatter:off
 		EngineTestKit.engine(ENGINE_ID)
 				.selectors(selectClass(SuiteSuite.class))
-				.outputDirectoryCreator(hierarchicalOutputDirectoryCreator(outputDir))
 				.execute()
 				.testEvents()
 				.assertThatEvents()
@@ -331,8 +331,7 @@ class SuiteEngineTests {
 				.selectors(
 						selectClass(SelectClassesSuite.class),
 						selectClass(MultipleSuite.class)
-				)
-				.outputDirectoryCreator(hierarchicalOutputDirectoryCreator(outputDir));
+				);
 
 		assertThat(testKit.discover().getDiscoveryIssues())
 				.isEmpty();
@@ -354,8 +353,7 @@ class SuiteEngineTests {
 				.selectors(
 						selectClass(SelectClassesSuite.class),
 						selectClass(MultipleSuite.class)
-				)
-				.outputDirectoryCreator(hierarchicalOutputDirectoryCreator(outputDir));
+				);
 
 		assertThat(testKit.discover().getDiscoveryIssues())
 				.isEmpty();
@@ -374,9 +372,8 @@ class SuiteEngineTests {
 		// @formatter:off
 		UniqueId uniqId = UniqueId.forEngine(ENGINE_ID)
 				.append(SuiteTestDescriptor.SEGMENT_TYPE, SelectClassesSuite.class.getName());
-		EngineTestKit.Builder builder = EngineTestKit.engine(ENGINE_ID)
-				.selectors(selectUniqueId(uniqId));
-			builder.outputDirectoryCreator(hierarchicalOutputDirectoryCreator(outputDir))
+		EngineTestKit.engine(ENGINE_ID)
+				.selectors(selectUniqueId(uniqId))
 				.execute()
 				.testEvents()
 				.assertThatEvents()
@@ -429,10 +426,9 @@ class SuiteEngineTests {
 				.append(ClassTestDescriptor.SEGMENT_TYPE, MultipleTestsTestCase.class.getName())
 				.append(TestMethodTestDescriptor.SEGMENT_TYPE, "test()");
 
-		EngineTestKit.Builder builder = EngineTestKit.engine(ENGINE_ID)
+		EngineTestKit.engine(ENGINE_ID)
 				.selectors(selectUniqueId(uniqueId))
-				.selectors(selectClass(SelectClassesSuite.class));
-			builder.outputDirectoryCreator(hierarchicalOutputDirectoryCreator(outputDir))
+				.selectors(selectClass(SelectClassesSuite.class))
 				.execute()
 				.testEvents()
 				.assertThatEvents()
@@ -593,9 +589,8 @@ class SuiteEngineTests {
 				.source(ClassSource.from(CyclicSuite.class))
 				.build();
 
-		EngineTestKit.Builder builder = EngineTestKit.engine(ENGINE_ID)
+		var testKit = EngineTestKit.engine(ENGINE_ID)
 				.selectors(selectClass(CyclicSuite.class));
-			var testKit = builder.outputDirectoryCreator(hierarchicalOutputDirectoryCreator(outputDir));
 
 		assertThat(testKit.discover().getDiscoveryIssues())
 				.containsExactly(issue);
@@ -625,9 +620,8 @@ class SuiteEngineTests {
 	@Test
 	void threePartCyclicSuite() {
 		// @formatter:off
-		EngineTestKit.Builder builder = EngineTestKit.engine(ENGINE_ID)
-				.selectors(selectClass(ThreePartCyclicSuite.PartA.class));
-			builder.outputDirectoryCreator(hierarchicalOutputDirectoryCreator(outputDir))
+		EngineTestKit.engine(ENGINE_ID)
+				.selectors(selectClass(ThreePartCyclicSuite.PartA.class))
 				.execute()
 				.allEvents()
 				.assertThatEvents()
@@ -660,9 +654,8 @@ class SuiteEngineTests {
 	@Test
 	void selectByIdentifier() {
 		// @formatter:off
-		EngineTestKit.Builder builder = EngineTestKit.engine(ENGINE_ID)
-				.selectors(selectClass(SelectByIdentifierSuite.class));
-			builder.outputDirectoryCreator(hierarchicalOutputDirectoryCreator(outputDir))
+		EngineTestKit.engine(ENGINE_ID)
+				.selectors(selectClass(SelectByIdentifierSuite.class))
 				.execute()
 				.testEvents()
 				.assertThatEvents()
@@ -674,13 +667,13 @@ class SuiteEngineTests {
 	@Test
 	void passesOutputDirectoryCreatorToEnginesInSuite() {
 		// @formatter:off
-		EngineTestKit.Builder builder = EngineTestKit.engine(ENGINE_ID)
-				.selectors(selectClass(SelectClassesSuite.class));
-			builder.outputDirectoryCreator(hierarchicalOutputDirectoryCreator(outputDir))
+		EngineTestKit.engine(ENGINE_ID)
+				.selectors(selectClass(SingleTestWithTestReporterSuite.class))
+				.outputDirectoryCreator(hierarchicalOutputDirectoryCreator(outputDir))
 				.execute()
 				.testEvents()
 				.assertThatEvents()
-				.haveExactly(1, event(test(SingleTestTestCase.class.getName()), finishedSuccessfully()));
+				.haveExactly(1, event(test(SingleTestWithTestReporterTestCase.class.getName()), finishedSuccessfully()));
 		// @formatter:on
 
 		assertThat(outputDir).isDirectoryRecursivelyContaining("glob:**/test.txt");

--- a/platform-tests/src/test/java/org/junit/platform/suite/engine/SuiteTestDescriptorTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/suite/engine/SuiteTestDescriptorTests.java
@@ -20,7 +20,6 @@ import java.util.Optional;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestReporter;
 import org.junit.jupiter.engine.descriptor.ClassTestDescriptor;
 import org.junit.jupiter.engine.descriptor.JupiterEngineDescriptor;
 import org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor;
@@ -44,8 +43,7 @@ class SuiteTestDescriptorTests {
 	final UniqueId jupiterEngineId = suiteId.append("engine", JupiterEngineDescriptor.ENGINE_ID);
 	final UniqueId testClassId = jupiterEngineId.append(ClassTestDescriptor.SEGMENT_TYPE,
 		SingleTestTestCase.class.getName());
-	final UniqueId methodId = testClassId.append(TestMethodTestDescriptor.SEGMENT_TYPE,
-		"test(%s)".formatted(TestReporter.class.getName()));
+	final UniqueId methodId = testClassId.append(TestMethodTestDescriptor.SEGMENT_TYPE, "test()");
 
 	final ConfigurationParameters configurationParameters = new EmptyConfigurationParameters();
 	final OutputDirectoryCreator outputDirectoryCreator = OutputDirectoryCreators.dummyOutputDirectoryCreator();

--- a/platform-tests/src/test/java/org/junit/platform/suite/engine/testcases/SingleTestWithTestReporterTestCase.java
+++ b/platform-tests/src/test/java/org/junit/platform/suite/engine/testcases/SingleTestWithTestReporterTestCase.java
@@ -10,15 +10,19 @@
 
 package org.junit.platform.suite.engine.testcases;
 
+import java.nio.file.Files;
+
+import org.junit.jupiter.api.MediaType;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestReporter;
 
 /**
- * @since 1.8
+ * @since 6.2
  */
-public class SingleTestTestCase {
+public class SingleTestWithTestReporterTestCase {
 
 	@Test
-	void test() {
-
+	void test(TestReporter testReporter) {
+		testReporter.publishFile("test.txt", MediaType.TEXT_PLAIN_UTF_8, file -> Files.writeString(file, "test"));
 	}
 }

--- a/platform-tests/src/test/java/org/junit/platform/suite/engine/testsuites/SingleTestWithTestReporterSuite.java
+++ b/platform-tests/src/test/java/org/junit/platform/suite/engine/testsuites/SingleTestWithTestReporterSuite.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2015-2026 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.suite.engine.testsuites;
+
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
+import org.junit.platform.suite.engine.testcases.SingleTestWithTestReporterTestCase;
+
+/**
+ * @since 6.2
+ */
+@Suite
+@SelectClasses(SingleTestWithTestReporterTestCase.class)
+public class SingleTestWithTestReporterSuite {
+}


### PR DESCRIPTION
The output directory is only needed for the `passesOutputDirectoryCreatorToEnginesInSuite` test, but because that test uses the `SelectClassesSuite` every other test also needed to set the output directory. This makes the tests larger than strictly necessary.

By removing the `TestReporter` from the `SingleTestTestCase` and adding a dedicated `SingleTestWithTestReporterTestCase` we can make all the suite tests a bit more focused.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://docs.junit.org/snapshot/) and [Release Notes](https://docs.junit.org/snapshot/release-notes.html)
