### PR TITLE
Validate argument max length configuration parameter

### DIFF
--- a/documentation/modules/ROOT/partials/release-notes/release-notes-6.2.0-M1.adoc
+++ b/documentation/modules/ROOT/partials/release-notes/release-notes-6.2.0-M1.adoc
@@ -39,7 +39,9 @@ repository on GitHub.
 [[v6.2.0-M1-junit-jupiter-bug-fixes]]
 ==== Bug Fixes
 
-* ❓
+* The `junit.jupiter.params.displayname.argument.maxlength` configuration parameter is
+  now validated and rejected with a clear error when set to a non-positive value instead
+  of causing parameterized tests to fail with an internal exception.
 
 [[v6.2.0-M1-junit-jupiter-deprecations-and-breaking-changes]]
 ==== Deprecations and Breaking Changes

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedInvocationNameFormatter.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedInvocationNameFormatter.java
@@ -74,6 +74,8 @@ class ParameterizedInvocationNameFormatter {
 
 		int argumentMaxLength = extensionContext.getConfigurationParameter(ARGUMENT_MAX_LENGTH_KEY, Integer::parseInt) //
 				.orElse(512);
+		Preconditions.condition(argumentMaxLength > 0,
+			() -> ARGUMENT_MAX_LENGTH_KEY + " must be a positive number: " + argumentMaxLength);
 
 		return new ParameterizedInvocationNameFormatter(pattern, extensionContext.getDisplayName(), declarationContext,
 			argumentMaxLength);

--- a/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java
@@ -492,8 +492,8 @@ class ParameterizedTestIntegrationTests extends AbstractJupiterTestEngineTests {
 				.selectors(selectMethod(TestCase.class, "testWithCsvSource", String.class.getName())) //
 				.execute();
 		results.allEvents().assertThatEvents() //
-				.haveExactly(1, event(container(), finishedWithFailure(message(msg -> msg.contains(
-					ParameterizedInvocationNameFormatter.ARGUMENT_MAX_LENGTH_KEY + " must be a positive number")))));
+				.haveExactly(1, event(container(), finishedWithFailure(message(
+					ParameterizedInvocationNameFormatter.ARGUMENT_MAX_LENGTH_KEY + " must be a positive number: 0"))));
 	}
 
 	@Test

--- a/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java
@@ -486,6 +486,17 @@ class ParameterizedTestIntegrationTests extends AbstractJupiterTestEngineTests {
 	}
 
 	@Test
+	void failsContainerWhenArgumentMaxLengthIsNotPositive() {
+		var results = EngineTestKit.engine(new JupiterTestEngine()) //
+				.configurationParameter(ParameterizedInvocationNameFormatter.ARGUMENT_MAX_LENGTH_KEY, "0") //
+				.selectors(selectMethod(TestCase.class, "testWithCsvSource", String.class.getName())) //
+				.execute();
+		results.allEvents().assertThatEvents() //
+				.haveExactly(1, event(container(), finishedWithFailure(message(msg -> msg.contains(
+					ParameterizedInvocationNameFormatter.ARGUMENT_MAX_LENGTH_KEY + " must be a positive number")))));
+	}
+
+	@Test
 	void displayNamePatternFromConfiguration() {
 		var results = EngineTestKit.engine(new JupiterTestEngine()) //
 				.configurationParameter(ParameterizedInvocationNameFormatter.DISPLAY_NAME_PATTERN_KEY, "{index}") //


### PR DESCRIPTION
This validates the `junit.jupiter.params.displayname.argument.maxlength` configuration parameter and fails fast with a clear configuration error when the value is less than `1`.

Previously the value was read without any lower-bound validation. A non-positive value caused the display-name formatter to call `substring(0, argumentMaxLength - 1)` with a negative end index, throwing a `StringIndexOutOfBoundsException` that was wrapped as a `JUnitException` and failed every parameterized test in the run:

```
org.junit.platform.commons.JUnitException: Failed to format display name for parameterized test
  Caused by: java.lang.StringIndexOutOfBoundsException: begin 0, end -1, length 1
```

The sibling CSV attribute `maxCharsPerColumn` is already validated, so this also aligns the input validation across the module.

Closes: #5810

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Coding conventions have been followed
- [x] Change is covered by automated tests including corner cases, errors, and exception handling
- [x] Method preconditions are checked and documented in the method's Javadoc — n/a; this validates a configuration parameter rather than adding a new public method
- [x] Public API has Javadoc and `@API` annotations — n/a; no public API was added or changed
- [x] Change is documented in the User Guide and Release Notes — the User Guide already documents the parameter; a Release Notes entry can be added if preferred
