### PR TITLE
Cache Antora collector extension output on GitHub Actions

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -69,6 +69,8 @@ jobs:
         run: bundle install
       - name: Download dependencies (NPM)
         run: npm ci
+      - name: Expose GitHub Actions environment for collector-cache Antora extension
+        uses: crazy-max/ghaction-github-runtime@04d248b84655b509d8c44dc1d6f990c879747487 # v4.0.0
       - name: Run Antora
         run: npm run build
       - name: Check out docs.junit.org repo

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /build/
 /node_modules/
 /.idea/
+/*.iml

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ This branch contains the Antora project for building JUnit's documentation site.
 
 It requires Node.js (for Antora) and Ruby (for asciidoctor.pdf).
 
-A `.tool-versions` file can be used with `asdf`:
+A `.tool-versions` file can be used with `asdf` or `mise`:
 
 ```
-asdf install
+asdf install # or mise install
 npm install
 bundle install
 ```

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -1,5 +1,8 @@
 antora:
   extensions:
+    - require: './extensions/collector-cache.js'
+      excludes:
+        - main
     - '@antora/collector-extension'
     - require: '@antora/html-single-extension'
       config_file: ./antora-assembler-html.yml

--- a/extensions/cache-scandir/copy-recursive.js
+++ b/extensions/cache-scandir/copy-recursive.js
@@ -1,0 +1,29 @@
+// Modified version of https://github.com/spring-io/antora-extensions/blob/fee110d465480db87f029426bfab7da8068e282e/lib/cache-scandir/copy-recursive.js
+// SPDX-License-Identifier: Apache-2.0
+
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+
+const copyRecursiveSync = function (src, dest) {
+  const exists = fs.existsSync(src)
+  const stats = exists && fs.statSync(src)
+  const isDirectory = exists && stats.isDirectory()
+  if (isDirectory) {
+    if (!fs.existsSync(dest)) {
+      fs.mkdirSync(dest, { recursive: true })
+    }
+    fs.readdirSync(src).forEach(function (childItemName) {
+      copyRecursiveSync(path.join(src, childItemName), path.join(dest, childItemName))
+    })
+  } else {
+    fs.copyFileSync(src, dest)
+  }
+}
+
+function copyRecursive (scanDir, cacheDir) {
+  copyRecursiveSync(scanDir, cacheDir)
+}
+
+module.exports = copyRecursive

--- a/extensions/cache-scandir/index.js
+++ b/extensions/cache-scandir/index.js
@@ -1,0 +1,11 @@
+// Modified version of https://github.com/spring-io/antora-extensions/blob/fee110d465480db87f029426bfab7da8068e282e/lib/cache-scandir/index.js
+// SPDX-License-Identifier: Apache-2.0
+
+'use strict'
+
+const copyRecursive = require('./copy-recursive')
+
+const [, , ...args] = process.argv
+const [scanDir, cacheDir] = args
+
+copyRecursive(scanDir, cacheDir)

--- a/extensions/collector-cache.js
+++ b/extensions/collector-cache.js
@@ -7,30 +7,22 @@ const expandPath = require('@antora/expand-path-helper')
 const ospath = require('path')
 const resolvedCopyRecursiveJs = require.resolve('./cache-scandir')
 const { createHash } = require('crypto')
+// @actions/cache is ESM-only, so load it via dynamic import from this CommonJS module.
+const cacheLib = import('@actions/cache')
 
 module.exports.register = function ({ playbook, config = {} }) {
   const logger = this.getLogger('collector-cache')
-  const siteUrl = playbook.site?.url
   const excludes = config.excludes || []
-  const configuredBaseCacheUrl = config.baseCacheUrl
-  if (!siteUrl && !configuredBaseCacheUrl) {
-    throw new Error(
-      "One of playbook site.url or collector-cache plugin's base_cache_url property is required."
-    )
-  }
-  const baseCacheUrl = configuredBaseCacheUrl || siteUrl + '/.cache'
   const getUserCacheDir = this.require('cache-directory')
   const fs = this.require('fs')
-  const decompress = this.require('decompress')
-  const { concat: get } = this.require('simple-get')
 
-  const outputDir = ospath.join(playbook.dir, 'build/antora/collector-cache/.cache')
-  if (!fs.existsSync(outputDir)) {
-    fs.mkdirSync(outputDir, { recursive: true })
-  }
-
-  const zipInfo = []
+  const cacheInfo = []
   this.once('contentAggregated', async ({ playbook, contentAggregate }) => {
+    const cache = await cacheLib
+    const cacheAvailable = cache.isFeatureAvailable()
+    if (!cacheAvailable) {
+      logger.info('GitHub Actions cache is not available; skipping restore/save operations')
+    }
     const baseCacheDir = getBaseCacheDir(getUserCacheDir, playbook)
     for (const { origins } of contentAggregate) {
       for (const origin of origins) {
@@ -42,23 +34,20 @@ module.exports.register = function ({ playbook, config = {} }) {
           const shortref = refhash.slice(0, 7)
           const cacheDirName = `${shortref}-${refname}`
           const cacheDir = ospath.join(baseCollectorCacheCacheDir, cacheDirName)
-          const zipFileName = `${cacheDirName}.zip`
-          const zipCacheFile = ospath.join(outputDir, zipFileName)
+          const cacheKey = `collector-cache-${repositoryCacheDirName}-${cacheDirName}`
           if (!fs.existsSync(baseCollectorCacheCacheDir)) {
             fs.mkdirSync(baseCollectorCacheCacheDir, { recursive: true })
           }
-          if (!fs.existsSync(cacheDir)) {
-            // try and restore from URL by downloading zip
-            const cacheUrl = `${baseCacheUrl}/${cacheDirName}.zip`
-            const content = await download(get, cacheUrl).then((content) => content)
-            if (content) {
-              fs.writeFileSync(zipCacheFile, content)
-              await decompress(zipCacheFile, ospath.join(baseCollectorCacheCacheDir, cacheDirName)).then((files) =>
-                logger.debug(`Successfully unzipped ${zipCacheFile}.`)
-              )
-              logger.info(`Successfully restored cache from ${cacheUrl}`)
+          if (cacheAvailable && !fs.existsSync(cacheDir)) {
+            // try and restore from the GitHub Actions cache
+            const restoredKey = await cache.restoreCache([cacheDir], cacheKey).catch((err) => {
+              logger.warn(`Failed to restore cache for key ${cacheKey}: ${err.message}`)
+              return undefined
+            })
+            if (restoredKey) {
+              logger.info(`Successfully restored cache for key ${cacheKey}`)
             } else {
-              logger.info(`Unable to restore cache from ${cacheUrl}`)
+              logger.info(`Unable to restore cache for key ${cacheKey}`)
             }
           }
           if (fs.existsSync(cacheDir)) {
@@ -84,31 +73,23 @@ module.exports.register = function ({ playbook, config = {} }) {
                 cachedConfig.push.apply(cachedConfig, cachedCollectorConfig)
               })
             })
-            // add the zip of cache to be published
-            zipInfo.push({ cacheDir, zipCacheFile })
+            if (cacheAvailable) {
+              cacheInfo.push({ cacheDir, cacheKey })
+            }
           }
         }
       }
     }
   })
   this.once('beforePublish', async () => {
-    for (const info of zipInfo) {
-      await zip(fs, logger, info.cacheDir, info.zipCacheFile)
+    if (cacheInfo) {
+      const cache = await cacheLib
+      for (const {cacheDir, cacheKey} of cacheInfo) {
+        await cache.saveCache([cacheDir], cacheKey)
+        logger.info(`Saved cache for key ${cacheKey}`)
+      }
     }
   })
-}
-
-function download (get, url) {
-  return new Promise((resolve, reject) =>
-    get({ url }, (err, response, contents) => {
-      // return resolve(undefined)
-      if (response?.statusCode === 404) return resolve(undefined)
-      if (err) return reject(err)
-      if (response?.statusCode === 200) return resolve(contents)
-      const message = `${url} returned response code ${response?.statusCode} (${response?.statusMessage})`
-      reject(Object.assign(new Error(message), { name: 'HTTPError' }))
-    })
-  )
 }
 
 function getBaseCacheDir (getUserCacheDir, { dir: dot, runtime: { cacheDir: preferredDir } = {} }) {
@@ -131,41 +112,4 @@ function createCachedCollectorConfig (scanDir, cacheDir, subDir) {
       },
     },
   ]
-}
-
-const zip = async function (fs, logger, src, destination) {
-  const path = require('path')
-  const { ZipArchive } = await import('archiver')
-  const destParent = path.dirname(destination)
-  if (!fs.existsSync(destParent)) {
-    fs.mkdirs(destParent, { recursive: true })
-  }
-  const output = fs.createWriteStream(destination)
-  const archive = new ZipArchive({
-    zlib: { level: 9 }, // Sets the compression level.
-  })
-
-  // good practice to catch warnings (ie stat failures and other non-blocking errors)
-  archive.on('warning', function (err) {
-    if (err.code === 'ENOENT') {
-      // log warning
-    } else {
-      // throw error
-      throw err
-    }
-  })
-
-  // good practice to catch this error explicitly
-  archive.on('error', function (err) {
-    throw err
-  })
-
-  // pipe archive data to the file
-  archive.pipe(output)
-
-  archive.directory(src, false)
-
-  await archive.finalize()
-
-  logger.info(`Saving ${src} into ${destination}`)
 }

--- a/extensions/collector-cache.js
+++ b/extensions/collector-cache.js
@@ -1,0 +1,171 @@
+// Modified version of https://github.com/spring-io/antora-extensions/blob/fee110d465480db87f029426bfab7da8068e282e/lib/inject-collector-cache-config-extension.js
+// SPDX-License-Identifier: Apache-2.0
+
+'use strict'
+
+const expandPath = require('@antora/expand-path-helper')
+const ospath = require('path')
+const resolvedCopyRecursiveJs = require.resolve('./cache-scandir')
+const { createHash } = require('crypto')
+
+module.exports.register = function ({ playbook, config = {} }) {
+  const logger = this.getLogger('collector-cache')
+  const siteUrl = playbook.site?.url
+  const excludes = config.excludes || []
+  const configuredBaseCacheUrl = config.baseCacheUrl
+  if (!siteUrl && !configuredBaseCacheUrl) {
+    throw new Error(
+      "One of playbook site.url or collector-cache plugin's base_cache_url property is required."
+    )
+  }
+  const baseCacheUrl = configuredBaseCacheUrl || siteUrl + '/.cache'
+  const getUserCacheDir = this.require('cache-directory')
+  const fs = this.require('fs')
+  const decompress = this.require('decompress')
+  const { concat: get } = this.require('simple-get')
+
+  const outputDir = ospath.join(playbook.dir, 'build/antora/collector-cache/.cache')
+  if (!fs.existsSync(outputDir)) {
+    fs.mkdirSync(outputDir, { recursive: true })
+  }
+
+  const zipInfo = []
+  this.once('contentAggregated', async ({ playbook, contentAggregate }) => {
+    const baseCacheDir = getBaseCacheDir(getUserCacheDir, playbook)
+    for (const { origins } of contentAggregate) {
+      for (const origin of origins) {
+        const { url, gitdir, refhash, worktree, descriptor, refname } = origin
+        const repositoryCacheDirName = generateWorktreeFolderName({ url, gitdir, worktree })
+        const baseCollectorCacheCacheDir = ospath.join(baseCacheDir, 'collector-cache', repositoryCacheDirName)
+        const collectorConfig = descriptor?.ext?.collector
+        if (collectorConfig !== undefined && !excludes.includes(refname)) {
+          const shortref = refhash.slice(0, 7)
+          const cacheDirName = `${shortref}-${refname}`
+          const cacheDir = ospath.join(baseCollectorCacheCacheDir, cacheDirName)
+          const zipFileName = `${cacheDirName}.zip`
+          const zipCacheFile = ospath.join(outputDir, zipFileName)
+          if (!fs.existsSync(baseCollectorCacheCacheDir)) {
+            fs.mkdirSync(baseCollectorCacheCacheDir, { recursive: true })
+          }
+          if (!fs.existsSync(cacheDir)) {
+            // try and restore from URL by downloading zip
+            const cacheUrl = `${baseCacheUrl}/${cacheDirName}.zip`
+            const content = await download(get, cacheUrl).then((content) => content)
+            if (content) {
+              fs.writeFileSync(zipCacheFile, content)
+              await decompress(zipCacheFile, ospath.join(baseCollectorCacheCacheDir, cacheDirName)).then((files) =>
+                logger.debug(`Successfully unzipped ${zipCacheFile}.`)
+              )
+              logger.info(`Successfully restored cache from ${cacheUrl}`)
+            } else {
+              logger.info(`Unable to restore cache from ${cacheUrl}`)
+            }
+          }
+          if (fs.existsSync(cacheDir)) {
+            // use the cache
+            origin.descriptor.ext.collector = {
+              scan: {
+                dir: cacheDir,
+              },
+            }
+            logger.info(`Using the cache found at ${cacheDir}`)
+          } else {
+            const cachedConfig = []
+            const normalizedCollectorConfig = Array.isArray(collectorConfig) ? collectorConfig : [collectorConfig]
+            logger.info(`Configuring collector for caching (url: ${url} | ref: ${refname})`)
+            origin.descriptor.ext.collector = cachedConfig
+            normalizedCollectorConfig.forEach((collector) => {
+              cachedConfig.push(collector)
+              const { scan: scanConfig = [] } = collector
+              const normalizedScanConfigs = Array.isArray(scanConfig) ? scanConfig : [scanConfig]
+              normalizedScanConfigs.forEach((normalizedScanConfig) => {
+                // cache the output of the build
+                const cachedCollectorConfig = createCachedCollectorConfig(normalizedScanConfig.dir, cacheDir, normalizedScanConfig.into)
+                cachedConfig.push.apply(cachedConfig, cachedCollectorConfig)
+              })
+            })
+            // add the zip of cache to be published
+            zipInfo.push({ cacheDir, zipCacheFile })
+          }
+        }
+      }
+    }
+  })
+  this.once('beforePublish', async () => {
+    for (const info of zipInfo) {
+      await zip(fs, logger, info.cacheDir, info.zipCacheFile)
+    }
+  })
+}
+
+function download (get, url) {
+  return new Promise((resolve, reject) =>
+    get({ url }, (err, response, contents) => {
+      // return resolve(undefined)
+      if (response?.statusCode === 404) return resolve(undefined)
+      if (err) return reject(err)
+      if (response?.statusCode === 200) return resolve(contents)
+      const message = `${url} returned response code ${response?.statusCode} (${response?.statusMessage})`
+      reject(Object.assign(new Error(message), { name: 'HTTPError' }))
+    })
+  )
+}
+
+function getBaseCacheDir (getUserCacheDir, { dir: dot, runtime: { cacheDir: preferredDir } = {} }) {
+  return preferredDir == null
+    ? getUserCacheDir(`antora${process.env.NODE_ENV === 'test' ? '-test' : ''}`) || ospath.join(dot, '.cache/antora')
+    : expandPath(preferredDir, { dot })
+}
+
+function generateWorktreeFolderName ({ url, gitdir, worktree }) {
+  if (worktree === undefined) return ospath.basename(gitdir, '.git')
+  return `${url.substr(url.lastIndexOf('/') + 1)}-${createHash('sha1').update(url).digest('hex')}`
+}
+
+function createCachedCollectorConfig (scanDir, cacheDir, subDir) {
+  return [
+    {
+      run: {
+        command: `\${{env.NODE}} '${resolvedCopyRecursiveJs}' '.' '${cacheDir}${subDir ? `/${subDir}` : ''}'`,
+        dir: scanDir,
+      },
+    },
+  ]
+}
+
+const zip = async function (fs, logger, src, destination) {
+  const path = require('path')
+  const { ZipArchive } = await import('archiver')
+  const destParent = path.dirname(destination)
+  if (!fs.existsSync(destParent)) {
+    fs.mkdirs(destParent, { recursive: true })
+  }
+  const output = fs.createWriteStream(destination)
+  const archive = new ZipArchive({
+    zlib: { level: 9 }, // Sets the compression level.
+  })
+
+  // good practice to catch warnings (ie stat failures and other non-blocking errors)
+  archive.on('warning', function (err) {
+    if (err.code === 'ENOENT') {
+      // log warning
+    } else {
+      // throw error
+      throw err
+    }
+  })
+
+  // good practice to catch this error explicitly
+  archive.on('error', function (err) {
+    throw err
+  })
+
+  // pipe archive data to the file
+  archive.pipe(output)
+
+  archive.directory(src, false)
+
+  await archive.finalize()
+
+  logger.info(`Saving ${src} into ${destination}`)
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "docs.junit.org",
       "dependencies": {
+        "@actions/cache": "^6.1.0",
         "@antora/collector-extension": "1.0.3",
         "@antora/html-single-extension": "1.0.0-beta.20",
         "@antora/lunr-extension": "1.0.0-alpha.13",
@@ -18,6 +19,96 @@
       "devDependencies": {
         "antora": "3.2.0-rc.2"
       }
+    },
+    "node_modules/@actions/cache": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@actions/cache/-/cache-6.1.0.tgz",
+      "integrity": "sha512-LVqybSbzhBp2uAETOQ3HnVjXA4AcjavgMH+LCr+cjgO+PZfciv/1QAgoW+esXBaAhvDid+vXeV70GGJpAh4V5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@actions/core": "^3.0.1",
+        "@actions/exec": "^3.0.0",
+        "@actions/glob": "^0.6.1",
+        "@actions/http-client": "^4.0.1",
+        "@actions/io": "^3.0.2",
+        "@azure/core-rest-pipeline": "^1.23.0",
+        "@azure/storage-blob": "^12.31.0",
+        "@protobuf-ts/runtime-rpc": "^2.11.1",
+        "semver": "^7.7.4"
+      }
+    },
+    "node_modules/@actions/core": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-3.0.1.tgz",
+      "integrity": "sha512-a6d/Nwahm9fliVGRhdhofo40HjHQasUPusmc7vBfyky+7Z+P2A1J68zyFVaNcEclc/Se+eO595oAr5nwEIoIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@actions/exec": "^3.0.0",
+        "@actions/http-client": "^4.0.0"
+      }
+    },
+    "node_modules/@actions/exec": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-3.0.0.tgz",
+      "integrity": "sha512-6xH/puSoNBXb72VPlZVm7vQ+svQpFyA96qdDBvhB8eNZOE8LtPf9L4oAsfzK/crCL8YZ+19fKYVnM63Sl+Xzlw==",
+      "license": "MIT",
+      "dependencies": {
+        "@actions/io": "^3.0.2"
+      }
+    },
+    "node_modules/@actions/glob": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@actions/glob/-/glob-0.6.1.tgz",
+      "integrity": "sha512-K4+2Ac5ILcf2ySdJCha+Pop9NcKjxqCL4xL4zI50dgB2PbXgC0+AcP011xfH4Of6b4QEJJg8dyZYv7zl4byTsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@actions/core": "^3.0.0",
+        "minimatch": "^3.0.4"
+      }
+    },
+    "node_modules/@actions/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/@actions/glob/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@actions/glob/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@actions/http-client": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-4.0.1.tgz",
+      "integrity": "sha512-+Nvd1ImaOZBSoPbsUtEhv+1z99H12xzncCkz0a3RuehINE81FZSe2QTj3uvAPTcJX/SCzUQHQ0D1GrPMbrPitg==",
+      "license": "MIT",
+      "dependencies": {
+        "tunnel": "^0.0.6",
+        "undici": "^6.23.0"
+      }
+    },
+    "node_modules/@actions/io": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@actions/io/-/io-3.0.2.tgz",
+      "integrity": "sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==",
+      "license": "MIT"
     },
     "node_modules/@antora/asciidoc-loader": {
       "version": "3.2.0-rc.2",
@@ -506,6 +597,208 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@azure/abort-controller": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+      "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-auth": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.10.1.tgz",
+      "integrity": "sha512-ykRMW8PjVAn+RS6ww5cmK9U2CyH9p4Q88YJwvUslfuMmN98w/2rdGRLPqJYObapBCdzBVeDgYWdJnFPFb7qzpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-util": "^1.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-client": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.10.2.tgz",
+      "integrity": "sha512-1D2LpsU7y9xrqKjdIbsB7PlrRePw0xsVV8p+AKTlzITrWmscajryfJCdDJB/oGwvDI5HmRo04eMMADB67uwAwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-rest-pipeline": "^1.22.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-http-compat": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-http-compat/-/core-http-compat-2.4.0.tgz",
+      "integrity": "sha512-f1P96IB399YiN2ARYHP7EpZi3Bf3wH4SN2lGzrw7JVwm7bbsVYtf2iKSBwTywD2P62NOPZGHFSZi+6jjb75JuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@azure/core-client": "^1.10.0",
+        "@azure/core-rest-pipeline": "^1.22.0"
+      }
+    },
+    "node_modules/@azure/core-lro": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-lro/-/core-lro-2.7.2.tgz",
+      "integrity": "sha512-0YIpccoX8m/k00O7mDDMdJpbr6mf1yWo2dfmxt5A8XVZVVMz2SSKaEbMCeJRvgQ0IaSlqhjT47p4hVIRRy90xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-util": "^1.2.0",
+        "@azure/logger": "^1.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-paging": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-paging/-/core-paging-1.6.2.tgz",
+      "integrity": "sha512-YKWi9YuCU04B55h25cnOYZHxXYtEvQEbKST5vqRga7hWY9ydd3FZHdeQF8pyh+acWZvppw13M/LMGx0LABUVMA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-rest-pipeline": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.24.0.tgz",
+      "integrity": "sha512-PpLsoDQ3AMmKZ0VU+0GrmqMxgp/sExjlVm4R+nLWngeoEGAzOIPVifaxKGU5gMv+nWELUoHfvrolWD+ZS/nFJg==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
+        "@typespec/ts-http-runtime": "^0.3.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-tracing": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.3.1.tgz",
+      "integrity": "sha512-9MWKevR7Hz8kNzzPLfX4EAtGM2b8mr50HPDBvio96bURP/9C+HjdH3sBlLSNNrvRAr5/k/svoH457gB5IKpmwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-util": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.13.1.tgz",
+      "integrity": "sha512-XPArKLzsvl0Hf0CaGyKHUyVgF7oDnhKoP85Xv6M4StF/1AhfORhZudHtOyf2s+FcbuQ9dPRAjB8J2KvRRMUK2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-xml": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-xml/-/core-xml-1.5.1.tgz",
+      "integrity": "sha512-xcNRHqCoSp4AunOALEae6A8f3qATb83gSrm31Iqb01OzblvC3/W/bfXozcq78EzIdzZzuH1bZ2NvRR0TdX709w==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-parser": "^5.5.9",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/logger": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.3.0.tgz",
+      "integrity": "sha512-fCqPIfOcLE+CGqGPd66c8bZpwAji98tZ4JI9i/mlTNTlsIWslCfpg48s/ypyLxZTump5sypjrKn2/kY7q8oAbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/storage-blob": {
+      "version": "12.33.0",
+      "resolved": "https://registry.npmjs.org/@azure/storage-blob/-/storage-blob-12.33.0.tgz",
+      "integrity": "sha512-2SX8oP8PyblUcAFZSg39c8Ls+tFjavM6sBeV+qpw33mRzRhI/5hrFJmJ/x0H9xx5l6ECPvgSP8uPxqTeVbHNIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-client": "^1.9.3",
+        "@azure/core-http-compat": "^2.2.0",
+        "@azure/core-lro": "^2.2.0",
+        "@azure/core-paging": "^1.6.2",
+        "@azure/core-rest-pipeline": "^1.19.1",
+        "@azure/core-tracing": "^1.2.0",
+        "@azure/core-util": "^1.11.0",
+        "@azure/core-xml": "^1.4.5",
+        "@azure/logger": "^1.1.4",
+        "@azure/storage-common": "^12.4.1",
+        "events": "^3.0.0",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/storage-common": {
+      "version": "12.4.1",
+      "resolved": "https://registry.npmjs.org/@azure/storage-common/-/storage-common-12.4.1.tgz",
+      "integrity": "sha512-t14unw/WofGDUi7TKJrsyXyPsN+NLgRm7hMaq0llxNmTIzt7f257+6LE6FKIJPh88zLj6M7LPvzve0fEYg/L3A==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-http-compat": "^2.2.0",
+        "@azure/core-rest-pipeline": "^1.24.0",
+        "@azure/core-tracing": "^1.2.0",
+        "@azure/core-util": "^1.11.0",
+        "@azure/logger": "^1.1.4",
+        "events": "^3.3.0",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@babel/runtime": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
@@ -576,6 +869,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@protobuf-ts/runtime": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@protobuf-ts/runtime/-/runtime-2.11.1.tgz",
+      "integrity": "sha512-KuDaT1IfHkugM2pyz+FwiY80ejWrkH1pAtOBOZFuR6SXEFTsnb/jiQWQ1rCIrcKx2BtyxnxW6BWwsVSA/Ie+WQ==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
+    "node_modules/@protobuf-ts/runtime-rpc": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@protobuf-ts/runtime-rpc/-/runtime-rpc-2.11.1.tgz",
+      "integrity": "sha512-4CqqUmNA+/uMz00+d3CYKgElXO9VrEbucjnBFEjqI4GuDrEQ32MaI3q+9qPBvIGOlL4PmHXrzM32vBPWRhQKWQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@protobuf-ts/runtime": "^2.11.1"
+      }
+    },
     "node_modules/@solid-primitives/refs": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@solid-primitives/refs/-/refs-1.1.3.tgz",
@@ -634,6 +942,20 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@typespec/ts-http-runtime": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.6.tgz",
+      "integrity": "sha512-jIXhD0eWQ1JA6ln/5Dltyx22UxWNrw0hZmhy2rlv6m6KgF7kplHx3g0fzi09lNmTJQRR91OlemYp3xFnvDK9og==",
+      "license": "MIT",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -644,6 +966,15 @@
       },
       "engines": {
         "node": ">=6.5"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/antora": {
@@ -1138,6 +1469,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "license": "MIT"
+    },
     "node_modules/convict": {
       "version": "6.2.5",
       "resolved": "https://registry.npmjs.org/convict/-/convict-6.2.5.tgz",
@@ -1188,6 +1525,23 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
     },
     "node_modules/decompress": {
       "version": "4.2.1",
@@ -1892,6 +2246,32 @@
         "entities": "^4.5.0"
       }
     },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -2287,6 +2667,12 @@
         "minimist": "^1.2.5"
       }
     },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/multi-progress": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/multi-progress/-/multi-progress-4.0.0.tgz",
@@ -2668,6 +3054,18 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "license": "MIT"
     },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/seroval": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.4.tgz",
@@ -2964,6 +3362,21 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
+    },
     "node_modules/typed-array-buffer": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
@@ -3023,6 +3436,15 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/unxhr": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "antora": "3.2.0-rc.2"
   },
   "dependencies": {
+    "@actions/cache": "^6.1.0",
     "@antora/collector-extension": "1.0.3",
     "@antora/html-single-extension": "1.0.0-beta.20",
     "@antora/lunr-extension": "1.0.0-alpha.13",


### PR DESCRIPTION
- **Document `mise` as alternative to `asdf`**
- **Ignore IntelliJ IDEA config files**
- **Initial import of modified version of Spring's collector cache extension**
- **Use GitHub Actions cache for collector cache entries**

---

**Before:** 12m 36s
**After:**  5m 28s
