### PR TITLE
Fix NoTestsDiscoveredException for suites containing only dynamic tests

### DIFF
--- a/documentation/modules/ROOT/partials/release-notes/release-notes-6.1.2.adoc
+++ b/documentation/modules/ROOT/partials/release-notes/release-notes-6.1.2.adoc
@@ -16,7 +16,7 @@ repository on GitHub.
 [[v6.1.2-junit-platform-bug-fixes]]
 ==== Bug Fixes
 
-* ❓
+* Fix `NoTestsDiscoveredException` for suites containing only dynamic tests
 
 [[v6.1.2-junit-platform-deprecations-and-breaking-changes]]
 ==== Deprecations and Breaking Changes

--- a/junit-platform-suite-engine/src/main/java/org/junit/platform/suite/engine/SuiteTestDescriptor.java
+++ b/junit-platform-suite-engine/src/main/java/org/junit/platform/suite/engine/SuiteTestDescriptor.java
@@ -337,6 +337,13 @@ final class SuiteTestDescriptor extends AbstractTestDescriptor {
 			this.testsFound.set(testPlan.countTestIdentifiers(TestIdentifier::isTest));
 		}
 
+		@Override
+		public void dynamicTestRegistered(TestIdentifier testIdentifier) {
+			if (testIdentifier.isTest()) {
+				testsFound.incrementAndGet();
+			}
+		}
+
 		long getTestsFoundCount() {
 			return testsFound.get();
 		}

--- a/platform-tests/src/test/java/org/junit/platform/suite/engine/BeforeAndAfterSuiteTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/suite/engine/BeforeAndAfterSuiteTests.java
@@ -16,7 +16,7 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.junit.platform.commons.util.CollectionUtils.getOnlyElement;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
 import static org.junit.platform.suite.engine.SuiteEngineDescriptor.ENGINE_ID;
-import static org.junit.platform.testkit.engine.EventConditions.container;
+import static org.junit.platform.suite.engine.SuiteEventConditions.suite;
 import static org.junit.platform.testkit.engine.EventConditions.event;
 import static org.junit.platform.testkit.engine.EventConditions.finishedSuccessfully;
 import static org.junit.platform.testkit.engine.EventConditions.finishedWithFailure;
@@ -113,7 +113,7 @@ public class BeforeAndAfterSuiteTests {
 				.assertStatistics(stats -> stats.started(2).finished(2).succeeded(1).failed(1))
 				.assertThatEvents()
 				.haveExactly(1, event(
-						container(FailingBeforeSuite.class),
+						suite(FailingBeforeSuite.class),
 						finishedWithFailure(instanceOf(RuntimeException.class),
 								message("Exception thrown by @BeforeSuite method"))));
 
@@ -132,7 +132,7 @@ public class BeforeAndAfterSuiteTests {
 				.assertStatistics(stats -> stats.started(7).finished(7).succeeded(5).failed(2))
 				.assertThatEvents()
 				.haveExactly(1, event(
-						container(FailingAfterSuite.class),
+						suite(FailingAfterSuite.class),
 						finishedWithFailure(instanceOf(RuntimeException.class),
 								message("Exception thrown by @AfterSuite method"))));
 
@@ -153,7 +153,7 @@ public class BeforeAndAfterSuiteTests {
 				.assertStatistics(stats -> stats.started(2).finished(2).succeeded(1).failed(1))
 				.assertThatEvents()
 				.haveExactly(1, event(
-						container(FailingBeforeAndAfterSuite.class),
+						suite(FailingBeforeAndAfterSuite.class),
 						finishedWithFailure(instanceOf(RuntimeException.class),
 								message("Exception thrown by @BeforeSuite method"),
 								suppressed(0, instanceOf(RuntimeException.class),
@@ -174,7 +174,7 @@ public class BeforeAndAfterSuiteTests {
 				.assertStatistics(stats -> stats.started(2).finished(2).succeeded(1).failed(1))
 				.assertThatEvents()
 				.haveExactly(1, event(
-						container(SeveralFailingBeforeAndAfterSuite.class),
+						suite(SeveralFailingBeforeAndAfterSuite.class),
 						finishedWithFailure(instanceOf(RuntimeException.class),
 								message("Exception thrown by @BeforeSuite method"),
 								suppressed(0, instanceOf(RuntimeException.class),

--- a/platform-tests/src/test/java/org/junit/platform/suite/engine/SuiteEngineTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/suite/engine/SuiteEngineTests.java
@@ -19,6 +19,7 @@ import static org.junit.platform.engine.discovery.DiscoverySelectors.selectUniqu
 import static org.junit.platform.launcher.TagFilter.excludeTags;
 import static org.junit.platform.launcher.core.OutputDirectoryCreators.hierarchicalOutputDirectoryCreator;
 import static org.junit.platform.suite.engine.SuiteEngineDescriptor.ENGINE_ID;
+import static org.junit.platform.suite.engine.SuiteEventConditions.suite;
 import static org.junit.platform.testkit.engine.EventConditions.container;
 import static org.junit.platform.testkit.engine.EventConditions.displayName;
 import static org.junit.platform.testkit.engine.EventConditions.engine;
@@ -126,9 +127,9 @@ class SuiteEngineTests {
 
 		testKit
 				.execute()
-				.testEvents()
+				.allEvents()
 				.assertThatEvents()
-				.haveExactly(1, event(test(suiteClass.getName()), finishedSuccessfully()))
+				.haveExactly(1, event(suite(suiteClass), finishedSuccessfully()))
 				.haveExactly(1, event(test(SingleTestTestCase.class.getName()), finishedSuccessfully()));
 		// @formatter:on
 	}
@@ -144,8 +145,9 @@ class SuiteEngineTests {
 
 		testKit
 				.execute()
-				.testEvents()
+				.allEvents()
 				.assertThatEvents()
+				.haveExactly(1, event(suite(SelectMethodsSuite.class), finishedSuccessfully()))
 				.haveExactly(1, event(test(MultipleTestsTestCase.class.getName(), "test()"), finishedSuccessfully()))
 				.doNotHave(event(test(MultipleTestsTestCase.class.getName(), "test2()")));
 		// @formatter:on
@@ -308,8 +310,9 @@ class SuiteEngineTests {
 		EngineTestKit.engine(ENGINE_ID)
 				.selectors(selectClass(DynamicSuite.class))
 				.execute()
-				.testEvents()
+				.allEvents()
 				.assertThatEvents()
+				.haveExactly(1, event(suite(DynamicSuite.class), finishedSuccessfully()))
 				.haveExactly(2, event(test(DynamicTestsTestCase.class.getName()), finishedSuccessfully()));
 		// @formatter:on
 	}
@@ -320,10 +323,10 @@ class SuiteEngineTests {
 		EngineTestKit.engine(ENGINE_ID)
 				.selectors(selectClass(SuiteSuite.class))
 				.execute()
-				.testEvents()
+				.allEvents()
 				.assertThatEvents()
-				.haveExactly(1, event(test(SuiteSuite.class.getName()), finishedSuccessfully()))
-				.haveExactly(1, event(test(SelectClassesSuite.class.getName()), finishedSuccessfully()))
+				.haveExactly(1, event(suite(SuiteSuite.class), finishedSuccessfully()))
+				.haveExactly(1, event(suite(SelectClassesSuite.class), finishedSuccessfully()))
 				.haveExactly(1, event(test(SingleTestTestCase.class.getName()), finishedSuccessfully()));
 		// @formatter:on
 	}
@@ -342,10 +345,12 @@ class SuiteEngineTests {
 
 		testKit
 				.execute()
-				.testEvents()
+				.allEvents()
 				.assertThatEvents()
-				.haveExactly(1, event(test(SelectClassesSuite.class.getName()), finishedSuccessfully()))
-				.haveExactly(2, event(test(MultipleSuite.class.getName()), finishedSuccessfully()));
+				.haveExactly(1, event(suite(SelectClassesSuite.class), finishedSuccessfully()))
+				.haveExactly(1, event(test(SingleTestTestCase.class.getName()), finishedSuccessfully()))
+				.haveExactly(1, event(suite(MultipleSuite.class), finishedSuccessfully()))
+				.haveExactly(2, event(test(MultipleTestsTestCase.class.getName()), finishedSuccessfully()));
 		// @formatter:on
 	}
 
@@ -364,10 +369,12 @@ class SuiteEngineTests {
 
 		testKit
 				.execute()
-				.testEvents()
+				.allEvents()
 				.assertThatEvents()
-				.haveExactly(1, event(test(SelectClassesSuite.class.getName()), finishedSuccessfully()))
-				.haveExactly(2, event(test(MultipleSuite.class.getName()), finishedSuccessfully()));
+				.haveExactly(1, event(suite(SelectClassesSuite.class), finishedSuccessfully()))
+				.haveExactly(1, event(test(SingleTestTestCase.class.getName()), finishedSuccessfully()))
+				.haveExactly(1, event(suite(MultipleSuite.class), finishedSuccessfully()))
+				.haveExactly(2, event(test(MultipleTestsTestCase.class.getName()), finishedSuccessfully()));
 		// @formatter:on
 	}
 
@@ -379,9 +386,9 @@ class SuiteEngineTests {
 		EngineTestKit.engine(ENGINE_ID)
 				.selectors(selectUniqueId(uniqId))
 				.execute()
-				.testEvents()
+				.allEvents()
 				.assertThatEvents()
-				.haveExactly(1, event(test(SelectClassesSuite.class.getName()), finishedSuccessfully()))
+				.haveExactly(1, event(suite(SelectClassesSuite.class), finishedSuccessfully()))
 				.haveExactly(1, event(test(SingleTestTestCase.class.getName()), finishedSuccessfully()));
 		// @formatter:on
 	}
@@ -398,9 +405,9 @@ class SuiteEngineTests {
 		EngineTestKit.engine(ENGINE_ID)
 				.selectors(selectUniqueId(uniqueId))
 				.execute()
-				.testEvents()
+				.allEvents()
 				.assertThatEvents()
-				.haveExactly(1, event(test(MultipleSuite.class.getName()), finishedSuccessfully()))
+				.haveExactly(1, event(suite(MultipleSuite.class), finishedSuccessfully()))
 				.haveExactly(1, event(test(MultipleTestsTestCase.class.getName()), finishedSuccessfully()));
 		// @formatter:on
 	}
@@ -414,9 +421,9 @@ class SuiteEngineTests {
 		EngineTestKit.engine(ENGINE_ID)
 				.selectors(selectUniqueId(uniqueId))
 				.execute()
-				.testEvents()
+				.allEvents()
 				.assertThatEvents()
-				.haveExactly(2, event(test(MultipleSuite.class.getName()), finishedSuccessfully()))
+				.haveExactly(1, event(suite(MultipleSuite.class), finishedSuccessfully()))
 				.haveExactly(2, event(test(MultipleTestsTestCase.class.getName()), finishedSuccessfully()));
 		// @formatter:on
 	}
@@ -434,11 +441,11 @@ class SuiteEngineTests {
 				.selectors(selectUniqueId(uniqueId))
 				.selectors(selectClass(SelectClassesSuite.class))
 				.execute()
-				.testEvents()
+				.allEvents()
 				.assertThatEvents()
-				.haveExactly(1, event(test(SelectClassesSuite.class.getName()), finishedSuccessfully()))
+				.haveExactly(1, event(suite(SelectClassesSuite.class), finishedSuccessfully()))
 				.haveExactly(1, event(test(SingleTestTestCase.class.getName()), finishedSuccessfully()))
-				.haveExactly(1, event(test(MultipleSuite.class.getName()), finishedSuccessfully()))
+				.haveExactly(1, event(suite(MultipleSuite.class), finishedSuccessfully()))
 				.haveExactly(1, event(test(MultipleTestsTestCase.class.getName()), finishedSuccessfully()));
 		// @formatter:on
 	}
@@ -462,9 +469,9 @@ class SuiteEngineTests {
 				.selectors(selectUniqueId(uniqueId))
 				.selectors(selectUniqueId(uniqueId2))
 				.execute()
-				.testEvents()
+				.allEvents()
 				.assertThatEvents()
-				.haveExactly(2, event(test(MultipleSuite.class.getName()), finishedSuccessfully()))
+				.haveExactly(1, event(suite(MultipleSuite.class), finishedSuccessfully()))
 				.haveExactly(2, event(test(MultipleTestsTestCase.class.getName()), finishedSuccessfully()));
 		// @formatter:on
 	}
@@ -490,8 +497,9 @@ class SuiteEngineTests {
 					selectUniqueId(uniqueId2)
 				)
 				.execute()
-				.testEvents()
+				.allEvents()
 				.assertThatEvents()
+				.haveExactly(1, event(suite(ConfigurationSuite.class), finishedSuccessfully()))
 				.haveExactly(1, event(test(ConfigurationSuite.class.getName(), "test1()"), finishedSuccessfully()))
 				.haveExactly(1, event(test(ConfigurationSuite.class.getName(), "test2()"), finishedSuccessfully()));
 		// @formatter:on
@@ -504,7 +512,7 @@ class SuiteEngineTests {
 				.filter(MethodSource.class::isInstance)
 				.map(MethodSource.class::cast)
 				.filter(classSource -> SingleTestTestCase.class.equals(classSource.getJavaClass()))
-				.map(classSource -> FilterResult.excluded("Was a test in SimpleTest"))
+				.map(_ -> FilterResult.excluded("Was a test in SimpleTest"))
 				.orElseGet(() -> FilterResult.included("Was not a test in SimpleTest"));
 
 		EngineTestKit.engine(ENGINE_ID)
@@ -525,7 +533,7 @@ class SuiteEngineTests {
 				.execute()
 				.containerEvents()
 				.assertThatEvents()
-				.haveExactly(1, event(container(EmptyTestCaseSuite.class), finishedWithFailure(instanceOf(NoTestsDiscoveredException.class))));
+				.haveExactly(1, event(suite(EmptyTestCaseSuite.class), finishedWithFailure(instanceOf(NoTestsDiscoveredException.class))));
 		// @formatter:on
 	}
 
@@ -549,7 +557,7 @@ class SuiteEngineTests {
 				.execute()
 				.containerEvents()
 				.assertThatEvents()
-				.haveExactly(1, event(container(EmptyDynamicTestSuite.class), finishedWithFailure(instanceOf(NoTestsDiscoveredException.class))));
+				.haveExactly(1, event(suite(EmptyDynamicTestSuite.class), finishedWithFailure(instanceOf(NoTestsDiscoveredException.class))));
 		// @formatter:on
 	}
 
@@ -561,7 +569,7 @@ class SuiteEngineTests {
 				.execute()
 				.allEvents()
 				.assertThatEvents()
-				.haveAtLeastOne(event(container(EmptyDynamicTestWithFailIfNoTestFalseSuite.class), finishedSuccessfully()));
+				.haveAtLeastOne(event(suite(EmptyDynamicTestWithFailIfNoTestFalseSuite.class), finishedSuccessfully()));
 		// @formatter:on
 	}
 
@@ -603,6 +611,7 @@ class SuiteEngineTests {
 				.execute()
 				.allEvents()
 				.assertThatEvents()
+				.haveExactly(1, event(suite(CyclicSuite.class), finishedSuccessfully()))
 				.haveExactly(1, event(test(SingleTestTestCase.class.getName()), finishedSuccessfully()));
 		// @formatter:on
 	}
@@ -615,7 +624,7 @@ class SuiteEngineTests {
 				.execute()
 				.allEvents()
 				.assertThatEvents()
-				.haveExactly(1, event(container(EmptyCyclicSuite.class), finishedWithFailure(message(
+				.haveExactly(1, event(suite(EmptyCyclicSuite.class), finishedWithFailure(message(
 						"Suite [org.junit.platform.suite.engine.testsuites.EmptyCyclicSuite] did not discover any tests"
 				))));
 		// @formatter:on
@@ -629,6 +638,9 @@ class SuiteEngineTests {
 				.execute()
 				.allEvents()
 				.assertThatEvents()
+				.haveExactly(1, event(suite(ThreePartCyclicSuite.PartA.class), finishedSuccessfully()))
+				.haveExactly(1, event(suite(ThreePartCyclicSuite.PartB.class), finishedSuccessfully()))
+				.haveExactly(1, event(suite(ThreePartCyclicSuite.PartC.class), finishedSuccessfully()))
 				.haveExactly(1, event(test(SingleTestTestCase.class.getName()), finishedSuccessfully()));
 		// @formatter:on
 	}
@@ -644,10 +656,9 @@ class SuiteEngineTests {
 
 		testKit
 				.execute()
-				.testEvents()
-				.debug()
+				.allEvents()
 				.assertThatEvents()
-				.haveExactly(1, event(test(FailingSuite.class.getName()), finishedWithFailure()))
+				.haveExactly(1, event(suite(FailingSuite.class), finishedSuccessfully()))
 				.haveExactly(1, event(test(SingleFailingTestTestCase.class.getName()),finishedWithFailure()));
 		// @formatter:on
 
@@ -661,9 +672,9 @@ class SuiteEngineTests {
 		EngineTestKit.engine(ENGINE_ID)
 				.selectors(selectClass(SelectByIdentifierSuite.class))
 				.execute()
-				.testEvents()
+				.allEvents()
 				.assertThatEvents()
-				.haveExactly(1, event(test(SelectByIdentifierSuite.class.getName()), finishedSuccessfully()))
+				.haveExactly(1, event(suite(SelectByIdentifierSuite.class), finishedSuccessfully()))
 				.haveExactly(1, event(test(SingleTestTestCase.class.getName()), finishedSuccessfully()));
 		// @formatter:on
 	}
@@ -675,8 +686,9 @@ class SuiteEngineTests {
 				.selectors(selectClass(SingleTestWithTestReporterSuite.class))
 				.outputDirectoryCreator(hierarchicalOutputDirectoryCreator(outputDir))
 				.execute()
-				.testEvents()
+				.allEvents()
 				.assertThatEvents()
+				.haveExactly(1, event(suite(SingleTestWithTestReporterSuite.class), finishedSuccessfully()))
 				.haveExactly(1, event(test(SingleTestWithTestReporterTestCase.class.getName()), finishedSuccessfully()));
 		// @formatter:on
 
@@ -762,9 +774,9 @@ class SuiteEngineTests {
 			results.allEvents() //
 					.assertStatistics(stats -> stats.started(3).succeeded(2).aborted(1).skipped(2)) //
 					.assertEventsMatchLooselyInOrder( //
-						event(container(CancellingSuite.class), started()), //
+						event(suite(CancellingSuite.class), started()), //
 						event(container(SingleTestTestCase.class), skippedWithReason("Execution cancelled")), //
-						event(container(CancellingSuite.class), finishedSuccessfully()), //
+						event(suite(CancellingSuite.class), finishedSuccessfully()), //
 						event(container(SelectMethodsSuite.class), skippedWithReason("Execution cancelled")) //
 					);
 		}
@@ -784,8 +796,10 @@ class SuiteEngineTests {
 			var results = testKit.execute();
 
 			results.allEvents().assertThatEvents() //
-					.haveExactly(1, event(container(SingleTestTestCase.class),
-						skippedWithReason("Execution cancelled"))).haveExactly(0, event(test(), started()));
+					.haveExactly(1, event(suite(CancellingSuite.class), finishedSuccessfully())) //
+					.haveExactly(1, //
+						event(container(SingleTestTestCase.class), skippedWithReason("Execution cancelled"))) //
+					.haveExactly(0, event(test(), started()));
 
 			assertThat(CancellingSuite.afterCalled) //
 					.describedAs("@AfterSuite method was called") //
@@ -840,7 +854,7 @@ class SuiteEngineTests {
 		testKit.execute() //
 				.allEvents() //
 				.assertThatEvents() //
-				.haveExactly(1, event(container(DisabledSuite.class.getName()),
+				.haveExactly(1, event(suite(DisabledSuite.class), //
 					skippedWithReason(DisabledSuite.class + " is @Disabled")));
 	}
 
@@ -855,7 +869,7 @@ class SuiteEngineTests {
 		testKit.execute() //
 				.allEvents() //
 				.assertThatEvents() //
-				.haveExactly(1, event(container(DisabledWithReasonSuite.class.getName()),
+				.haveExactly(1, event(suite(DisabledWithReasonSuite.class), //
 					skippedWithReason("for testing purposes")));
 	}
 
@@ -872,9 +886,9 @@ class SuiteEngineTests {
 		assertThat(testKit.discover().getDiscoveryIssues()).contains(expectedIssue);
 
 		testKit.execute() //
-				.testEvents() //
+				.allEvents() //
 				.assertThatEvents() //
-				.haveExactly(1, event(test(JupiterDisabledSuite.class.getName()), finishedSuccessfully())) //
+				.haveExactly(1, event(suite(JupiterDisabledSuite.class), finishedSuccessfully())) //
 				.haveExactly(1, event(test(SingleTestTestCase.class.getName()), finishedSuccessfully()));
 	}
 
@@ -907,11 +921,13 @@ class SuiteEngineTests {
 	private static class PrivateSuite {
 	}
 
+	@SuppressWarnings("InnerClassMayBeStatic")
 	@Suite
 	@SelectClasses(names = "org.junit.platform.suite.engine.testcases.SingleTestTestCase")
 	abstract class AbstractInnerSuite {
 	}
 
+	@SuppressWarnings("InnerClassMayBeStatic")
 	@Suite
 	@SelectClasses(names = "org.junit.platform.suite.engine.testcases.SingleTestTestCase")
 	class InnerSuite {

--- a/platform-tests/src/test/java/org/junit/platform/suite/engine/SuiteEventConditions.java
+++ b/platform-tests/src/test/java/org/junit/platform/suite/engine/SuiteEventConditions.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.suite.engine;
+
+import static org.junit.platform.testkit.engine.EventConditions.container;
+
+import org.assertj.core.api.Condition;
+import org.junit.platform.engine.UniqueId;
+import org.junit.platform.testkit.engine.Event;
+import org.junit.platform.testkit.engine.EventConditions;
+
+class SuiteEventConditions {
+
+	private SuiteEventConditions() {
+		/* no-op */
+	}
+
+	static Condition<Event> suite(Class<?> clazz) {
+		return container(EventConditions.uniqueId(suiteId(clazz)));
+	}
+
+	private static Condition<UniqueId> suiteId(Class<?> clazz) {
+		return new Condition<>(uniqueId -> {
+			var last = uniqueId.getSegments().getLast();
+			return last.getType().equals(SuiteTestDescriptor.SEGMENT_TYPE) && last.getValue().equals(clazz.getName());
+		}, "last segment equals '%s:%s'", SuiteTestDescriptor.SEGMENT_TYPE, clazz.getName());
+	}
+}


### PR DESCRIPTION
With the introduction of the `SuiteSummaryGeneratingListener` the dynamic tests were not included in the test discovery count leading to an `NoTestsDiscoveredException` when suites contained only dynamic tests. Counting the registration of dynamic tests in addition to the directly discovered test solves this.

We did have a test case to cover this. While it checked that the tests in the suite were executed, it did not check if the suite container itself passed.

Checking this was actually surprisingly difficult.The `EventConditions.container(DynamicSuite.class)` can be satisfied by the events from the `DynamicSuite` and the `DynamicTestsTestCase`, so there always exists some ambiguity about which event is being matched. By matching exactly against the suite descriptor segment we can avoid this.

Fixes: #5837

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://docs.junit.org/snapshot/) and [Release Notes](https://docs.junit.org/snapshot/release-notes.html)
