### PR TITLE
Restore compatibility with GraalVM 25

### DIFF
--- a/.github/actions/setup-graalvm/action.yml
+++ b/.github/actions/setup-graalvm/action.yml
@@ -1,0 +1,17 @@
+name: Set up GraalVM
+description: Installs GraalVM and exports its home directory under a versioned env var
+inputs:
+  java-version:
+    required: true
+    description: "The GraalVM Java version to install"
+runs:
+  using: "composite"
+  steps:
+    - uses: graalvm/setup-graalvm@0def53c0fd8534bc13416c9469f5be45265824fd # v1.6.3
+      with:
+        distribution: graalvm
+        java-version: ${{ inputs.java-version }}
+    - shell: bash
+      env:
+        JAVA_VERSION: ${{ inputs.java-version }}
+      run: echo "GRAALVM_${JAVA_VERSION}_HOME=$GRAALVM_HOME" >> "$GITHUB_ENV" # zizmor: ignore[github-env]

--- a/.github/actions/setup-graalvm/action.yml
+++ b/.github/actions/setup-graalvm/action.yml
@@ -1,0 +1,17 @@
+name: Set up GraalVM
+description: Installs GraalVM and exports its home directory under a versioned env var
+inputs:
+  java-version:
+    required: true
+    description: "The GraalVM Java version to install"
+runs:
+  using: "composite"
+  steps:
+    - uses: graalvm/setup-graalvm@5298d94fb55a4f185c602eeac5de1b553882abe2 # v1.6.4
+      with:
+        distribution: graalvm
+        java-version: ${{ inputs.java-version }}
+    - shell: bash
+      env:
+        JAVA_VERSION: ${{ inputs.java-version }}
+      run: echo "GRAALVM_${JAVA_VERSION}_HOME=$GRAALVM_HOME" >> "$GITHUB_ENV" # zizmor: ignore[github-env]

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -17,11 +17,14 @@ jobs:
       with:
         fetch-depth: 1
         persist-credentials: false
-    - name: Install GraalVM
-      uses: graalvm/setup-graalvm@0def53c0fd8534bc13416c9469f5be45265824fd # v1.6.3
+    - name: Set up GraalVM 21
+      uses: ./.github/actions/setup-graalvm
       with:
-        distribution: graalvm
         java-version: 21
+    - name: Set up GraalVM 25
+      uses: ./.github/actions/setup-graalvm
+      with:
+        java-version: 25
     - name: Build
       uses: ./.github/actions/main-build
       with:

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -17,11 +17,14 @@ jobs:
       with:
         fetch-depth: 1
         persist-credentials: false
-    - name: Install GraalVM
-      uses: graalvm/setup-graalvm@5298d94fb55a4f185c602eeac5de1b553882abe2 # v1.6.4
+    - name: Set up GraalVM 21
+      uses: ./.github/actions/setup-graalvm
       with:
-        distribution: graalvm
         java-version: 21
+    - name: Set up GraalVM 25
+      uses: ./.github/actions/setup-graalvm
+      with:
+        java-version: 25
     - name: Build
       uses: ./.github/actions/main-build
       with:

--- a/documentation/modules/ROOT/partials/release-notes/release-notes-6.1.3.adoc
+++ b/documentation/modules/ROOT/partials/release-notes/release-notes-6.1.3.adoc
@@ -16,7 +16,8 @@ repository on GitHub.
 [[v6.1.3-junit-platform-bug-fixes]]
 ==== Bug Fixes
 
-* Provide serialization metadata for `UniqueId` to fix compatibility with GraalVM 25
+* Provide reachability metadata for `junit-platform-engine` to restore compatibility with
+  GraalVM 25
 
 [[v6.1.3-junit-platform-deprecations-and-breaking-changes]]
 ==== Deprecations and Breaking Changes

--- a/documentation/modules/ROOT/partials/release-notes/release-notes-6.1.3.adoc
+++ b/documentation/modules/ROOT/partials/release-notes/release-notes-6.1.3.adoc
@@ -16,7 +16,7 @@ repository on GitHub.
 [[v6.1.3-junit-platform-bug-fixes]]
 ==== Bug Fixes
 
-* ❓
+* Provide serialization metadata for `UniqueId` to fix compatibility with GraalVM 25
 
 [[v6.1.3-junit-platform-deprecations-and-breaking-changes]]
 ==== Deprecations and Breaking Changes

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.caching=true
 org.gradle.parallel=true
 org.gradle.configuration-cache=true
 org.gradle.configuration-cache.parallel=true
-org.gradle.java.installations.fromEnv=GRAALVM_HOME,JDK17,JDK21,JDK24,JDK25
+org.gradle.java.installations.fromEnv=JDK17,JDK21,JDK24,JDK25
 org.gradle.kotlin.dsl.allWarningsAsErrors=true
 
 # Test Distribution

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,6 +36,7 @@ fastcsv = { module = "de.siegmar:fastcsv", version = "4.3.1" }
 groovy = { module = "org.apache.groovy:groovy", version = "5.0.7" }
 groovy2-bom = { module = "org.codehaus.groovy:groovy-bom", version = "2.5.23" }
 hamcrest = { module = "org.hamcrest:hamcrest", version = "3.0" }
+jackson-databind = { module = "tools.jackson.core:jackson-databind", version.ref = "jackson" }
 jackson-dataformat-yaml = { module = "tools.jackson.dataformat:jackson-dataformat-yaml", version.ref = "jackson" }
 jackson-module-kotlin = { module = "tools.jackson.module:jackson-module-kotlin", version.ref = "jackson" }
 jaxb-api = { module = "jakarta.xml.bind:jakarta.xml.bind-api", version = "4.0.5" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,6 +36,7 @@ fastcsv = { module = "de.siegmar:fastcsv", version = "4.4.0" }
 groovy = { module = "org.apache.groovy:groovy", version = "5.0.8" }
 groovy2-bom = { module = "org.codehaus.groovy:groovy-bom", version = "2.5.23" }
 hamcrest = { module = "org.hamcrest:hamcrest", version = "3.0" }
+jackson-databind = { module = "tools.jackson.core:jackson-databind", version.ref = "jackson" }
 jackson-dataformat-yaml = { module = "tools.jackson.dataformat:jackson-dataformat-yaml", version.ref = "jackson" }
 jackson-module-kotlin = { module = "tools.jackson.module:jackson-module-kotlin", version.ref = "jackson" }
 jaxb-api = { module = "jakarta.xml.bind:jakarta.xml.bind-api", version = "4.0.5" }

--- a/gradle/plugins/common/src/main/kotlin/junitbuild.testing-conventions.gradle.kts
+++ b/gradle/plugins/common/src/main/kotlin/junitbuild.testing-conventions.gradle.kts
@@ -6,6 +6,7 @@ import junitbuild.extensions.dependencyFromLibs
 import junitbuild.extensions.trackOperationSystemAsInput
 import org.gradle.api.tasks.PathSensitivity.RELATIVE
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
+import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.gradle.api.tasks.testing.logging.TestLogEvent.FAILED
 import org.gradle.internal.os.OperatingSystem
 import java.io.IOException
@@ -80,6 +81,11 @@ tasks.withType<Test>().configureEach {
 	testLogging {
 		events = setOf(FAILED)
 		exceptionFormat = FULL
+
+		info {
+			events = TestLogEvent.entries.toSet()
+			showStandardStreams = true
+		}
 	}
 	develocity {
 		testRetry {

--- a/junit-platform-engine/src/main/resources/META-INF/native-image/org.junit.platform/junit-platform-engine/reachability-metadata.json
+++ b/junit-platform-engine/src/main/resources/META-INF/native-image/org.junit.platform/junit-platform-engine/reachability-metadata.json
@@ -1,0 +1,8 @@
+{
+  "reflection": [
+    {
+      "type": "org.junit.platform.engine.UniqueId$SerializedForm",
+      "serializable": true
+    }
+  ]
+}

--- a/junit-platform-engine/src/main/resources/META-INF/native-image/org.junit.platform/junit-platform-engine/serialization-config.json
+++ b/junit-platform-engine/src/main/resources/META-INF/native-image/org.junit.platform/junit-platform-engine/serialization-config.json
@@ -1,0 +1,5 @@
+[
+  {
+    "name": "org.junit.platform.engine.UniqueId$SerializedForm"
+  }
+]

--- a/junit-platform-engine/src/main/resources/META-INF/native-image/org.junit.platform/junit-platform-engine/serialization-config.json
+++ b/junit-platform-engine/src/main/resources/META-INF/native-image/org.junit.platform/junit-platform-engine/serialization-config.json
@@ -1,5 +1,0 @@
-[
-  {
-    "name": "org.junit.platform.engine.UniqueId$SerializedForm"
-  }
-]

--- a/platform-tooling-support-tests/platform-tooling-support-tests.gradle.kts
+++ b/platform-tooling-support-tests/platform-tooling-support-tests.gradle.kts
@@ -186,8 +186,10 @@ val graalVmTest = testing.suites.register("graalVmTest", JvmTestSuite::class) {
 		all {
 			testTask.configure {
 				configureToolingSupportTests()
-				val graalVmHome = providers.environmentVariable("GRAALVM_HOME")
-				onlyIf("GRAALVM_HOME environment variable is set") { graalVmHome.isPresent }
+				val graalVmHomePattern = "GRAALVM_\\d+_HOME".toRegex()
+				val graalVmHomePresent = providers.environmentVariablesPrefixedBy("GRAALVM_")
+					.map { it.keys.any { name -> name.matches(graalVmHomePattern) } }
+				onlyIf("a GRAALVM_<version>_HOME environment variable is set") { graalVmHomePresent.get() }
 			}
 		}
 	}

--- a/platform-tooling-support-tests/platform-tooling-support-tests.gradle.kts
+++ b/platform-tooling-support-tests/platform-tooling-support-tests.gradle.kts
@@ -176,6 +176,9 @@ val graalVmTest = testing.suites.register("graalVmTest", JvmTestSuite::class) {
 		implementation(projects.junitJupiter)
 		implementation(testFixtures(projects.junitJupiterApi))
 		implementation(libs.assertj)
+		implementation(libs.jackson.databind) {
+			because("parsing GraalVM reachability metadata")
+		}
 		runtimeOnly(projects.junitPlatformLauncher)
 		runtimeOnly(projects.junitPlatformReporting)
 		runtimeOnly(libs.openTestReporting.events)

--- a/platform-tooling-support-tests/projects/graalvm-starter/agent-access-filter.json
+++ b/platform-tooling-support-tests/projects/graalvm-starter/agent-access-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.junit.**"
+    }
+  ]
+}

--- a/platform-tooling-support-tests/projects/graalvm-starter/build.gradle.kts
+++ b/platform-tooling-support-tests/projects/graalvm-starter/build.gradle.kts
@@ -38,6 +38,10 @@ val initializeAtBuildTime = mapOf<String, List<String>>(
 )
 
 graalvmNative {
+	agent {
+		// Only record metadata for JUnit's own classes when running with `-Pagent`
+		accessFilterFiles.from(layout.projectDirectory.file("agent-access-filter.json"))
+	}
 	metadataRepository {
 		enabled = false
 	}

--- a/platform-tooling-support-tests/projects/graalvm-starter/build.gradle.kts
+++ b/platform-tooling-support-tests/projects/graalvm-starter/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 }
 
 val junitVersion = providers.gradleProperty("junitVersion").orNull
+val jdkVersion = providers.gradleProperty("jdkVersion").orNull!!.toInt()
 
 dependencies {
 	testImplementation("org.junit.jupiter:junit-jupiter:$junitVersion")
@@ -14,7 +15,7 @@ dependencies {
 }
 
 tasks.withType<JavaCompile>().configureEach {
-	options.release = 21
+	options.release = jdkVersion
 }
 
 tasks.test {
@@ -31,16 +32,9 @@ tasks.test {
 	}
 }
 
-val initializeAtBuildTime = mapOf(
+val initializeAtBuildTime = mapOf<String, List<String>>(
 	// These need to be added to native-build-tools
-	"5.14.1" to listOf(
-		// https://github.com/graalvm/native-build-tools/pull/794
-		"org.junit.jupiter.engine.discovery.MethodSegmentResolver"
-	),
-	"6.1" to listOf(
-		// https://github.com/graalvm/native-build-tools/pull/867
-		"org.junit.platform.launcher.core.DiscoveryIssueReportingDiscoveryListener",
-	),
+	"6.2" to listOf(),
 )
 
 graalvmNative {
@@ -50,9 +44,11 @@ graalvmNative {
 	binaries {
 		named("test") {
 			buildArgs.add("-H:+ReportExceptionStackTraces")
-			val classNames = initializeAtBuildTime.values.flatten()
-			if (classNames.isNotEmpty()) {
-				buildArgs.add("--initialize-at-build-time=${classNames.joinToString(",")}")
+			if (jdkVersion <= 21) { // no longer necessary on higher versions, see https://github.com/graalvm/native-build-tools/pull/693
+				val classNames = initializeAtBuildTime.values.flatten()
+				if (classNames.isNotEmpty()) {
+					buildArgs.add("--initialize-at-build-time=${classNames.joinToString(",")}")
+				}
 			}
 		}
 	}

--- a/platform-tooling-support-tests/src/graalVmTest/java/platform/tooling/support/tests/GraalVmStarterTests.java
+++ b/platform-tooling-support-tests/src/graalVmTest/java/platform/tooling/support/tests/GraalVmStarterTests.java
@@ -11,14 +11,21 @@
 package platform.tooling.support.tests;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.stream.Collectors.toSet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.junit.platform.commons.util.StringUtils.isNotBlank;
 import static platform.tooling.support.Projects.copyToWorkspace;
 
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Set;
+import java.util.stream.StreamSupport;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.DisabledOnOpenJ9;
 import org.junit.jupiter.api.io.TempDir;
@@ -30,6 +37,7 @@ import platform.tooling.support.FilePrefix;
 import platform.tooling.support.MavenRepo;
 import platform.tooling.support.ProcessStarters;
 import platform.tooling.support.Projects;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * @since 1.9.1
@@ -42,22 +50,17 @@ class GraalVmStarterTests {
 	@Timeout(value = 10, unit = MINUTES)
 	void runsTestsInNativeImage(int jdkVersion, @TempDir Path workspace, @FilePrefix("gradle") OutputFiles outputFiles)
 			throws Exception {
-		var envVarName = "GRAALVM_%d_HOME".formatted(jdkVersion);
-		var graalVmHome = System.getenv(envVarName);
-		assumeTrue(isNotBlank(graalVmHome), () -> "Expected env var is not set: " + envVarName);
 
-		var result = ProcessStarters.gradlew() //
+		var gradlew = ProcessStarters.gradlew() //
 				.workingDir(copyToWorkspace(Projects.GRAALVM_STARTER, workspace)) //
 				.addArguments("-Dmaven.repo=" + MavenRepo.dir()) //
 				.addArguments("javaToolchains", "nativeTest", "--no-daemon", "--stacktrace", "--no-build-cache", //
-					// Use `--warning-mode=fail` again after the following issue is resolved and released:
-					// https://github.com/graalvm/native-build-tools/issues/900
-					"--warning-mode=all", //
-					"--refresh-dependencies", //
+					"--warning-mode=fail", //
 					"-PjdkVersion=" + jdkVersion) //
 				.redirectOutput(outputFiles) //
-				.putEnvironment("GRAALVM_HOME", graalVmHome) //
-				.startAndWait();
+				.putEnvironment("GRAALVM_HOME", getGraalVmHome(jdkVersion));
+
+		var result = gradlew.startAndWait();
 
 		assertEquals(0, result.exitCode());
 		assertThat(result.stdOutLines()) //
@@ -71,5 +74,50 @@ class GraalVmStarterTests {
 					line -> line.contains("com.example.project.CalculatorParameterizedClassTests > [2] 2 SUCCESSFUL")) //
 				.anyMatch(line -> line.contains("com.example.project.VintageTests > test SUCCESSFUL")) //
 				.anyMatch(line -> line.contains("BUILD SUCCESSFUL"));
+	}
+
+	@Test
+	@Timeout(value = 1, unit = MINUTES)
+	void reachabilityMetadataContainsRequiredSerializableTypes(@TempDir Path workspace,
+			@FilePrefix("gradle") OutputFiles outputFiles) throws Exception {
+
+		var gradlew = ProcessStarters.gradlew() //
+				.workingDir(copyToWorkspace(Projects.GRAALVM_STARTER, workspace)) //
+				.addArguments("-Dmaven.repo=" + MavenRepo.dir()) //
+				.addArguments("test", "-Pagent", "--no-daemon", "--stacktrace", "--no-build-cache", //
+					"--warning-mode=fail", //
+					"-PjdkVersion=25") //
+				.redirectOutput(outputFiles) //
+				.putEnvironment("GRAALVM_HOME", getGraalVmHome(25));
+
+		var result = gradlew.startAndWait();
+
+		assertEquals(0, result.exitCode());
+
+		var agentOutput = workspace.resolve(Path.of("build/native/agent-output/test/reachability-metadata.json"));
+		assertThat(readSerializableTypes(agentOutput)) //
+				.isEqualTo(readSerializableTypesFromJar());
+	}
+
+	private static Set<String> readSerializableTypesFromJar() throws IOException {
+		try (var fileSystem = FileSystems.newFileSystem(MavenRepo.jar("junit-platform-engine"))) {
+			return readSerializableTypes(fileSystem.getPath(
+				"META-INF/native-image/org.junit.platform/junit-platform-engine/reachability-metadata.json"));
+		}
+	}
+
+	private static Set<String> readSerializableTypes(Path reachabilityMetadata) throws IOException {
+		var json = new JsonMapper().readTree(Files.readString(reachabilityMetadata));
+		return StreamSupport.stream(json.path("reflection").spliterator(), false) //
+				.filter(entry -> entry.path("serializable").asBoolean(false)) //
+				.map(entry -> entry.path("type").asString()) //
+				.collect(toSet());
+	}
+
+	private static String getGraalVmHome(int jdkVersion) {
+		var envVarName = "GRAALVM_%d_HOME".formatted(jdkVersion);
+		var graalVmHome = System.getenv(envVarName);
+		assumeTrue(isNotBlank(graalVmHome), () -> "Expected env var is not set: " + envVarName);
+		return graalVmHome;
 	}
 }

--- a/platform-tooling-support-tests/src/graalVmTest/java/platform/tooling/support/tests/GraalVmStarterTests.java
+++ b/platform-tooling-support-tests/src/graalVmTest/java/platform/tooling/support/tests/GraalVmStarterTests.java
@@ -13,15 +13,17 @@ package platform.tooling.support.tests;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.junit.platform.commons.util.StringUtils.isNotBlank;
 import static platform.tooling.support.Projects.copyToWorkspace;
 
 import java.nio.file.Path;
 
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.junit.jupiter.api.extension.DisabledOnOpenJ9;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.junit.platform.tests.process.OutputFiles;
 
 import platform.tooling.support.FilePrefix;
@@ -33,13 +35,17 @@ import platform.tooling.support.Projects;
  * @since 1.9.1
  */
 @DisabledOnOpenJ9
-@EnabledIfEnvironmentVariable(named = "GRAALVM_HOME", matches = ".+")
 class GraalVmStarterTests {
 
-	@Test
+	@ParameterizedTest
+	@ValueSource(ints = { 21, 25 })
 	@Timeout(value = 10, unit = MINUTES)
-	void runsTestsInNativeImage(@TempDir Path workspace, @FilePrefix("gradle") OutputFiles outputFiles)
+	void runsTestsInNativeImage(int jdkVersion, @TempDir Path workspace, @FilePrefix("gradle") OutputFiles outputFiles)
 			throws Exception {
+		var envVarName = "GRAALVM_%d_HOME".formatted(jdkVersion);
+		var graalVmHome = System.getenv(envVarName);
+		assumeTrue(isNotBlank(graalVmHome), () -> "Expected env var is not set: " + envVarName);
+
 		var result = ProcessStarters.gradlew() //
 				.workingDir(copyToWorkspace(Projects.GRAALVM_STARTER, workspace)) //
 				.addArguments("-Dmaven.repo=" + MavenRepo.dir()) //
@@ -47,8 +53,10 @@ class GraalVmStarterTests {
 					// Use `--warning-mode=fail` again after the following issue is resolved and released:
 					// https://github.com/graalvm/native-build-tools/issues/900
 					"--warning-mode=all", //
-					"--refresh-dependencies") //
+					"--refresh-dependencies", //
+					"-PjdkVersion=" + jdkVersion) //
 				.redirectOutput(outputFiles) //
+				.putEnvironment("GRAALVM_HOME", graalVmHome) //
 				.startAndWait();
 
 		assertEquals(0, result.exitCode());

--- a/platform-tooling-support-tests/src/graalVmTest/java/platform/tooling/support/tests/GraalVmStarterTests.java
+++ b/platform-tooling-support-tests/src/graalVmTest/java/platform/tooling/support/tests/GraalVmStarterTests.java
@@ -25,7 +25,9 @@ import java.nio.file.Path;
 import java.util.Set;
 import java.util.stream.StreamSupport;
 
+import org.junit.jupiter.api.MediaType;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestReporter;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.DisabledOnOpenJ9;
 import org.junit.jupiter.api.io.TempDir;
@@ -79,7 +81,7 @@ class GraalVmStarterTests {
 	@Test
 	@Timeout(value = 1, unit = MINUTES)
 	void reachabilityMetadataContainsRequiredSerializableTypes(@TempDir Path workspace,
-			@FilePrefix("gradle") OutputFiles outputFiles) throws Exception {
+			@FilePrefix("gradle") OutputFiles outputFiles, TestReporter reporter) throws Exception {
 
 		var gradlew = ProcessStarters.gradlew() //
 				.workingDir(copyToWorkspace(Projects.GRAALVM_STARTER, workspace)) //
@@ -95,6 +97,7 @@ class GraalVmStarterTests {
 		assertEquals(0, result.exitCode());
 
 		var agentOutput = workspace.resolve(Path.of("build/native/agent-output/test/reachability-metadata.json"));
+		reporter.publishFile(agentOutput, MediaType.APPLICATION_JSON);
 		assertThat(readSerializableTypes(agentOutput)) //
 				.isEqualTo(readSerializableTypesFromJar());
 	}


### PR DESCRIPTION
- **Add test coverage for GraalVM 25**
- **Log test events and output when using `--info`**
- **Add serialization-config.json for compatibility with GraalVM 25**

Fixes #5892.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://docs.junit.org/snapshot/) and [Release Notes](https://docs.junit.org/snapshot/release-notes.html)
