### PR TITLE
Adopt configuration cache and Gradle 9.7.0-rc-1 features

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,14 +57,14 @@ jobs:
           sudo apt-get update && sudo apt-get install --yes jc
           unzip -c /tmp/reference.jar META-INF/MANIFEST.MF | jc --jar-manifest | jq '.[0]' > /tmp/manifest.json
           echo "createdBy=$(jq --raw-output .Created_By /tmp/manifest.json)" >> "$GITHUB_OUTPUT"
-          echo "buildTimestamp=$(jq --raw-output .Build_Date /tmp/manifest.json) $(jq --raw-output .Build_Time /tmp/manifest.json)" >> "$GITHUB_OUTPUT"
+          echo "sourceDateEpoch=$(jq --raw-output .Build_Date /tmp/manifest.json) $(jq --raw-output .Build_Time /tmp/manifest.json)" >> "$GITHUB_OUTPUT"
       - name: Verify artifacts
         uses: ./.github/actions/run-gradle
         with:
           encryptionKey: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
           arguments: >-
             --rerun-tasks
-            -Pmanifest.buildTimestamp="${{ steps.referenceJar.outputs.buildTimestamp }}"
+            -PsourceDateEpoch="${{ steps.referenceJar.outputs.sourceDateEpoch }}"
             -Pmanifest.createdBy="${{ steps.referenceJar.outputs.createdBy }}"
             :verifyArtifactsInStagingRepositoryAreReproducible
             --remote-repo-url=${{ env.STAGING_REPO_URL }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,3 @@
-import junitbuild.extensions.dependencyProject
-
 plugins {
 	id("junitbuild.base-conventions")
 	id("junitbuild.build-metadata")
@@ -17,40 +15,29 @@ extra["license"] = License(
 	headerFile = layout.settingsDirectory.file("gradle/config/spotless/eclipse-public-license-2.0.java")
 )
 
-val platformProjects = listOf(
-		projects.junitPlatformCommons,
-		projects.junitPlatformConsole,
-		projects.junitPlatformConsoleStandalone,
-		projects.junitPlatformEngine,
-		projects.junitPlatformLauncher,
-		projects.junitPlatformReporting,
-		projects.junitPlatformSuite,
-		projects.junitPlatformSuiteApi,
-		projects.junitPlatformSuiteEngine,
-		projects.junitPlatformTestkit
-)
-	.map { dependencyProject(it) }
-	.also { extra["platformProjects"] = it }
-
-val jupiterProjects = listOf(
-		projects.junitJupiter,
-		projects.junitJupiterApi,
-		projects.junitJupiterEngine,
-		projects.junitJupiterMigrationsupport,
-		projects.junitJupiterParams
-)
-	.map { dependencyProject(it) }
-	.also { extra["jupiterProjects"] = it }
-
-val vintageProjects = listOf(
+val mavenizedProjects = listOf(
+	projects.junitStart,
+	projects.junitPlatformCommons,
+	projects.junitPlatformConsole,
+	projects.junitPlatformConsoleStandalone,
+	projects.junitPlatformEngine,
+	projects.junitPlatformLauncher,
+	projects.junitPlatformReporting,
+	projects.junitPlatformSuite,
+	projects.junitPlatformSuiteApi,
+	projects.junitPlatformSuiteEngine,
+	projects.junitPlatformTestkit,
+	projects.junitJupiter,
+	projects.junitJupiterApi,
+	projects.junitJupiterEngine,
+	projects.junitJupiterMigrationsupport,
+	projects.junitJupiterParams,
 	projects.junitVintageEngine
 )
-	.map { dependencyProject(it) }
-	.also { extra["vintageProjects"] = it }
-
-val mavenizedProjects = (listOf(dependencyProject(projects.junitStart)) + platformProjects + jupiterProjects + vintageProjects)
 	.also { extra["mavenizedProjects"] = it }
-val modularProjects = (mavenizedProjects - setOf(dependencyProject(projects.junitPlatformConsoleStandalone)))
+
+val modularProjects = mavenizedProjects
+	.filter { it.path != projects.junitPlatformConsoleStandalone.path }
 	.also { extra["modularProjects"] = it }
 
 dependencies {

--- a/documentation/documentation.gradle.kts
+++ b/documentation/documentation.gradle.kts
@@ -2,6 +2,7 @@ import junitbuild.exec.CaptureJavaExecOutput
 import junitbuild.exec.ClasspathSystemPropertyProvider
 import junitbuild.exec.GenerateStandaloneConsoleLauncherShadowedArtifactsFile
 import junitbuild.exec.RunConsoleLauncher
+import junitbuild.extensions.dependencyProject
 import junitbuild.extensions.isSnapshot
 import junitbuild.extensions.javaModuleName
 import junitbuild.javadoc.JavadocValuesOption
@@ -20,9 +21,9 @@ plugins {
 }
 
 @Suppress("UNCHECKED_CAST")
-val mavenizedProjects = rootProject.extra["mavenizedProjects"] as List<Project>
+val mavenizedProjects = rootProject.extra["mavenizedProjects"] as List<ProjectDependency>
 @Suppress("UNCHECKED_CAST")
-val modularProjects = rootProject.extra["modularProjects"] as List<Project>
+val modularProjects = rootProject.extra["modularProjects"] as List<ProjectDependency>
 
 // Because we need to set up Javadoc aggregation
 modularProjects.forEach { evaluationDependsOn(it.path) }
@@ -300,7 +301,7 @@ tasks {
 	}
 
 	val aggregateJavadocs = register("aggregateJavadocs", Javadoc::class) {
-		dependsOn(modularProjects.map { it.tasks.jar })
+		dependsOn(modularProjects.map { dependencyProject(it).tasks.jar })
 		dependsOn(downloadJavadocElementLists)
 		group = "Documentation"
 		description = "Generates aggregated Javadocs"
@@ -351,7 +352,7 @@ tasks {
 			addOption(ModuleSpecificJavadocFileOption("-module-source-path", modularProjects.associate { project ->
 				project.javaModuleName to provider {
 					files(
-						project.sourceSets.named { it.startsWith("main") }.map {
+						dependencyProject(project).sourceSets.named { it.startsWith("main") }.map {
 							it.allJava.srcDirs.filter { it.exists() }
 						}
 					).asPath
@@ -374,9 +375,9 @@ tasks {
 		}
 
 		source(modularProjects.map { project ->
-			files(project.sourceSets.named { it.startsWith("main") }.map { it.allJava })
+			files(dependencyProject(project).sourceSets.named { it.startsWith("main") }.map { it.allJava })
 		})
-		classpath = files(modularProjects.map { it.sourceSets.main.get().compileClasspath })
+		classpath = files(modularProjects.map { dependencyProject(it).sourceSets.main.get().compileClasspath })
 
 		setMaxMemory("1024m")
 		options.destinationDirectory = layout.buildDirectory.dir("docs/javadoc").get().asFile

--- a/documentation/documentation.gradle.kts
+++ b/documentation/documentation.gradle.kts
@@ -229,15 +229,17 @@ tasks {
 		mainClass = "org.junit.api.tools.ApiReportGenerator"
 		systemProperty("api.moduleNames", modularProjects.map { it.javaModuleName }.sorted().joinToString(","))
 		jvmArgumentProviders += ClasspathSystemPropertyProvider("api.modulePath", apiReportClasspath.get())
+		val deprecationFile = deprecatedApisTableFile
+		val experimentalFile = experimentalApisTableFile
 		argumentProviders += CommandLineArgumentProvider {
 			listOf(
-				"DEPRECATED=${deprecatedApisTableFile.get().asFile.absolutePath}",
-				"EXPERIMENTAL=${experimentalApisTableFile.get().asFile.absolutePath}",
+				"DEPRECATED=${deprecationFile.get().asFile.absolutePath}",
+				"EXPERIMENTAL=${experimentalFile.get().asFile.absolutePath}",
 			)
 		}
 		outputs.cacheIf { true }
-		outputs.file(deprecatedApisTableFile)
-		outputs.file(experimentalApisTableFile)
+		outputs.file(deprecationFile)
+		outputs.file(experimentalFile)
 	}
 
 	val generateStandaloneConsoleLauncherShadowedArtifactsFile = register("generateStandaloneConsoleLauncherShadowedArtifactsFile", GenerateStandaloneConsoleLauncherShadowedArtifactsFile::class) {
@@ -266,12 +268,19 @@ tasks {
 
 	val downloadJavadocElementLists = register("downloadJavadocElementLists") {
 		outputs.cacheIf { true }
-		outputs.dir(elementListsDir).withPropertyName("elementListsDir")
-		inputs.property("externalModulesWithoutModularJavadoc", externalModulesWithoutModularJavadoc)
+
+		val targetDir = elementListsDir
+		outputs.dir(targetDir).withPropertyName("targetDir")
+
+		val modules = externalModulesWithoutModularJavadoc
+		inputs.property("modules", modules)
+
+		val textResourceFactory = resources.text
+
 		doFirst {
-			externalModulesWithoutModularJavadoc.forEach { (moduleName, baseUrl) ->
-				val resource = resources.text.fromUri("${baseUrl}element-list")
-				elementListsDir.get().asFile.resolve(moduleName).apply {
+			modules.forEach { (moduleName, baseUrl) ->
+				val resource = textResourceFactory.fromUri("${baseUrl}element-list")
+				targetDir.get().asFile.resolve(moduleName).apply {
 					mkdir()
 					resolve("element-list").writeText("module:$moduleName\n${resource.asString()}")
 				}
@@ -280,15 +289,20 @@ tasks {
 	}
 
 	val mergeJavadocSinceValues = register("mergeJavadocSinceValues") {
-		inputs.files(allJavadocSinceValuesClasspath).withPathSensitivity(PathSensitivity.NONE)
+
+		val classpath = files(allJavadocSinceValuesClasspath.flatMap { it.elements })
+		inputs.files(classpath).withPathSensitivity(PathSensitivity.NONE)
+
 		val outputFile = layout.buildDirectory.file("docs/aggregated-javadoc-since-values.txt")
 		outputs.file(outputFile)
+
 		outputs.cacheIf { true }
+
 		doFirst {
 			val initialVersions = setOf("1.0", "4.12", "5.0")
 			val noPublicItems = setOf("1.3.1", "5.0.3", "5.4.1", "5.11.3")
 			val excludes = initialVersions + noPublicItems
-			val values = allJavadocSinceValuesClasspath.get().files.asSequence()
+			val values = classpath.files.asSequence()
 				.flatMap { it.readLines().asSequence() }
 				.filter { it.isNotBlank() && it !in excludes }
 				.sortedBy { VersionNumber(it) }
@@ -312,6 +326,8 @@ tasks {
 		inputs.file(additionalStylesheetFile)
 		val overviewFile = "src/javadoc/junit-overview.html"
 		inputs.file(overviewFile)
+
+		notCompatibleWithConfigurationCache("--module and --since options need to be lazy")
 
 		options {
 
@@ -389,11 +405,19 @@ tasks {
 		description = "Fix links to external API specs in the locally aggregated Javadoc HTML files"
 
 		val inputDir = aggregateJavadocs.map { it.destinationDir!! }
-		inputs.property("externalModulesWithoutModularJavadoc", externalModulesWithoutModularJavadoc)
+		val modules = externalModulesWithoutModularJavadoc
+		inputs.property("externalModulesWithoutModularJavadoc", modules)
 		from(inputDir.map { File(it, "element-list") }) {
 			// For compatibility with pre JDK 10 versions of the Javadoc tool
 			rename { "package-list" }
 		}
+		val targetUrl = provider { project.version.toString().replace("-SNAPSHOT", "") }
+			.map { version ->
+				if (buildParameters.ci)
+					"https://docs.junit.org/$version"
+				else
+					project.antora.siteDir.get().asFile.toURI().resolve(version).toString()
+			}
 		from(inputDir) {
 			filesMatching("**/*.html") {
 				val favicon =
@@ -402,19 +426,13 @@ tasks {
 						<link rel="icon" type="image/svg+xml" href="https://junit.org/assets/img/junit-diamond-adaptive.svg" sizes="any">
 						""".trimIndent()
 
-				val version = project.version.toString().replace("-SNAPSHOT", "")
-				val targetUrl = if (buildParameters.ci)
-					"https://docs.junit.org/$version"
-				else
-					project.antora.siteDir.get().asFile.toURI().resolve(version).toString()
-
 				filter { line ->
 					var result = if (line.startsWith("<head>")) line.replace("<head>", "<head>$favicon") else line
-					externalModulesWithoutModularJavadoc.forEach { (moduleName, baseUrl) ->
+					modules.forEach { (moduleName, baseUrl) ->
 						result = result.replace("${baseUrl}$moduleName/", baseUrl)
 					}
 
-					result = result.replace("https://docs.junit.org/current", targetUrl)
+					result = result.replace("https://docs.junit.org/current", targetUrl.get())
 
 					return@filter result
 				}

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,7 @@ apiBaselineVersion = 6.1.2
 org.gradle.jvmargs=-Xmx1g -XX:+HeapDumpOnOutOfMemoryError
 org.gradle.caching=true
 org.gradle.parallel=true
+org.gradle.configuration-cache=true
 org.gradle.configuration-cache.parallel=true
 org.gradle.java.installations.fromEnv=GRAALVM_HOME,JDK17,JDK21,JDK24,JDK25
 org.gradle.kotlin.dsl.allWarningsAsErrors=true

--- a/gradle/base/code-generator-model/src/main/resources/jre.yaml
+++ b/gradle/base/code-generator-model/src/main/resources/jre.yaml
@@ -35,4 +35,4 @@
 - version: 27
   since: '6.1'
 - version: 28
-  since: '6.2'
+  since: '6.1.1'

--- a/gradle/plugins/backward-compatibility/src/main/kotlin/junitbuild.backward-compatibility.gradle.kts
+++ b/gradle/plugins/backward-compatibility/src/main/kotlin/junitbuild.backward-compatibility.gradle.kts
@@ -52,7 +52,8 @@ val downloadPreviousReleaseJar = tasks.register("downloadPreviousReleaseJar", Do
 	if (gradle.startParameter.isOffline) {
 		enabled = false
 	}
-	onlyIf { extension.enabled.get() }
+	val enabled = extension.enabled
+	onlyIf { enabled.get() }
 	val previousVersion = extension.previousVersion.get()
 	src("https://repo1.maven.org/maven2/${project.group.toString().replace(".", "/")}/${project.name}/$previousVersion/${project.name}-$previousVersion.jar")
 	dest(layout.buildDirectory.dir("previousRelease"))
@@ -68,7 +69,8 @@ val roseau = tasks.register("roseau", RoseauDiff::class) {
 	if (gradle.startParameter.isOffline) {
 		enabled = false
 	}
-	onlyIf { extension.enabled.get() }
+	val enabled = extension.enabled
+	onlyIf { enabled.get() }
 
 	toolClasspath.from(roseauClasspath)
 	libraryClasspath.from(configurations.compileClasspath)

--- a/gradle/plugins/build-parameters/build.gradle.kts
+++ b/gradle/plugins/build-parameters/build.gradle.kts
@@ -107,11 +107,14 @@ buildParameters {
 			description = "The version computed by Jitpack"
 		}
 	}
+	string("sourceDateEpoch") {
+		description = """
+			Overrides the value of the 'Build-Date' and 'Build-Time' jar manifest entries as well as the timestamp of file entries in JAR files.
+			Can be set as a String (e.g. '2023-11-05 17:49:13.996+0100') or as seconds since the epoch.
+			""".trimIndent()
+		fromEnvironment("SOURCE_DATE_EPOCH") // see https://reproducible-builds.org/docs/source-date-epoch/
+	}
 	group("manifest") {
-		string("buildTimestamp") {
-			description = "Overrides the value of the 'Build-Date' and 'Build-Time' jar manifest entries. Can be set as a String (e.g. '2023-11-05 17:49:13.996+0100') or as seconds since the epoch."
-			fromEnvironment("SOURCE_DATE_EPOCH") // see https://reproducible-builds.org/docs/source-date-epoch/
-		}
 		string("builtBy") {
 			description = "Overrides the value of the 'Built-By' jar manifest entry"
 		}

--- a/gradle/plugins/common/src/main/kotlin/junitbuild.build-metadata.gradle.kts
+++ b/gradle/plugins/common/src/main/kotlin/junitbuild.build-metadata.gradle.kts
@@ -1,32 +1,33 @@
 import java.time.Instant
-import java.time.OffsetDateTime
-import java.time.ZoneOffset
+import java.time.ZoneOffset.UTC
 import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeFormatterBuilder
+import java.time.temporal.ChronoUnit.SECONDS
 
 plugins {
 	id("junitbuild.build-parameters")
 }
 
-val dateFormatter = DateTimeFormatter.ISO_LOCAL_DATE
-val timeFormatter = DateTimeFormatter.ofPattern("HH:mm:ss.SSSZ")
+val dateFormatter = DateTimeFormatter.ISO_LOCAL_DATE.withZone(UTC)
+val timeFormatter = DateTimeFormatter.ofPattern("HH:mm:ss.SSSZ").withZone(UTC)
 
-val buildTimeAndDate = buildParameters.manifest.buildTimestamp
-	.map {
-		it.toLongOrNull()
-			?.let { s -> Instant.ofEpochSecond(s).atOffset(ZoneOffset.UTC) }
+val buildTimestamp = buildParameters.sourceDateEpoch
+	.map { value ->
+		value.toLongOrNull()
+			?.let { longValue -> Instant.ofEpochSecond(longValue) }
 			?: DateTimeFormatterBuilder()
 				.append(dateFormatter)
 				.appendLiteral(' ')
 				.append(timeFormatter)
 				.toFormatter()
-				.parse(it)
+				.parse(value, Instant::from)
+				.truncatedTo(SECONDS)
 	}
-	.orNull
-	?: OffsetDateTime.now()
+	.getOrElse(Instant.now())
 
-extra["buildDate"] = dateFormatter.format(buildTimeAndDate)
-extra["buildTime"] = timeFormatter.format(buildTimeAndDate)
+extra["buildTimestamp"] = buildTimestamp
+extra["buildDate"] = dateFormatter.format(buildTimestamp)
+extra["buildTime"] = timeFormatter.format(buildTimestamp)
 extra["buildRevision"] = providers.exec {
 	commandLine("git", "rev-parse", "--verify", "HEAD")
 }.standardOutput.asText.get().trim()

--- a/gradle/plugins/common/src/main/kotlin/junitbuild.jacoco-java-conventions.gradle.kts
+++ b/gradle/plugins/common/src/main/kotlin/junitbuild.jacoco-java-conventions.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 @Suppress("UNCHECKED_CAST")
-val mavenizedProjects = rootProject.extra["mavenizedProjects"] as List<Project>
+val mavenizedProjects = rootProject.extra["mavenizedProjects"] as List<ProjectDependency>
 
 tasks.withType<Test>().configureEach {
 	configure<JacocoTaskExtension> {
@@ -19,7 +19,7 @@ tasks.withType<Test>().configureEach {
 val codeCoverageClassesJar = tasks.register("codeCoverageClassesJar", Jar::class) {
 	from(tasks.jar.map { zipTree(it.archiveFile) })
 	archiveClassifier = "jacoco"
-	enabled = project in mavenizedProjects
+	enabled = project.path in mavenizedProjects.map { it.path }
 	duplicatesStrategy = DuplicatesStrategy.INCLUDE
 }
 

--- a/gradle/plugins/common/src/main/kotlin/junitbuild.java-library-conventions.gradle.kts
+++ b/gradle/plugins/common/src/main/kotlin/junitbuild.java-library-conventions.gradle.kts
@@ -1,5 +1,6 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import junitbuild.extensions.isSnapshot
+import java.time.Instant
 
 plugins {
 	`java-library`
@@ -13,6 +14,7 @@ plugins {
 
 @Suppress("UNCHECKED_CAST")
 val mavenizedProjects = rootProject.extra["mavenizedProjects"] as List<ProjectDependency>
+val buildTimestamp = rootProject.extra["buildTimestamp"] as Instant
 val buildDate = rootProject.extra["buildDate"] as String
 val buildTime = rootProject.extra["buildTime"] as String
 val buildRevision = rootProject.extra["buildRevision"] as String
@@ -85,7 +87,7 @@ if (project.path in mavenizedProjects.map { it.path }) {
 }
 
 tasks.withType<AbstractArchiveTask>().configureEach {
-	isPreserveFileTimestamps = false
+	reproducibleFileTimestamp = buildTimestamp.toEpochMilli()
 	isReproducibleFileOrder = true
 	dirPermissions {
 		unix("rwxr-xr-x")

--- a/gradle/plugins/common/src/main/kotlin/junitbuild.java-library-conventions.gradle.kts
+++ b/gradle/plugins/common/src/main/kotlin/junitbuild.java-library-conventions.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 }
 
 @Suppress("UNCHECKED_CAST")
-val mavenizedProjects = rootProject.extra["mavenizedProjects"] as List<Project>
+val mavenizedProjects = rootProject.extra["mavenizedProjects"] as List<ProjectDependency>
 val buildDate = rootProject.extra["buildDate"] as String
 val buildTime = rootProject.extra["buildTime"] as String
 val buildRevision = rootProject.extra["buildRevision"] as String
@@ -23,7 +23,7 @@ java {
 	modularity.inferModulePath = true
 }
 
-if (project in mavenizedProjects) {
+if (project.path in mavenizedProjects.map { it.path }) {
 
 	apply(plugin = "junitbuild.javadoc-conventions")
 	apply(plugin = "junitbuild.publishing-conventions")

--- a/gradle/plugins/common/src/main/kotlin/junitbuild.javadoc-conventions.gradle.kts
+++ b/gradle/plugins/common/src/main/kotlin/junitbuild.javadoc-conventions.gradle.kts
@@ -70,13 +70,17 @@ tasks.named<Jar>("javadocJar").configure {
 }
 
 val extractJavadocSinceValues = tasks.register("extractJavadocSinceValues") {
-	inputs.files(sourceSets.main.get().allJava).withPathSensitivity(PathSensitivity.NONE)
+	val sourceFiles = files(sourceSets.main.get().allJava.elements)
+	inputs.files(sourceFiles).withPathSensitivity(PathSensitivity.NONE)
+
 	val outputFile = layout.buildDirectory.file("docs/javadoc-since-values.txt")
 	outputs.file(outputFile)
+
 	outputs.cacheIf { true }
+
 	doFirst {
 		val regex = "\\s+(?:\\*|///) @since ([0-9.]+).*".toRegex()
-		val values = sourceSets.main.get().allJava.files.asSequence()
+		val values = sourceFiles.files.asSequence()
 			.flatMap { file -> file.readLines().asSequence() }
 			.mapNotNull(regex::matchEntire)
 			.map { result -> result.groupValues[1] }

--- a/gradle/plugins/common/src/main/kotlin/junitbuild.osgi-conventions.gradle.kts
+++ b/gradle/plugins/common/src/main/kotlin/junitbuild.osgi-conventions.gradle.kts
@@ -1,5 +1,6 @@
 import aQute.bnd.gradle.BundleTaskExtension
 import aQute.bnd.gradle.Resolve
+import java.time.Instant
 
 plugins {
 	`java-library`
@@ -12,7 +13,9 @@ val projectDescription = objects.property<String>().convention(provider { projec
 // metadata into the jar
 tasks.withType<Jar>().named {
 	it == "jar" || it == "shadowJar"
-}.all { // configure tasks eagerly as workaround for https://github.com/bndtools/bnd/issues/5695
+}.configureEach {
+
+	val buildTimestamp = rootProject.extra["buildTimestamp"] as Instant
 
 	val importAPIGuardian = "org.apiguardian.*;resolution:=\"optional\""
 		.also { extra["importAPIGuardian"] = it }
@@ -72,6 +75,8 @@ tasks.withType<Jar>().named {
 				# See https://bnd.bndtools.org/instructions/noimportjava.html
 				# Issue: https://github.com/junit-team/junit-framework/issues/4733
 				-noimportjava: true
+
+				-reproducible: ${buildTimestamp.epochSecond}
 			"""
 		)
 

--- a/gradle/plugins/common/src/main/kotlin/junitbuild.publishing-conventions.gradle.kts
+++ b/gradle/plugins/common/src/main/kotlin/junitbuild.publishing-conventions.gradle.kts
@@ -7,22 +7,15 @@ plugins {
 	id("junitbuild.build-parameters")
 }
 
-@Suppress("UNCHECKED_CAST")
-val jupiterProjects = rootProject.extra["jupiterProjects"] as List<Project>
-
-@Suppress("UNCHECKED_CAST")
-val platformProjects = rootProject.extra["platformProjects"] as List<Project>
-
-@Suppress("UNCHECKED_CAST")
-val vintageProjects = rootProject.extra["vintageProjects"] as List<Project>
-
 group = buildParameters.publishing.group
-	.getOrElse(when (project) {
-		in jupiterProjects -> "org.junit.jupiter"
-		in platformProjects -> "org.junit.platform"
-		in vintageProjects -> "org.junit.vintage"
-		else -> "org.junit"
-	})
+	.getOrElse(
+		when {
+			name.startsWith("junit-jupiter") -> "org.junit.jupiter"
+			name.startsWith("junit-platform") -> "org.junit.platform"
+			name.startsWith("junit-vintage") -> "org.junit.vintage"
+			else -> "org.junit"
+		}
+	)
 
 val signArtifacts = buildParameters.publishing.signArtifacts.getOrElse(!(project.version.isSnapshot() || buildParameters.ci))
 

--- a/gradle/plugins/common/src/main/kotlin/junitbuild.publishing-conventions.gradle.kts
+++ b/gradle/plugins/common/src/main/kotlin/junitbuild.publishing-conventions.gradle.kts
@@ -33,7 +33,13 @@ publishing {
 	publications {
 		create<MavenPublication>("maven") {
 			version = buildParameters.jitpack.version
-				.map { value -> "(.+)-[0-9a-f]+-\\d+".toRegex().matchEntire(value)!!.groupValues[1] + "-SNAPSHOT" }
+				.map { value ->
+					val pattern = "(.+)-[0-9a-f]+-\\d+".toRegex()
+					val matcher = requireNotNull(pattern.matchEntire(value)) {
+						"Jitpack version does not match expected pattern: $pattern"
+					}
+					matcher.groupValues[1] + "-SNAPSHOT"
+				}
 				.getOrElse(project.version.toString())
 			pom {
 				name.set(provider {

--- a/gradle/plugins/common/src/main/kotlin/junitbuild.shadow-conventions.gradle.kts
+++ b/gradle/plugins/common/src/main/kotlin/junitbuild.shadow-conventions.gradle.kts
@@ -38,12 +38,20 @@ tasks {
 	shadowJar {
 		configurations = listOf(shadowedClasspath.get())
 		exclude("META-INF/maven/**")
+
 		excludes.remove("module-info.class")
-		archiveClassifier = ""
 		from(sourceSets.main.get().output.classesDirs) {
 			include("module-info.class")
 		}
+
+		duplicatesStrategy = DuplicatesStrategy.FAIL
+		filesMatching("module-info.class") {
+			duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+		}
+
+		archiveClassifier = ""
 		addMultiReleaseAttribute = false
+		failOnDuplicateEntries = true
 	}
 	jar {
 		dependsOn(shadowJar)

--- a/gradle/plugins/common/src/main/kotlin/junitbuild.testing-conventions.gradle.kts
+++ b/gradle/plugins/common/src/main/kotlin/junitbuild.testing-conventions.gradle.kts
@@ -51,10 +51,8 @@ val generateOpenTestHtmlReport = tasks.register("generateOpenTestHtmlReport", Ja
 		outputLocation = layout.buildDirectory.file("reports/open-test-report.html")
 	}
 	if (buildParameters.testing.hideOpenTestReportHtmlGeneratorOutput) {
-		standardOutput = object : OutputStream() {
-			override fun write(b: Int) {
-				// discard output
-			}
+		doFirst {
+			standardOutput = OutputStream.nullOutputStream()
 		}
 	}
 	outputs.cacheIf { true }

--- a/gradle/plugins/common/src/main/kotlin/junitbuild/java/UpdateJarAction.kt
+++ b/gradle/plugins/common/src/main/kotlin/junitbuild/java/UpdateJarAction.kt
@@ -2,45 +2,30 @@ package junitbuild.java
 
 import org.gradle.api.Action
 import org.gradle.api.Task
-import org.gradle.api.internal.file.archive.ZipEntryConstants
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.jvm.toolchain.JavaLauncher
 import org.gradle.process.ExecOperations
 import java.time.Instant
-import java.time.LocalDateTime
-import java.time.ZoneId
-import java.time.ZoneOffset
 import javax.inject.Inject
 
 abstract class UpdateJarAction @Inject constructor(private val operations: ExecOperations): Action<Task> {
-
-    companion object {
-        // Since ZipCopyAction.CONSTANT_TIME_FOR_ZIP_ENTRIES is in the default time zone (see its Javadoc),
-        // we're converting it to the same time in UTC here to make the jar reproducible regardless of the
-        // build's time zone.
-        private val CONSTANT_TIME_FOR_ZIP_ENTRIES = LocalDateTime.ofInstant(Instant.ofEpochMilli(ZipEntryConstants.CONSTANT_TIME_FOR_ZIP_ENTRIES), ZoneId.systemDefault())
-            .toInstant(ZoneOffset.UTC)
-            .toString()
-    }
 
     abstract val javaLauncher: Property<JavaLauncher>
 
     abstract val args: ListProperty<String>
 
-    init {
-        args.addAll(
-            "--update",
-            // Use a constant time to make the JAR reproducible.
-            "--date=$CONSTANT_TIME_FOR_ZIP_ENTRIES",
-        )
-    }
+    abstract val date : Property<Instant>
 
     override fun execute(t: Task) {
         operations.exec {
             executable = javaLauncher.get()
                 .metadata.installationPath.file("bin/jar").asFile.absolutePath
-            args = this@UpdateJarAction.args.get()
+            args = listOf(
+                "--update",
+                // Use a constant time to make the JAR reproducible.
+                "--date=${date.get()}",
+            ) + this@UpdateJarAction.args.get()
         }
     }
 }

--- a/gradle/plugins/publishing/src/main/kotlin/junitbuild.maven-central-publishing.settings.gradle.kts
+++ b/gradle/plugins/publishing/src/main/kotlin/junitbuild.maven-central-publishing.settings.gradle.kts
@@ -16,15 +16,3 @@ nmcpSettings {
 		publishingTimeout = buildParameters.publishing.timeout.map(Duration::parse)
 	}
 }
-
-gradle.lifecycle.afterProject {
-	if (project == rootProject) {
-		tasks.named<Zip>("nmcpZipAggregation") {
-			eachFile {
-				if (name.contains(".asc.")) {
-					exclude()
-				}
-			}
-		}
-	}
-}

--- a/junit-bom/junit-bom.gradle.kts
+++ b/junit-bom/junit-bom.gradle.kts
@@ -15,8 +15,9 @@ dependencies {
 			.forEach {
 				api(
 					jitPackVersion
-						.orElse(provider { it.version })
-						.map { version -> "${it.group}:${it.name}:${version}" })
+						.map<Any> { version -> "${it.group}:${it.name}:${version}" }
+						.orElse(it)
+				)
 			}
 	}
 }

--- a/junit-bom/junit-bom.gradle.kts
+++ b/junit-bom/junit-bom.gradle.kts
@@ -8,14 +8,16 @@ description = "${rootProject.description} (Bill of Materials)"
 dependencies {
 	constraints {
 		@Suppress("UNCHECKED_CAST")
-		val mavenizedProjects = rootProject.extra["mavenizedProjects"] as List<Project>
-		mavenizedProjects.sorted()
-				.forEach {
-					val version = buildParameters.jitpack.version
-						.map { value -> "(.+)-[0-9a-f]+-\\d+".toRegex().matchEntire(value)!!.groupValues[1] + "-SNAPSHOT" }
-						.getOrElse(it.version.toString())
-					api("${it.group}:${it.name}:${version}")
-				}
+		val mavenizedProjects = rootProject.extra["mavenizedProjects"] as List<ProjectDependency>
+		val jitPackVersion = buildParameters.jitpack.version
+			.map { value -> "(.+)-[0-9a-f]+-\\d+".toRegex().matchEntire(value)!!.groupValues[1] + "-SNAPSHOT" }
+		mavenizedProjects.sortedBy { it.name }
+			.forEach {
+				api(
+					jitPackVersion
+						.orElse(provider { it.version })
+						.map { version -> "${it.group}:${it.name}:${version}" })
+			}
 	}
 }
 

--- a/junit-platform-console/junit-platform-console.gradle.kts
+++ b/junit-platform-console/junit-platform-console.gradle.kts
@@ -2,6 +2,7 @@ import junitbuild.extensions.javaModuleName
 import junitbuild.java.UpdateJarAction
 import net.ltgt.gradle.errorprone.errorprone
 import net.ltgt.gradle.nullaway.nullaway
+import java.time.Instant
 
 plugins {
 	id("junitbuild.java-library-conventions")
@@ -54,6 +55,7 @@ tasks {
 		}
 		doLast(objects.newInstance(UpdateJarAction::class).apply {
 			javaLauncher = project.javaToolchains.launcherFor(java.toolchain)
+			date = rootProject.extra["buildTimestamp"] as Instant
 			args.addAll(
 				"--file", archiveFile.get().asFile.absolutePath,
 				"--main-class", "org.junit.platform.console.ConsoleLauncher",

--- a/junit-platform-reporting/junit-platform-reporting.gradle.kts
+++ b/junit-platform-reporting/junit-platform-reporting.gradle.kts
@@ -32,6 +32,7 @@ tasks {
 			val packageName = "org.opentest4j.reporting.${name}"
 			relocate(packageName, "org.junit.platform.reporting.shadow.${packageName}")
 		}
+		exclude("META-INF/LICENSE.md")
 		from(projectDir) {
 			include("LICENSE-open-test-reporting.md")
 			into("META-INF")

--- a/platform-tests/platform-tests.gradle.kts
+++ b/platform-tests/platform-tests.gradle.kts
@@ -65,7 +65,7 @@ dependencies {
 
 	// --- Test run-time dependencies ---------------------------------------------
 	@Suppress("UNCHECKED_CAST")
-	val mavenizedProjects = rootProject.extra["mavenizedProjects"] as List<Project>
+	val mavenizedProjects = rootProject.extra["mavenizedProjects"] as List<ProjectDependency>
 	mavenizedProjects.filter { it.path != projects.junitPlatformConsoleStandalone.path }.forEach {
 		// Add all projects to the classpath for tests using classpath scanning
 		testRuntimeOnly(it)

--- a/platform-tooling-support-tests/platform-tooling-support-tests.gradle.kts
+++ b/platform-tooling-support-tests/platform-tooling-support-tests.gradle.kts
@@ -55,7 +55,7 @@ val mavenDistributionClasspath = configurations.resolvable("mavenDistributionCla
 }
 
 @Suppress("UNCHECKED_CAST")
-val modularProjects = rootProject.extra["modularProjects"] as List<Project>
+val modularProjects = rootProject.extra["modularProjects"] as List<ProjectDependency>
 
 dependencies {
 	implementation(libs.commons.io) {
@@ -112,13 +112,13 @@ val unzipMavenDistribution = tasks.register("unzipMavenDistribution", Sync::clas
 val normalizeMavenRepo = tasks.register("normalizeMavenRepo", Sync::class) {
 
 	@Suppress("UNCHECKED_CAST")
-	val mavenizedProjects = rootProject.extra["mavenizedProjects"] as List<Project>
+	val mavenizedProjects = rootProject.extra["mavenizedProjects"] as List<ProjectDependency>
 	val tempRepoDir = rootProject.extra["tempRepoDir"] as File
 	val tempRepoName = rootProject.extra["tempRepoName"] as String
 
 	// All maven-aware projects must be published to the local temp repository
-	(mavenizedProjects + dependencyProject(projects.junitBom))
-		.map { project -> project.tasks.named("publishAllPublicationsTo${tempRepoName.capitalized()}Repository") }
+	(mavenizedProjects + projects.junitBom)
+		.map { project -> dependencyProject(project).tasks.named("publishAllPublicationsTo${tempRepoName.capitalized()}Repository") }
 		.forEach { dependsOn(it) }
 
 	from(tempRepoDir) {
@@ -228,7 +228,7 @@ testing.suites.named<JvmTestSuite>("test") {
 				systemProperty("junit.modules", modularProjects.map { it.javaModuleName }.joinToString(","))
 
 				jvmArgumentProviders += CommandLineArgumentProvider {
-					modularProjects.map { "-Djunit.moduleSourcePath.${it.javaModuleName}=${it.sourceSets["main"].allJava.sourceDirectories.filter { it.exists() }.asPath}" }
+					modularProjects.map { "-Djunit.moduleSourcePath.${it.javaModuleName}=${dependencyProject(it).sourceSets["main"].allJava.sourceDirectories.filter { it.exists() }.asPath}" }
 				}
 
 				inputs.apply {

--- a/platform-tooling-support-tests/platform-tooling-support-tests.gradle.kts
+++ b/platform-tooling-support-tests/platform-tooling-support-tests.gradle.kts
@@ -227,8 +227,8 @@ testing.suites.named<JvmTestSuite>("test") {
 
 				systemProperty("junit.modules", modularProjects.map { it.javaModuleName }.joinToString(","))
 
-				jvmArgumentProviders += CommandLineArgumentProvider {
-					modularProjects.map { "-Djunit.moduleSourcePath.${it.javaModuleName}=${dependencyProject(it).sourceSets["main"].allJava.sourceDirectories.filter { it.exists() }.asPath}" }
+				modularProjects.forEach {
+					jvmArgumentProviders += ModuleSourcePath(dependencyProject(it))
 				}
 
 				inputs.apply {
@@ -327,4 +327,15 @@ class MavenDistribution(project: Project, sourceTask: TaskProvider<*>, distribut
 		.fileProvider(project.files(distributionDir).builtBy(sourceTask).elements.map { it.single().asFile.listFilesOrdered().single() })
 
 	override fun asArguments() = listOf("-DmavenDistribution=${mavenDistribution.get().asFile.absolutePath}")
+}
+
+class ModuleSourcePath(project: Project) : CommandLineArgumentProvider {
+	@Input
+	val moduleName: Property<String> = project.objects.property<String>().value(project.javaModuleName)
+
+	@Internal // already tracked indirectly
+	val dirs: ConfigurableFileCollection = project.objects.fileCollection()
+		.from(project.sourceSets["main"].allJava.sourceDirectories.filter { it.exists() })
+
+	override fun asArguments() = listOf("-Djunit.moduleSourcePath.${moduleName.get()}=${dirs.asPath}")
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -106,3 +106,4 @@ rootProject.children.forEach { project ->
 enableFeaturePreview("STABLE_CONFIGURATION_CACHE")
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 enableFeaturePreview("NO_IMPLICIT_LOOKUP_IN_PARENT_PROJECTS")
+enableFeaturePreview("ENHANCED_GRAPH_ORDERING")


### PR DESCRIPTION
- **Resolve "project object as dependency notation" deprecations**
- **Improve error message if Jitpack version does not match expected pattern**
- **Include correct license file in junit-platform-reporting JAR**
- **Use project dependency unless Jitpack version is set**
- **Opt in to improved dependency resolution ordering**
- **Remove obsolete filter for checksums of signature files**
- **Use `SOURCE_DATE_EPOCH` or current timestamp for JAR file entries**
- **Fix "since" version of `JRE.JAVA_28`**
- **Resolve incompatibilities with the configuration cache**
- **Enable configuration cache by default**

<!-- Please describe your changes here and list any open questions you might have. -->

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://docs.junit.org/snapshot/) and [Release Notes](https://docs.junit.org/snapshot/release-notes.html)
