### PR TITLE
Apply Spotless to YAML files

### DIFF
--- a/gradle/plugins/common/src/main/kotlin/junitbuild.spotless-conventions.gradle.kts
+++ b/gradle/plugins/common/src/main/kotlin/junitbuild.spotless-conventions.gradle.kts
@@ -72,6 +72,10 @@ spotless {
 		}
 	}
 
+	yaml {
+		target("**/*.yaml", "**/*.yml")
+	}
+
 	// Explicitly configure line endings to avoid Spotless to search for .gitattributes file
 	// see https://github.com/gradle/gradle/issues/25469#issuecomment-3444231151
 	lineEndings = LineEnding.UNIX

--- a/gradle/plugins/common/src/main/kotlin/junitbuild.spotless-conventions.gradle.kts
+++ b/gradle/plugins/common/src/main/kotlin/junitbuild.spotless-conventions.gradle.kts
@@ -74,6 +74,8 @@ spotless {
 
 	yaml {
 		target("**/*.yaml", "**/*.yml")
+		trimTrailingWhitespace()
+		endWithNewline()
 	}
 
 	// Explicitly configure line endings to avoid Spotless to search for .gitattributes file


### PR DESCRIPTION
This PR adjusts the Gradle configuration to use Spotless also on YAML files to resolve #5822.

Following points are open for discussion:

1. Spotless is also integrated in `platform-tooling-support-tests/platform-tooling-support-tests.gradle.kts`. Should YAML files be handled also there? Currently, `platform-tooling-support-tests/projects` contains no YAML files, which seems to be the target directory of the file.
2. The current change only addresses trailing whitespace and missing final newlines in YAML files. There is also further YAML specific formatting available. The documentation mentions Jackson and Prettier for this. However, only for Jackson is a YAML specific documentation [there](https://github.com/diffplug/spotless/tree/main/plugin-gradle#jackson-1). It mentions "any SerializationFeature", which seems to refer to this documentation [here](https://www.javadoc.io/doc/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/latest/com/fasterxml/jackson/dataformat/yaml/YAMLGenerator.Feature.html). If some YAML specific formatting should be integrated, the concrete configuration needs to be discussed. The defaults of Jackson would make changes in almost every YAML file of the project.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://docs.junit.org/snapshot/) and [Release Notes](https://docs.junit.org/snapshot/release-notes.html)

(Most of this bullet points may not be really applicable for this Gradle only changes.)
