### PR TITLE
Add Kotlin code examples for writing tests topics

### DIFF
--- a/documentation/modules/ROOT/pages/writing-tests/assertions.adoc
+++ b/documentation/modules/ROOT/pages/writing-tests/assertions.adoc
@@ -65,10 +65,26 @@ you can statically import methods such as `assertThat()`, `assertThatException()
 from `org.assertj.core.api.Assertions` and then use them in tests like in the
 `assertWithAssertJ()` method below.
 
+[tabs]
+====
+Java::
++
+--
 [source,java,indent=0]
 ----
 include::example$java/example/AssertJAssertionsDemo.java[tags=user_guide]
 ----
+--
+
+Kotlin::
++
+--
+[source,kotlin,indent=0]
+----
+include::example$kotlin/example/kotlin/AssertJAssertionsDemo.kt[tags=user_guide]
+----
+--
+====
 
 [TIP]
 .Excluding Jupiter’s Assertions From a Project’s Classpath

--- a/documentation/modules/ROOT/pages/writing-tests/disabling-tests.adoc
+++ b/documentation/modules/ROOT/pages/writing-tests/disabling-tests.adoc
@@ -15,17 +15,49 @@ such as `@BeforeAll` methods, `@AfterAll` methods, and corresponding extension A
 
 Here's a `@Disabled` test class.
 
+[tabs]
+====
+Java::
++
+--
 [source,java,indent=0]
 ----
 include::example$java/example/DisabledClassDemo.java[tags=user_guide]
 ----
+--
+
+Kotlin::
++
+--
+[source,kotlin,indent=0]
+----
+include::example$kotlin/example/kotlin/DisabledClassDemo.kt[tags=user_guide]
+----
+--
+====
 
 And here's a test class that contains a `@Disabled` test method.
 
+[tabs]
+====
+Java::
++
+--
 [source,java,indent=0]
 ----
 include::example$java/example/DisabledTestsDemo.java[tags=user_guide]
 ----
+--
+
+Kotlin::
++
+--
+[source,kotlin,indent=0]
+----
+include::example$kotlin/example/kotlin/DisabledTestsDemo.kt[tags=user_guide]
+----
+--
+====
 
 [TIP]
 ====

--- a/documentation/modules/ROOT/pages/writing-tests/parallel-execution.adoc
+++ b/documentation/modules/ROOT/pages/writing-tests/parallel-execution.adoc
@@ -43,10 +43,26 @@ method.
 You can use the `@Execution` annotation to explicitly configure the execution mode for a
 test class or method:
 
-[source,java]
+[tabs]
+====
+Java::
++
+--
+[source,java,indent=0]
 ----
 include::example$java/example/ExplicitExecutionModeDemo.java[tags=user_guide]
 ----
+--
+
+Kotlin::
++
+--
+[source,kotlin,indent=0]
+----
+include::example$kotlin/example/kotlin/ExplicitExecutionModeDemo.kt[tags=user_guide]
+----
+--
+====
 
 This allows test classes or methods to opt in or out of concurrent execution regardless of
 the globally configured default.
@@ -70,7 +86,7 @@ combining both configuration parameters, you can configure classes to run in par
 their methods in the same thread:
 
 [source,properties]
-.Configuration parameters to execute top-level classes in parallel but methods in same thread
+.Configuration parameters to execute top-level classes in parallel but methods in the same thread
 ----
 junit.jupiter.execution.parallel.enabled = true
 junit.jupiter.execution.parallel.mode.default = same_thread
@@ -197,9 +213,9 @@ If no configuration strategy is set, JUnit Jupiter uses the `dynamic` configurat
 strategy with a factor of `1`. Consequently, the desired parallelism will be equal to the
 number of available processors/cores.
 
-.Parallelism alone does not imply maximum number of concurrent threads
+.Parallelism alone does not imply the maximum number of concurrent threads
 NOTE: By default, JUnit Jupiter does not guarantee that the number of threads used to
-execute test will not exceed the configured parallelism. For example, when using one
+execute a test will not exceed the configured parallelism. For example, when using one
 of the synchronization mechanisms described in the next section, the executor service
 implementation may spawn additional threads to ensure execution continues with sufficient
 parallelism. If you require such guarantees, it is possible to limit the maximum number of
@@ -316,17 +332,49 @@ an access mode. Two tests that require `READ` access to a shared resource may ru
 parallel with each other but not while any other test that requires `READ_WRITE` access
 to the same shared resource is running.
 
-[source,java]
 .Declaring shared resources "statically" with `{ResourceLock}` annotation
+[tabs]
+====
+Java::
++
+--
+[source,java,indent=0]
 ----
 include::example$java/example/sharedresources/StaticSharedResourcesDemo.java[tags=user_guide]
 ----
+--
 
-[source,java]
+Kotlin::
++
+--
+[source,kotlin,indent=0]
+----
+include::example$kotlin/example/kotlin/sharedresources/StaticSharedResourcesDemo.kt[tags=user_guide]
+----
+--
+====
+
 .Adding shared resources "dynamically" with `{ResourceLocksProvider}` implementation
+[tabs]
+====
+Java::
++
+--
+[source,java,indent=0]
 ----
 include::example$java/example/sharedresources/DynamicSharedResourcesDemo.java[tags=user_guide]
 ----
+--
+
+Kotlin::
++
+--
+[source,kotlin,indent=0]
+----
+include::example$kotlin/example/kotlin/sharedresources/DynamicSharedResourcesDemo.kt[tags=user_guide]
+----
+--
+====
 
 Also, "static" shared resources can be declared for _direct_ child nodes via the `target`
 attribute in the `{ResourceLock}` annotation, the attribute accepts a value from
@@ -344,8 +392,24 @@ didn't have `target = CHILDREN`. This is because the test class declares a `READ
 shared resource, but one test method holds a `READ_WRITE` lock,
 which would force the `SAME_THREAD` execution mode for all the test methods.
 
-[source,java]
-.Declaring shared resources for child nodes with `target` attribute
+.Declaring shared resources for child nodes with the `target` attribute
+[tabs]
+====
+Java::
++
+--
+[source,java,indent=0]
 ----
 include::example$java/example/sharedresources/ChildrenSharedResourcesDemo.java[tags=user_guide]
 ----
+--
+
+Kotlin::
++
+--
+[source,kotlin,indent=0]
+----
+include::example$kotlin/example/kotlin/sharedresources/ChildrenSharedResourcesDemo.kt[tags=user_guide]
+----
+--
+====

--- a/documentation/modules/ROOT/pages/writing-tests/parallel-execution.adoc
+++ b/documentation/modules/ROOT/pages/writing-tests/parallel-execution.adoc
@@ -215,7 +215,7 @@ number of available processors/cores.
 
 .Parallelism alone does not imply the maximum number of concurrent threads
 NOTE: By default, JUnit Jupiter does not guarantee that the number of threads used to
-execute a test will not exceed the configured parallelism. For example, when using one
+execute tests will not exceed the configured parallelism. For example, when using one
 of the synchronization mechanisms described in the next section, the executor service
 implementation may spawn additional threads to ensure execution continues with sufficient
 parallelism. If you require such guarantees, it is possible to limit the maximum number of

--- a/documentation/src/test/kotlin/example/kotlin/AssertJAssertionsDemo.kt
+++ b/documentation/src/test/kotlin/example/kotlin/AssertJAssertionsDemo.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2015-2026 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package example.kotlin
+
+// tag::user_guide[]
+import example.util.Calculator
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class AssertJAssertionsDemo {
+    private val calculator = Calculator()
+
+    @Test
+    fun assertWithAssertJ() {
+        assertThat(calculator.subtract(4, 1)).isEqualTo(3)
+    }
+}
+// end::user_guide[]

--- a/documentation/src/test/kotlin/example/kotlin/DisabledClassDemo.kt
+++ b/documentation/src/test/kotlin/example/kotlin/DisabledClassDemo.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2015-2026 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package example.kotlin
+
+// tag::user_guide[]
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+
+@Disabled("Disabled until bug #99 has been fixed")
+class DisabledClassDemo {
+    @Test
+    fun testWillBeSkipped() {
+    }
+}
+// end::user_guide[]

--- a/documentation/src/test/kotlin/example/kotlin/DisabledTestsDemo.kt
+++ b/documentation/src/test/kotlin/example/kotlin/DisabledTestsDemo.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2015-2026 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package example.kotlin
+
+// tag::user_guide[]
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+
+class DisabledTestsDemo {
+    @Disabled("Disabled until bug #42 has been resolved")
+    @Test
+    fun testWillBeSkipped() {
+    }
+
+    @Test
+    fun testWillBeExecuted() {
+    }
+}
+// end::user_guide[]

--- a/documentation/src/test/kotlin/example/kotlin/ExplicitExecutionModeDemo.kt
+++ b/documentation/src/test/kotlin/example/kotlin/ExplicitExecutionModeDemo.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2015-2026 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package example.kotlin
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
+
+// tag::user_guide[]
+@Execution(ExecutionMode.CONCURRENT)
+class ExplicitExecutionModeDemo {
+    @Test
+    fun testA() {
+        // concurrent
+    }
+
+    @Test
+    @Execution(ExecutionMode.SAME_THREAD)
+    fun testB() {
+        // overrides to same_thread
+    }
+}
+// end::user_guide[]

--- a/documentation/src/test/kotlin/example/kotlin/sharedresources/ChildrenSharedResourcesDemo.kt
+++ b/documentation/src/test/kotlin/example/kotlin/sharedresources/ChildrenSharedResourcesDemo.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2015-2026 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package example.kotlin.sharedresources
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT
+import org.junit.jupiter.api.parallel.ResourceAccessMode.READ
+import org.junit.jupiter.api.parallel.ResourceAccessMode.READ_WRITE
+import org.junit.jupiter.api.parallel.ResourceLock
+import org.junit.jupiter.api.parallel.ResourceLockTarget.CHILDREN
+
+// tag::user_guide[]
+@Execution(CONCURRENT)
+@ResourceLock(value = "a", mode = READ, target = CHILDREN)
+class ChildrenSharedResourcesDemo {
+    @ResourceLock(value = "a", mode = READ_WRITE)
+    @Test
+    fun test1() {
+        Thread.sleep(2000L)
+    }
+
+    @Test
+    fun test2() {
+        Thread.sleep(2000L)
+    }
+
+    @Test
+    fun test3() {
+        Thread.sleep(2000L)
+    }
+
+    @Test
+    fun test4() {
+        Thread.sleep(2000L)
+    }
+
+    @Test
+    fun test5() {
+        Thread.sleep(2000L)
+    }
+}
+// end::user_guide[]

--- a/documentation/src/test/kotlin/example/kotlin/sharedresources/DynamicSharedResourcesDemo.kt
+++ b/documentation/src/test/kotlin/example/kotlin/sharedresources/DynamicSharedResourcesDemo.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2015-2026 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package example.kotlin.sharedresources
+
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT
+import org.junit.jupiter.api.parallel.ResourceAccessMode
+import org.junit.jupiter.api.parallel.ResourceAccessMode.READ
+import org.junit.jupiter.api.parallel.ResourceAccessMode.READ_WRITE
+import org.junit.jupiter.api.parallel.ResourceLock
+import org.junit.jupiter.api.parallel.ResourceLocksProvider
+import org.junit.jupiter.api.parallel.ResourceLocksProvider.Lock
+import org.junit.jupiter.api.parallel.Resources.SYSTEM_PROPERTIES
+import java.lang.reflect.Method
+import java.util.Properties
+
+// tag::user_guide[]
+@Execution(CONCURRENT)
+@ResourceLock(providers = [DynamicSharedResourcesDemo.Provider::class])
+class DynamicSharedResourcesDemo {
+    private lateinit var backup: Properties
+
+    @BeforeEach
+    fun backup() {
+        backup = Properties()
+        backup.putAll(System.getProperties())
+    }
+
+    @AfterEach
+    fun restore() {
+        System.setProperties(backup)
+    }
+
+    @Test
+    fun customPropertyIsNotSetByDefault() {
+        assertNull(System.getProperty("my.prop"))
+    }
+
+    @Test
+    fun canSetCustomPropertyToApple() {
+        System.setProperty("my.prop", "apple")
+        assertEquals("apple", System.getProperty("my.prop"))
+    }
+
+    @Test
+    fun canSetCustomPropertyToBanana() {
+        System.setProperty("my.prop", "banana")
+        assertEquals("banana", System.getProperty("my.prop"))
+    }
+
+    class Provider : ResourceLocksProvider {
+        override fun provideForMethod(
+            enclosingInstanceTypes: List<Class<*>>,
+            testClass: Class<*>,
+            testMethod: Method
+        ): Set<Lock> {
+            val mode: ResourceAccessMode =
+                if (testMethod.name.startsWith("canSet")) READ_WRITE else READ
+            return setOf(Lock(SYSTEM_PROPERTIES, mode))
+        }
+    }
+}
+// end::user_guide[]

--- a/documentation/src/test/kotlin/example/kotlin/sharedresources/StaticSharedResourcesDemo.kt
+++ b/documentation/src/test/kotlin/example/kotlin/sharedresources/StaticSharedResourcesDemo.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2015-2026 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package example.kotlin.sharedresources
+
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT
+import org.junit.jupiter.api.parallel.ResourceAccessMode.READ
+import org.junit.jupiter.api.parallel.ResourceAccessMode.READ_WRITE
+import org.junit.jupiter.api.parallel.ResourceLock
+import org.junit.jupiter.api.parallel.Resources.SYSTEM_PROPERTIES
+import java.util.Properties
+
+// tag::user_guide[]
+@Execution(CONCURRENT)
+class StaticSharedResourcesDemo {
+    private lateinit var backup: Properties
+
+    @BeforeEach
+    fun backup() {
+        backup = Properties()
+        backup.putAll(System.getProperties())
+    }
+
+    @AfterEach
+    fun restore() {
+        System.setProperties(backup)
+    }
+
+    @Test
+    @ResourceLock(value = SYSTEM_PROPERTIES, mode = READ)
+    fun customPropertyIsNotSetByDefault() {
+        assertNull(System.getProperty("my.prop"))
+    }
+
+    @Test
+    @ResourceLock(value = SYSTEM_PROPERTIES, mode = READ_WRITE)
+    fun canSetCustomPropertyToApple() {
+        System.setProperty("my.prop", "apple")
+        assertEquals("apple", System.getProperty("my.prop"))
+    }
+
+    @Test
+    @ResourceLock(value = SYSTEM_PROPERTIES, mode = READ_WRITE)
+    fun canSetCustomPropertyToBanana() {
+        System.setProperty("my.prop", "banana")
+        assertEquals("banana", System.getProperty("my.prop"))
+    }
+}
+// end::user_guide[]


### PR DESCRIPTION
Adds Kotlin tabbed code snippets to three more topics in the Writing Tests section of the User Guide,
continuing the effort started in https://github.com/junit-team/junit-framework/pull/5316, https://github.com/junit-team/junit-framework/pull/5432, and https://github.com/junit-team/junit-framework/pull/5590

Pages updated (Writing Tests):

* Assertions
* Disabling Tests
* Parallel Execution
---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://docs.junit.org/snapshot/) and [Release Notes](https://docs.junit.org/snapshot/release-notes.html)
