### PR TITLE
Add Kotlin tabs to advanced topics

### DIFF
--- a/documentation/modules/ROOT/pages/advanced-topics/junit-platform-suite-engine.adoc
+++ b/documentation/modules/ROOT/pages/advanced-topics/junit-platform-suite-engine.adoc
@@ -39,10 +39,26 @@ Annotate a class with `@Suite` to have it marked as a test suite on the JUnit Pl
 seen in the following example, selector and filter annotations can be used to control the
 contents of the suite.
 
+[tabs]
+====
+Java::
++
+--
 [source,java,indent=0]
 ----
 include::example$java/example/SuiteDemo.java[tags=user_guide]
 ----
+--
+
+Kotlin::
++
+--
+[source,kotlin,indent=0]
+----
+include::example$kotlin/example/kotlin/SuiteDemo.kt[tags=user_guide]
+----
+--
+====
 
 .Additional Configuration Options
 NOTE: There are numerous configuration options for discovering and filtering tests in a
@@ -55,10 +71,26 @@ list of supported annotations and further details.
 `@Suite`-annotated class. They will be executed before and after all tests of the test
 suite, respectively.
 
+[tabs]
+====
+Java::
++
+--
 [source,java,indent=0]
 ----
 include::example$java/example/BeforeAndAfterSuiteDemo.java[tags=user_guide]
 ----
+--
+
+Kotlin::
++
+--
+[source,kotlin,indent=0]
+----
+include::example$kotlin/example/kotlin/BeforeAndAfterSuiteDemo.kt[tags=user_guide]
+----
+--
+====
 
 [[duplicate-test-execution]]
 == Duplicate Test Execution

--- a/documentation/modules/ROOT/pages/advanced-topics/launcher-api.adoc
+++ b/documentation/modules/ROOT/pages/advanced-topics/launcher-api.adoc
@@ -26,15 +26,47 @@ methods in previous versions of JUnit.
 
 Usage Example:
 
+[tabs]
+====
+Java::
++
+--
 [source,java,indent=0]
 ----
 include::example$java/example/UsingTheLauncherForDiscoveryDemo.java[tags=imports]
 ----
+--
 
+Kotlin::
++
+--
+[source,kotlin,indent=0]
+----
+include::example$kotlin/example/kotlin/UsingTheLauncherForDiscoveryDemo.kt[tags=imports]
+----
+--
+====
+
+[tabs]
+====
+Java::
++
+--
 [source,java,indent=0]
 ----
 include::example$java/example/UsingTheLauncherForDiscoveryDemo.java[tags=discovery]
 ----
+--
+
+Kotlin::
++
+--
+[source,kotlin,indent=0]
+----
+include::example$kotlin/example/kotlin/UsingTheLauncherForDiscoveryDemo.kt[tags=discovery]
+----
+--
+====
 
 You can select classes, methods, and all classes in a package or even search for all tests
 in the class-path or module-path. Discovery takes place across all participating test
@@ -62,10 +94,26 @@ phase or create a new request. Test progress and reporting can be achieved by re
 one or more `{TestExecutionListener}` implementations with the `Launcher` as in the
 following example.
 
+[tabs]
+====
+Java::
++
+--
 [source,java,indent=0]
 ----
 include::example$java/example/UsingTheLauncherDemo.java[tags=execution]
 ----
+--
+
+Kotlin::
++
+--
+[source,kotlin,indent=0]
+----
+include::example$kotlin/example/kotlin/UsingTheLauncherDemo.kt[tags=execution]
+----
+--
+====
 
 There is no return value for the `execute()` method, but you can use a
 `TestExecutionListener` to aggregate the results. For examples see the
@@ -126,6 +174,11 @@ usually corresponds to the lifecycle of the test JVM. A custom listener that sta
 HTTP server before executing the first test and stops it after the last test has been
 executed, could look like this:
 
+[tabs]
+====
+Java::
++
+--
 [source,java]
 .src/test/java/example/session/GlobalSetupTeardownListener.java
 ----
@@ -133,6 +186,20 @@ package example.session;
 
 include::example$java/example/session/GlobalSetupTeardownListener.java[tags=user_guide]
 ----
+--
+
+Kotlin::
++
+--
+[source,kotlin]
+.src/test/kotlin/example/kotlin/session/GlobalSetupTeardownListener.kt
+----
+package example.kotlin.session
+
+include::example$kotlin/example/kotlin/session/GlobalSetupTeardownListener.kt[tags=user_guide]
+----
+--
+====
 <1> Get the store from the launcher session
 <2> Lazily create the HTTP server and put it into the store
 <3> Start the HTTP server
@@ -140,6 +207,11 @@ include::example$java/example/session/GlobalSetupTeardownListener.java[tags=user
 It uses a wrapper class to ensure the server is stopped when the launcher session is
 closed:
 
+[tabs]
+====
+Java::
++
+--
 [source,java]
 .src/test/java/example/session/CloseableHttpServer.java
 ----
@@ -147,6 +219,20 @@ package example.session;
 
 include::example$java/example/session/CloseableHttpServer.java[tags=user_guide]
 ----
+--
+
+Kotlin::
++
+--
+[source,kotlin]
+.src/test/kotlin/example/kotlin/session/CloseableHttpServer.kt
+----
+package example.kotlin.session
+
+include::example$kotlin/example/kotlin/session/CloseableHttpServer.kt[tags=user_guide]
+----
+--
+====
 <1> The `close()` method is called when the launcher session is closed
 <2> Stop the HTTP server
 
@@ -164,6 +250,11 @@ include::example$resources/META-INF/services/org.junit.platform.launcher.Launche
 
 You can now use the resource from your test:
 
+[tabs]
+====
+Java::
++
+--
 [source,java]
 .src/test/java/example/session/HttpTests.java
 ----
@@ -171,6 +262,20 @@ package example.session;
 
 include::example$java/example/session/HttpTests.java[tags=user_guide]
 ----
+--
+
+Kotlin::
++
+--
+[source,kotlin]
+.src/test/kotlin/example/kotlin/session/HttpTests.kt
+----
+package example.kotlin.session
+
+include::example$kotlin/example/kotlin/session/HttpTests.kt[tags=user_guide]
+----
+--
+====
 <1> Retrieve the HTTP server instance from the store
 <2> Get the host string directly from the injected HTTP server instance
 <3> Get the port number directly from the injected HTTP server instance
@@ -199,10 +304,26 @@ supplied in the `LauncherDiscoveryRequest` that is passed to the `{Launcher}`.
 A typical use case is to create a custom interceptor to replace the `ClassLoader` used by
 the JUnit Platform to load test classes and engine implementations.
 
+[tabs]
+====
+Java::
++
+--
 [source,java]
 ----
 include::example$java/example/CustomLauncherInterceptor.java[tags=user_guide]
 ----
+--
+
+Kotlin::
++
+--
+[source,kotlin]
+----
+include::example$kotlin/example/kotlin/CustomLauncherInterceptor.kt[tags=user_guide]
+----
+--
+====
 
 [[launcher-discovery-listeners-custom]]
 == Registering a LauncherDiscoveryListener
@@ -283,10 +404,26 @@ engines and listeners, you may create an instance of `{LauncherConfig}` and supp
 the `{LauncherFactory}`. Typically, an instance of `LauncherConfig` is created via the
 built-in fluent _builder_ API, as demonstrated in the following example.
 
+[tabs]
+====
+Java::
++
+--
 [source,java,indent=0]
 ----
 include::example$java/example/UsingTheLauncherDemo.java[tags=launcherConfig]
 ----
+--
+
+Kotlin::
++
+--
+[source,kotlin,indent=0]
+----
+include::example$kotlin/example/kotlin/UsingTheLauncherDemo.kt[tags=launcherConfig]
+----
+--
+====
 
 [[dry-run-mode]]
 == Dry-Run Mode
@@ -316,18 +453,50 @@ The following example demonstrates two custom test engines sharing a `ServerSock
 resource. `FirstCustomEngine` attempts to retrieve an existing `ServerSocket` from the
 global store or creates a new one if it doesn't exist:
 
+[tabs]
+====
+Java::
++
+--
 [source,java]
 ----
 include::example$java/example/FirstCustomEngine.java[tags=user_guide]
 ----
+--
+
+Kotlin::
++
+--
+[source,kotlin]
+----
+include::example$kotlin/example/kotlin/FirstCustomEngine.kt[tags=user_guide]
+----
+--
+====
 
 `SecondCustomEngine` follows the same pattern, ensuring that regardless whether it runs
 before or after `FirstCustomEngine`, it will use the same socket instance:
 
+[tabs]
+====
+Java::
++
+--
 [source,java]
 ----
 include::example$java/example/SecondCustomEngine.java[tags=user_guide]
 ----
+--
+
+Kotlin::
++
+--
+[source,kotlin]
+----
+include::example$kotlin/example/kotlin/SecondCustomEngine.kt[tags=user_guide]
+----
+--
+====
 
 TIP: In this case, the `ServerSocket` can be stored directly in the global store while
 ensuring since it gets closed because it implements `AutoCloseable`. If you need to use a
@@ -338,10 +507,26 @@ resource is closed properly when the test run is finished.
 For illustration, the following test verifies that both engines are sharing the same
 `ServerSocket` instance and that it's closed after `Launcher.execute()` returns:
 
+[tabs]
+====
+Java::
++
+--
 [source,java,indent=0]
 ----
 include::example$java/example/sharedresources/SharedResourceDemo.java[tags=user_guide]
 ----
+--
+
+Kotlin::
++
+--
+[source,kotlin,indent=0]
+----
+include::example$kotlin/example/kotlin/sharedresources/SharedResourceDemo.kt[tags=user_guide]
+----
+--
+====
 
 By using the Platform's `{NamespacedHierarchicalStore}` API with shared namespaces in this
 way, test engines can coordinate resource creation and sharing without direct dependencies
@@ -361,10 +546,26 @@ part of the `{LauncherExecutionRequest}`.
 For example, implementing a listener that cancels test execution after the first test
 failed can be achieved as follows.
 
+[tabs]
+====
+Java::
++
+--
 [source,java,indent=0]
 ----
 include::example$java/example/UsingTheLauncherDemo.java[tags=cancellation-direct]
 ----
+--
+
+Kotlin::
++
+--
+[source,kotlin,indent=0]
+----
+include::example$kotlin/example/kotlin/UsingTheLauncherDemo.kt[tags=cancellation-direct]
+----
+--
+====
 <1> Create a `{CancellationToken}`
 <2> Implement a `{TestExecutionListener}` that calls `cancel()` when a test fails
 <3> Register the cancellation token
@@ -396,10 +597,26 @@ Rather than building a `{LauncherExecutionRequest}` by starting with a
 `{LauncherDiscoveryRequestBuilder}` and calling `forExecution()`, you can create a
 `{LauncherExecutionRequestBuilder}` from a previously built `{LauncherDiscoveryRequest}`.
 
+[tabs]
+====
+Java::
++
+--
 [source,java,indent=0]
 ----
 include::example$java/example/UsingTheLauncherDemo.java[tags=cancellation-discovery-request]
 ----
+--
+
+Kotlin::
++
+--
+[source,kotlin,indent=0]
+----
+include::example$kotlin/example/kotlin/UsingTheLauncherDemo.kt[tags=cancellation-discovery-request]
+----
+--
+====
 <1> Build a `{LauncherDiscoveryRequest}`
 <2> Create a `{LauncherExecutionRequestBuilder}` with it
 <3> Register the cancellation token
@@ -412,10 +629,26 @@ include::example$java/example/UsingTheLauncherDemo.java[tags=cancellation-discov
 Alternatively, a `{LauncherExecutionRequestBuilder}` can be created from a previously
 discovered `{TestPlan}`.
 
+[tabs]
+====
+Java::
++
+--
 [source,java,indent=0]
 ----
 include::example$java/example/UsingTheLauncherDemo.java[tags=cancellation-test-plan]
 ----
+--
+
+Kotlin::
++
+--
+[source,kotlin,indent=0]
+----
+include::example$kotlin/example/kotlin/UsingTheLauncherDemo.kt[tags=cancellation-test-plan]
+----
+--
+====
 <1> Build a `{LauncherDiscoveryRequest}`
 <2> Discover a `{TestPlan}` via `Launcher.discover`
 <3> Create a `{LauncherExecutionRequestBuilder}` with it

--- a/documentation/modules/ROOT/pages/advanced-topics/testkit.adoc
+++ b/documentation/modules/ROOT/pages/advanced-topics/testkit.adoc
@@ -22,10 +22,26 @@ to build your `LauncherDiscoveryRequest`, you must use one of the `discover()` o
 The following test class written using JUnit Jupiter will be used in subsequent examples.
 
 [[engine-ExampleTestCase]]
+[tabs]
+====
+Java::
++
+--
 [source,java,indent=0]
 ----
 include::example$java/example/ExampleTestCase.java[tags=user_guide]
 ----
+--
+
+Kotlin::
++
+--
+[source,kotlin,indent=0]
+----
+include::example$kotlin/example/kotlin/ExampleTestCase.kt[tags=user_guide]
+----
+--
+====
 
 For the sake of brevity, the following sections demonstrate how to test JUnit's own
 `JupiterTestEngine` whose unique engine ID is `"junit-jupiter"`. If you want to test your
@@ -39,10 +55,26 @@ may test your own `TestEngine` by supplying an instance of it to the
 The following test demonstrates how to verify that a `TestPlan` was discovered as expected
 by the JUnit Jupiter `TestEngine`.
 
+[tabs]
+====
+Java::
++
+--
 [source,java,indent=0]
 ----
 include::example$java/example/testkit/EngineTestKitDiscoveryDemo.java[tags=user_guide]
 ----
+--
+
+Kotlin::
++
+--
+[source,kotlin,indent=0]
+----
+include::example$kotlin/example/kotlin/testkit/EngineTestKitDiscoveryDemo.kt[tags=user_guide]
+----
+--
+====
 <1> Select the JUnit Jupiter `TestEngine`.
 <2> Select the <<engine-ExampleTestCase, `ExampleTestCase`>> test class.
 <3> Discover the `TestPlan`.
@@ -57,10 +89,26 @@ against events fired during the execution of a `TestPlan`. The following tests d
 how to assert statistics for _containers_ and _tests_ in the JUnit Jupiter `TestEngine`.
 For details on what statistics are available, consult the Javadoc for `{EventStatistics}`.
 
+[tabs]
+====
+Java::
++
+--
 [source,java,indent=0]
 ----
 include::example$java/example/testkit/EngineTestKitStatisticsDemo.java[tags=user_guide]
 ----
+--
+
+Kotlin::
++
+--
+[source,kotlin,indent=0]
+----
+include::example$kotlin/example/kotlin/testkit/EngineTestKitStatisticsDemo.kt[tags=user_guide]
+----
+--
+====
 <1> Select the JUnit Jupiter `TestEngine`.
 <2> Select the <<engine-ExampleTestCase, `ExampleTestCase`>> test class.
 <3> Execute the `TestPlan`.
@@ -94,10 +142,26 @@ For details on what _conditions_ are available for use with AssertJ assertions a
 events, consult the Javadoc for `{EventConditions}`.
 ====
 
+[tabs]
+====
+Java::
++
+--
 [source,java,indent=0]
 ----
 include::example$java/example/testkit/EngineTestKitSkippedMethodDemo.java[tags=user_guide]
 ----
+--
+
+Kotlin::
++
+--
+[source,kotlin,indent=0]
+----
+include::example$kotlin/example/kotlin/testkit/EngineTestKitSkippedMethodDemo.kt[tags=user_guide]
+----
+--
+====
 <1> Select the JUnit Jupiter `TestEngine`.
 <2> Select the `skippedTest()` method in the <<engine-ExampleTestCase, `ExampleTestCase`>> test class.
 <3> Execute the `TestPlan`.
@@ -117,10 +181,26 @@ events and execution results, consult the Javadoc for `{EventConditions}` and
 `{TestExecutionResultConditions}`, respectively.
 ====
 
+[tabs]
+====
+Java::
++
+--
 [source,java,indent=0]
 ----
 include::example$java/example/testkit/EngineTestKitFailedMethodDemo.java[tags=user_guide]
 ----
+--
+
+Kotlin::
++
+--
+[source,kotlin,indent=0]
+----
+include::example$kotlin/example/kotlin/testkit/EngineTestKitFailedMethodDemo.kt[tags=user_guide]
+----
+--
+====
 <1> Select the JUnit Jupiter `TestEngine`.
 <2> Select the <<engine-ExampleTestCase, `ExampleTestCase`>> test class.
 <3> Execute the `TestPlan`.
@@ -147,10 +227,26 @@ If you want to do a _partial_ match _with_ or _without_ ordering requirements, y
 the methods `assertEventsMatchLooselyInOrder()` and `assertEventsMatchLoosely()`,
 respectively.
 
+[tabs]
+====
+Java::
++
+--
 [source,java,indent=0]
 ----
 include::example$java/example/testkit/EngineTestKitAllEventsDemo.java[tags=user_guide]
 ----
+--
+
+Kotlin::
++
+--
+[source,kotlin,indent=0]
+----
+include::example$kotlin/example/kotlin/testkit/EngineTestKitAllEventsDemo.kt[tags=user_guide]
+----
+--
+====
 <1> Select the JUnit Jupiter `TestEngine`.
 <2> Select the <<engine-ExampleTestCase, `ExampleTestCase`>> test class.
 <3> Execute the `TestPlan`.

--- a/documentation/src/test/kotlin/example/kotlin/BeforeAndAfterSuiteDemo.kt
+++ b/documentation/src/test/kotlin/example/kotlin/BeforeAndAfterSuiteDemo.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2015-2026 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package example.kotlin
+
+import org.junit.platform.suite.api.AfterSuite
+import org.junit.platform.suite.api.BeforeSuite
+import org.junit.platform.suite.api.SelectPackages
+import org.junit.platform.suite.api.Suite
+
+// tag::user_guide[]
+@Suite
+@SelectPackages("example")
+class BeforeAndAfterSuiteDemo {
+    companion object {
+        @JvmStatic
+        @BeforeSuite
+        fun beforeSuite() {
+            // executes before the test suite
+        }
+
+        @JvmStatic
+        @AfterSuite
+        fun afterSuite() {
+            // executes after the test suite
+        }
+    }
+}
+// end::user_guide[]

--- a/documentation/src/test/kotlin/example/kotlin/CustomLauncherInterceptor.kt
+++ b/documentation/src/test/kotlin/example/kotlin/CustomLauncherInterceptor.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2015-2026 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package example.kotlin
+
+// tag::user_guide[]
+import org.junit.platform.launcher.LauncherInterceptor
+import java.io.IOException
+import java.io.UncheckedIOException
+import java.net.URI
+import java.net.URLClassLoader
+
+class CustomLauncherInterceptor : LauncherInterceptor {
+    private val customClassLoader: URLClassLoader =
+        URLClassLoader(
+            arrayOf(URI.create("some.jar").toURL()),
+            Thread.currentThread().contextClassLoader
+        )
+
+    override fun <T> intercept(invocation: LauncherInterceptor.Invocation<T>): T {
+        val currentThread = Thread.currentThread()
+        val originalClassLoader = currentThread.contextClassLoader
+        currentThread.contextClassLoader = customClassLoader
+        try {
+            return invocation.proceed()
+        } finally {
+            currentThread.contextClassLoader = originalClassLoader
+        }
+    }
+
+    override fun close() {
+        try {
+            customClassLoader.close()
+        } catch (e: IOException) {
+            throw UncheckedIOException("Failed to close custom class loader", e)
+        }
+    }
+}
+// end::user_guide[]

--- a/documentation/src/test/kotlin/example/kotlin/CustomTestEngine.kt
+++ b/documentation/src/test/kotlin/example/kotlin/CustomTestEngine.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2015-2026 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package example.kotlin
+
+import org.junit.platform.engine.EngineDiscoveryRequest
+import org.junit.platform.engine.ExecutionRequest
+import org.junit.platform.engine.TestDescriptor
+import org.junit.platform.engine.TestEngine
+import org.junit.platform.engine.UniqueId
+import org.junit.platform.engine.support.descriptor.EngineDescriptor
+
+/**
+ * This is a no-op [TestEngine] that is only used to make examples compile.
+ */
+class CustomTestEngine : TestEngine {
+    override fun getId(): String = "custom-test-engine"
+
+    override fun discover(
+        discoveryRequest: EngineDiscoveryRequest,
+        uniqueId: UniqueId
+    ): TestDescriptor = EngineDescriptor(UniqueId.forEngine(id), "Custom Test Engine")
+
+    override fun execute(request: ExecutionRequest) {
+    }
+}

--- a/documentation/src/test/kotlin/example/kotlin/ExampleTestCase.kt
+++ b/documentation/src/test/kotlin/example/kotlin/ExampleTestCase.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2015-2026 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package example.kotlin
+
+// tag::user_guide[]
+
+import example.util.Calculator
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestMethodOrder
+
+@TestMethodOrder(OrderAnnotation::class)
+class ExampleTestCase {
+    private val calculator = Calculator()
+
+    @Test
+    @Disabled("for demonstration purposes")
+    @Order(1)
+    fun skippedTest() {
+        // skipped ...
+    }
+
+    @Test
+    @Order(2)
+    fun succeedingTest() {
+        assertEquals(42, calculator.multiply(6, 7))
+    }
+
+    @Test
+    @Order(3)
+    fun abortedTest() {
+        assumeTrue("abc".contains("Z"), "abc does not contain Z")
+        // aborted ...
+    }
+
+    @Test
+    @Order(4)
+    fun failingTest() {
+        // The following throws an ArithmeticException: "/ by zero"
+        calculator.divide(1, 0)
+    }
+}
+// end::user_guide[]

--- a/documentation/src/test/kotlin/example/kotlin/FirstCustomEngine.kt
+++ b/documentation/src/test/kotlin/example/kotlin/FirstCustomEngine.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2015-2026 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package example.kotlin
+
+// tag::user_guide[]
+import org.junit.platform.engine.EngineDiscoveryRequest
+import org.junit.platform.engine.ExecutionRequest
+import org.junit.platform.engine.TestDescriptor
+import org.junit.platform.engine.TestEngine
+import org.junit.platform.engine.TestExecutionResult.successful
+import org.junit.platform.engine.UniqueId
+import org.junit.platform.engine.support.descriptor.EngineDescriptor
+import org.junit.platform.engine.support.store.Namespace
+import java.io.IOException
+import java.io.UncheckedIOException
+import java.net.InetAddress.getLoopbackAddress
+import java.net.ServerSocket
+
+/**
+ * First custom test engine implementation.
+ */
+class FirstCustomEngine : TestEngine {
+    var socket: ServerSocket? = null
+
+    override fun getId(): String = "first-custom-test-engine"
+
+    override fun discover(
+        discoveryRequest: EngineDiscoveryRequest,
+        uniqueId: UniqueId
+    ): TestDescriptor = EngineDescriptor(uniqueId, "First Custom Test Engine")
+
+    override fun execute(request: ExecutionRequest) {
+        request.engineExecutionListener
+            .executionStarted(request.rootTestDescriptor)
+
+        val store = request.store
+        socket =
+            store.computeIfAbsent(Namespace.GLOBAL, "serverSocket", {
+                try {
+                    ServerSocket(0, 50, getLoopbackAddress())
+                } catch (e: IOException) {
+                    throw UncheckedIOException("Failed to start ServerSocket", e)
+                }
+            }, ServerSocket::class.java)
+
+        request.engineExecutionListener
+            .executionFinished(request.rootTestDescriptor, successful())
+    }
+}
+// end::user_guide[]

--- a/documentation/src/test/kotlin/example/kotlin/SecondCustomEngine.kt
+++ b/documentation/src/test/kotlin/example/kotlin/SecondCustomEngine.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2015-2026 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package example.kotlin
+
+import org.junit.platform.engine.EngineDiscoveryRequest
+import org.junit.platform.engine.ExecutionRequest
+import org.junit.platform.engine.TestDescriptor
+import org.junit.platform.engine.TestEngine
+import org.junit.platform.engine.TestExecutionResult.successful
+import org.junit.platform.engine.UniqueId
+import org.junit.platform.engine.support.descriptor.EngineDescriptor
+import org.junit.platform.engine.support.store.Namespace
+import java.io.IOException
+import java.io.UncheckedIOException
+import java.net.InetAddress.getLoopbackAddress
+import java.net.ServerSocket
+
+// tag::user_guide[]
+/**
+ * Second custom test engine implementation.
+ */
+class SecondCustomEngine : TestEngine {
+    var socket: ServerSocket? = null
+
+    override fun getId(): String = "second-custom-test-engine"
+
+    override fun discover(
+        discoveryRequest: EngineDiscoveryRequest,
+        uniqueId: UniqueId
+    ): TestDescriptor = EngineDescriptor(uniqueId, "Second Custom Test Engine")
+
+    override fun execute(request: ExecutionRequest) {
+        request.engineExecutionListener
+            .executionStarted(request.rootTestDescriptor)
+
+        val store = request.store
+        socket =
+            store.computeIfAbsent(Namespace.GLOBAL, "serverSocket", {
+                try {
+                    ServerSocket(0, 50, getLoopbackAddress())
+                } catch (e: IOException) {
+                    throw UncheckedIOException("Failed to start ServerSocket", e)
+                }
+            }, ServerSocket::class.java)
+
+        request.engineExecutionListener
+            .executionFinished(request.rootTestDescriptor, successful())
+    }
+}
+// end::user_guide[]

--- a/documentation/src/test/kotlin/example/kotlin/SuiteDemo.kt
+++ b/documentation/src/test/kotlin/example/kotlin/SuiteDemo.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2015-2026 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package example.kotlin
+
+// tag::user_guide[]
+import org.junit.platform.suite.api.IncludeClassNamePatterns
+import org.junit.platform.suite.api.SelectPackages
+import org.junit.platform.suite.api.Suite
+import org.junit.platform.suite.api.SuiteDisplayName
+
+// end::user_guide[]
+@org.junit.platform.suite.api.ExcludeTags("exclude")
+// tag::user_guide[]
+@Suite
+@SuiteDisplayName("JUnit Platform Suite Demo")
+@SelectPackages("example")
+@IncludeClassNamePatterns(".*Tests")
+class SuiteDemo
+// end::user_guide[]

--- a/documentation/src/test/kotlin/example/kotlin/UsingTheLauncherDemo.kt
+++ b/documentation/src/test/kotlin/example/kotlin/UsingTheLauncherDemo.kt
@@ -1,0 +1,228 @@
+/*
+ * Copyright 2015-2026 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package example.kotlin
+
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.platform.engine.CancellationToken
+import org.junit.platform.engine.FilterResult
+import org.junit.platform.engine.TestDescriptor
+import org.junit.platform.engine.TestExecutionResult
+import org.junit.platform.engine.TestExecutionResult.Status.FAILED
+import org.junit.platform.engine.discovery.ClassNameFilter.includeClassNamePatterns
+import org.junit.platform.engine.discovery.DiscoverySelectors.selectClass
+import org.junit.platform.engine.discovery.DiscoverySelectors.selectPackage
+import org.junit.platform.launcher.LauncherDiscoveryListener
+import org.junit.platform.launcher.LauncherSessionListener
+import org.junit.platform.launcher.PostDiscoveryFilter
+import org.junit.platform.launcher.TestExecutionListener
+import org.junit.platform.launcher.TestIdentifier
+import org.junit.platform.launcher.core.LauncherConfig
+import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder
+import org.junit.platform.launcher.core.LauncherExecutionRequestBuilder
+import org.junit.platform.launcher.core.LauncherFactory
+import org.junit.platform.launcher.listeners.SummaryGeneratingListener
+import org.junit.platform.reporting.legacy.xml.LegacyXmlReportGeneratingListener
+import java.io.PrintWriter
+import java.nio.file.Path
+
+/**
+ * @since 5.0
+ */
+class UsingTheLauncherDemo {
+    @Tag("exclude")
+    @Test
+    @Suppress("UNUSED_VARIABLE")
+    fun execution() {
+        // tag::execution[]
+        val discoveryRequest =
+            LauncherDiscoveryRequestBuilder
+                .request()
+                .selectors(
+                    selectPackage("com.example.mytests"),
+                    selectClass(MyTestClass::class.java)
+                ).filters(
+                    includeClassNamePatterns(".*Tests")
+                )
+                // end::execution[]
+                .configurationParameter("enableHttpServer", "false")
+                // tag::execution[]
+                .build()
+
+        val listener = SummaryGeneratingListener()
+
+        LauncherFactory.openSession().use { session ->
+            val launcher = session.launcher
+            // Register one ore more listeners of your choice.
+            launcher.registerTestExecutionListeners(listener)
+            // Discover tests and build a test plan.
+            val testPlan = launcher.discover(discoveryRequest)
+            // Execute the test plan.
+            launcher.execute(testPlan)
+            // Alternatively, execute the discovery request directly.
+            launcher.execute(discoveryRequest)
+        }
+
+        val summary = listener.summary
+        // Do something with the summary...
+
+        // end::execution[]
+    }
+
+    @Test
+    fun launcherConfig() {
+        val reportsDir = Path.of("target", "xml-reports")
+        val out = PrintWriter(System.out)
+        // tag::launcherConfig[]
+        val launcherConfig =
+            LauncherConfig
+                .builder()
+                .enableTestEngineAutoRegistration(false)
+                .enableLauncherSessionListenerAutoRegistration(false)
+                .enableLauncherDiscoveryListenerAutoRegistration(false)
+                .enablePostDiscoveryFilterAutoRegistration(false)
+                .enableTestExecutionListenerAutoRegistration(false)
+                .addTestEngines(CustomTestEngine())
+                .addLauncherSessionListeners(CustomLauncherSessionListener())
+                .addLauncherDiscoveryListeners(CustomLauncherDiscoveryListener())
+                .addPostDiscoveryFilters(CustomPostDiscoveryFilter())
+                .addTestExecutionListeners(LegacyXmlReportGeneratingListener(reportsDir, out))
+                .addTestExecutionListeners(CustomTestExecutionListener())
+                .build()
+
+        val discoveryRequest =
+            LauncherDiscoveryRequestBuilder
+                .request()
+                .selectors(selectPackage("com.example.mytests"))
+                .build()
+
+        LauncherFactory.openSession(launcherConfig).use { session ->
+            session.launcher.execute(discoveryRequest)
+        }
+        // end::launcherConfig[]
+    }
+
+    @Test
+    fun cancellationDirect() {
+        // tag::cancellation-direct[]
+        val cancellationToken = CancellationToken.create() // <1>
+
+        val failFastListener =
+            object : TestExecutionListener { // <2>
+                override fun executionFinished(
+                    identifier: TestIdentifier,
+                    result: TestExecutionResult
+                ) {
+                    if (result.status == FAILED) {
+                        cancellationToken.cancel()
+                    }
+                }
+            }
+
+        val executionRequest =
+            LauncherDiscoveryRequestBuilder
+                .request()
+                .selectors(selectClass(MyTestClass::class.java))
+                .forExecution()
+                .cancellationToken(cancellationToken) // <3>
+                .listeners(failFastListener) // <4>
+                .build()
+
+        LauncherFactory.openSession().use { session ->
+            session.launcher.execute(executionRequest) // <5>
+        }
+        // end::cancellation-direct[]
+    }
+
+    @Test
+    fun cancellationFromDiscoveryRequest() {
+        val cancellationToken = CancellationToken.create()
+
+        val failFastListener =
+            object : TestExecutionListener {
+                override fun executionFinished(
+                    identifier: TestIdentifier,
+                    result: TestExecutionResult
+                ) {
+                    if (result.status == FAILED) {
+                        cancellationToken.cancel()
+                    }
+                }
+            }
+
+        // tag::cancellation-discovery-request[]
+        val discoveryRequest =
+            LauncherDiscoveryRequestBuilder
+                .request()
+                .selectors(selectClass(MyTestClass::class.java))
+                .build() // <1>
+
+        val executionRequest =
+            LauncherExecutionRequestBuilder.request(discoveryRequest) // <2>
+                .cancellationToken(cancellationToken) // <3>
+                .listeners(failFastListener) // <4>
+                .build()
+
+        LauncherFactory.openSession().use { session ->
+            session.launcher.execute(executionRequest) // <5>
+        }
+        // end::cancellation-discovery-request[]
+    }
+
+    @Test
+    fun cancellationFromTestPlan() {
+        val cancellationToken = CancellationToken.create()
+
+        val failFastListener =
+            object : TestExecutionListener {
+                override fun executionFinished(
+                    identifier: TestIdentifier,
+                    result: TestExecutionResult
+                ) {
+                    if (result.status == FAILED) {
+                        cancellationToken.cancel()
+                    }
+                }
+            }
+
+        // tag::cancellation-test-plan[]
+        val discoveryRequest =
+            LauncherDiscoveryRequestBuilder
+                .request()
+                .selectors(selectClass(MyTestClass::class.java))
+                .build() // <1>
+
+        LauncherFactory.openSession().use { session ->
+            val launcher = session.launcher
+            val testPlan = launcher.discover(discoveryRequest) // <2>
+            val executionRequest =
+                LauncherExecutionRequestBuilder
+                    .request(testPlan) // <3>
+                    .cancellationToken(cancellationToken) // <4>
+                    .listeners(failFastListener) // <5>
+                    .build()
+            launcher.execute(executionRequest) // <6>
+        }
+        // end::cancellation-test-plan[]
+    }
+}
+
+class MyTestClass
+
+class CustomTestExecutionListener : TestExecutionListener
+
+class CustomLauncherSessionListener : LauncherSessionListener
+
+class CustomLauncherDiscoveryListener : LauncherDiscoveryListener
+
+class CustomPostDiscoveryFilter : PostDiscoveryFilter {
+    override fun apply(testDescriptor: TestDescriptor): FilterResult = FilterResult.included("includes everything")
+}

--- a/documentation/src/test/kotlin/example/kotlin/UsingTheLauncherForDiscoveryDemo.kt
+++ b/documentation/src/test/kotlin/example/kotlin/UsingTheLauncherForDiscoveryDemo.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2015-2026 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package example.kotlin
+
+// tag::imports[]
+import org.junit.platform.engine.discovery.ClassNameFilter.includeClassNamePatterns
+import org.junit.platform.engine.discovery.DiscoverySelectors.selectClass
+import org.junit.platform.engine.discovery.DiscoverySelectors.selectPackage
+import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.discoveryRequest
+import org.junit.platform.launcher.core.LauncherFactory
+// end::imports[]
+
+/**
+ * @since 6.0
+ */
+class UsingTheLauncherForDiscoveryDemo {
+    @org.junit.jupiter.api.Test
+    @Suppress("UNUSED_VARIABLE")
+    fun discovery() {
+        // tag::discovery[]
+        val discoveryRequest =
+            discoveryRequest()
+                .selectors(
+                    selectPackage("com.example.mytests"),
+                    selectClass(MyTestClass::class.java)
+                ).filters(
+                    includeClassNamePatterns(".*Tests")
+                ).build()
+
+        LauncherFactory.openSession().use { session ->
+            val testPlan = session.launcher.discover(discoveryRequest)
+
+            // ... discover additional test plans or execute tests
+        }
+        // end::discovery[]
+    }
+
+    class MyTestClass
+}

--- a/documentation/src/test/kotlin/example/kotlin/session/CloseableHttpServer.kt
+++ b/documentation/src/test/kotlin/example/kotlin/session/CloseableHttpServer.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2015-2026 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package example.kotlin.session
+
+// tag::user_guide[]
+import com.sun.net.httpserver.HttpServer
+import java.util.concurrent.ExecutorService
+
+class CloseableHttpServer(
+    val server: HttpServer,
+    private val executorService: ExecutorService
+) : AutoCloseable {
+    override fun close() { // <1>
+        server.stop(0) // <2>
+        executorService.shutdownNow()
+    }
+}
+// end::user_guide[]

--- a/documentation/src/test/kotlin/example/kotlin/session/GlobalSetupTeardownListener.kt
+++ b/documentation/src/test/kotlin/example/kotlin/session/GlobalSetupTeardownListener.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2015-2026 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package example.kotlin.session
+
+// tag::user_guide[]
+import com.sun.net.httpserver.HttpServer
+import org.junit.platform.engine.support.store.Namespace
+import org.junit.platform.launcher.LauncherSession
+import org.junit.platform.launcher.LauncherSessionListener
+import org.junit.platform.launcher.TestExecutionListener
+import org.junit.platform.launcher.TestPlan
+import java.io.IOException
+import java.io.UncheckedIOException
+import java.net.InetAddress.getLoopbackAddress
+import java.net.InetSocketAddress
+import java.util.concurrent.Executors
+
+class GlobalSetupTeardownListener : LauncherSessionListener {
+    override fun launcherSessionOpened(session: LauncherSession) {
+        // Avoid setup for test discovery by delaying it until tests are about to be executed
+        session.launcher.registerTestExecutionListeners(
+            object : TestExecutionListener {
+                override fun testPlanExecutionStarted(testPlan: TestPlan) {
+                    // end::user_guide[]
+                    if (!testPlan.configurationParameters.getBoolean("enableHttpServer").orElse(true)) {
+                        // avoid starting multiple HTTP servers unnecessarily from UsingTheLauncherDemo
+                        return
+                    }
+                    // tag::user_guide[]
+                    val store = session.store // <1>
+                    store.computeIfAbsent(Namespace.GLOBAL, "httpServer") { _ -> // <2>
+                        val address = InetSocketAddress(getLoopbackAddress(), 0)
+                        val server: HttpServer =
+                            try {
+                                HttpServer.create(address, 0)
+                            } catch (e: IOException) {
+                                throw UncheckedIOException("Failed to start HTTP server", e)
+                            }
+                        server.createContext("/test") { exchange ->
+                            exchange.sendResponseHeaders(204, -1)
+                            exchange.close()
+                        }
+                        val executorService = Executors.newCachedThreadPool()
+                        server.executor = executorService
+                        server.start() // <3>
+
+                        CloseableHttpServer(server, executorService)
+                    }
+                }
+            }
+        )
+    }
+}
+// end::user_guide[]

--- a/documentation/src/test/kotlin/example/kotlin/session/HttpTests.kt
+++ b/documentation/src/test/kotlin/example/kotlin/session/HttpTests.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2015-2026 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package example.kotlin.session
+
+// tag::user_guide[]
+import com.sun.net.httpserver.HttpServer
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.ExtensionContext
+import org.junit.jupiter.api.extension.ParameterContext
+import org.junit.jupiter.api.extension.ParameterResolver
+import java.net.HttpURLConnection
+import java.net.URI
+
+@ExtendWith(HttpServerParameterResolver::class)
+class HttpTests {
+    // end::user_guide[]
+    @org.junit.jupiter.api.Tag("exclude")
+    // tag::user_guide[]
+    @Test
+    fun respondsWith204(server: HttpServer) {
+        val host = server.address.hostString // <2>
+        val port = server.address.port // <3>
+        val url = URI.create("http://$host:$port/test").toURL()
+
+        val connection = url.openConnection() as HttpURLConnection
+        connection.requestMethod = "GET"
+        val responseCode = connection.responseCode // <4>
+
+        assertEquals(204, responseCode) // <5>
+    }
+}
+
+class HttpServerParameterResolver : ParameterResolver {
+    override fun supportsParameter(
+        parameterContext: ParameterContext,
+        extensionContext: ExtensionContext
+    ): Boolean = HttpServer::class.java == parameterContext.parameter.type
+
+    override fun resolveParameter(
+        parameterContext: ParameterContext,
+        extensionContext: ExtensionContext
+    ): Any =
+        extensionContext
+            .getStore(ExtensionContext.Namespace.GLOBAL)
+            .get("httpServer", CloseableHttpServer::class.java)!! // <1>
+            .server
+}
+// end::user_guide[]

--- a/documentation/src/test/kotlin/example/kotlin/sharedresources/SharedResourceDemo.kt
+++ b/documentation/src/test/kotlin/example/kotlin/sharedresources/SharedResourceDemo.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2015-2026 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package example.kotlin.sharedresources
+
+import example.kotlin.FirstCustomEngine
+import example.kotlin.SecondCustomEngine
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.platform.engine.discovery.DiscoverySelectors.selectPackage
+import org.junit.platform.launcher.core.LauncherConfig
+import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.discoveryRequest
+import org.junit.platform.launcher.core.LauncherFactory
+
+class SharedResourceDemo {
+    // tag::user_guide[]
+    @Test
+    fun runBothCustomEnginesTest() {
+        val firstCustomEngine = FirstCustomEngine()
+        val secondCustomEngine = SecondCustomEngine()
+
+        val launcherConfig =
+            LauncherConfig
+                .builder()
+                .addTestEngines(firstCustomEngine, secondCustomEngine)
+                .enableTestEngineAutoRegistration(false)
+                .build()
+
+        val discoveryRequest =
+            discoveryRequest()
+                .selectors(selectPackage("com.example.mytests"))
+                .build()
+
+        val launcher = LauncherFactory.create(launcherConfig)
+        launcher.execute(discoveryRequest)
+
+        assertSame(firstCustomEngine.socket, secondCustomEngine.socket)
+        assertTrue(firstCustomEngine.socket!!.isClosed, "socket should be closed")
+    }
+    // end::user_guide[]
+}

--- a/documentation/src/test/kotlin/example/kotlin/testkit/EngineTestKitAllEventsDemo.kt
+++ b/documentation/src/test/kotlin/example/kotlin/testkit/EngineTestKitAllEventsDemo.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2015-2026 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package example.kotlin.testkit
+
+// tag::user_guide[]
+import example.kotlin.ExampleTestCase
+import org.junit.jupiter.api.Test
+import org.junit.platform.engine.discovery.DiscoverySelectors.selectClass
+import org.junit.platform.testkit.engine.EngineTestKit
+import org.junit.platform.testkit.engine.EventConditions.abortedWithReason
+import org.junit.platform.testkit.engine.EventConditions.container
+import org.junit.platform.testkit.engine.EventConditions.engine
+import org.junit.platform.testkit.engine.EventConditions.event
+import org.junit.platform.testkit.engine.EventConditions.finishedSuccessfully
+import org.junit.platform.testkit.engine.EventConditions.finishedWithFailure
+import org.junit.platform.testkit.engine.EventConditions.skippedWithReason
+import org.junit.platform.testkit.engine.EventConditions.started
+import org.junit.platform.testkit.engine.EventConditions.test
+import org.junit.platform.testkit.engine.TestExecutionResultConditions.instanceOf
+import org.junit.platform.testkit.engine.TestExecutionResultConditions.message
+import org.opentest4j.TestAbortedException
+import java.io.StringWriter
+import java.io.Writer
+
+class EngineTestKitAllEventsDemo {
+    @Test
+    fun verifyAllJupiterEvents() {
+        val writer: Writer = // create a java.io.Writer for debug output
+            // end::user_guide[]
+            // For the demo, we are swallowing the debug output.
+            StringWriter()
+        // tag::user_guide[]
+
+        EngineTestKit
+            .engine("junit-jupiter") // <1>
+            .selectors(selectClass(ExampleTestCase::class.java)) // <2>
+            .execute() // <3>
+            .allEvents() // <4>
+            .debug(writer) // <5>
+            .assertEventsMatchExactly( // <6>
+                event(engine(), started()),
+                event(container(ExampleTestCase::class.java), started()),
+                event(test("skippedTest"), skippedWithReason("for demonstration purposes")),
+                event(test("succeedingTest"), started()),
+                event(test("succeedingTest"), finishedSuccessfully()),
+                event(test("abortedTest"), started()),
+                event(
+                    test("abortedTest"),
+                    abortedWithReason(
+                        instanceOf(TestAbortedException::class.java),
+                        message { it.contains("abc does not contain Z") }
+                    )
+                ),
+                event(test("failingTest"), started()),
+                event(
+                    test("failingTest"),
+                    finishedWithFailure(
+                        instanceOf(ArithmeticException::class.java),
+                        message { it.endsWith("by zero") }
+                    )
+                ),
+                event(container(ExampleTestCase::class.java), finishedSuccessfully()),
+                event(engine(), finishedSuccessfully())
+            )
+    }
+}
+// end::user_guide[]

--- a/documentation/src/test/kotlin/example/kotlin/testkit/EngineTestKitDiscoveryDemo.kt
+++ b/documentation/src/test/kotlin/example/kotlin/testkit/EngineTestKitDiscoveryDemo.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2015-2026 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package example.kotlin.testkit
+
+// tag::user_guide[]
+import example.kotlin.ExampleTestCase
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.platform.engine.DiscoveryIssue
+import org.junit.platform.engine.discovery.DiscoverySelectors.selectClass
+import org.junit.platform.testkit.engine.EngineTestKit
+
+class EngineTestKitDiscoveryDemo {
+    @Test
+    fun verifyJupiterDiscovery() {
+        val results =
+            EngineTestKit
+                .engine("junit-jupiter") // <1>
+                .selectors(selectClass(ExampleTestCase::class.java)) // <2>
+                .discover() // <3>
+
+        assertEquals("JUnit Jupiter", results.engineDescriptor.displayName) // <4>
+        assertEquals(emptyList<DiscoveryIssue>(), results.discoveryIssues) // <5>
+    }
+}
+// end::user_guide[]

--- a/documentation/src/test/kotlin/example/kotlin/testkit/EngineTestKitFailedMethodDemo.kt
+++ b/documentation/src/test/kotlin/example/kotlin/testkit/EngineTestKitFailedMethodDemo.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2015-2026 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package example.kotlin.testkit
+
+// tag::user_guide[]
+import example.kotlin.ExampleTestCase
+import org.junit.jupiter.api.Test
+import org.junit.platform.engine.discovery.DiscoverySelectors.selectClass
+import org.junit.platform.testkit.engine.EngineTestKit
+import org.junit.platform.testkit.engine.EventConditions.event
+import org.junit.platform.testkit.engine.EventConditions.finishedWithFailure
+import org.junit.platform.testkit.engine.EventConditions.test
+import org.junit.platform.testkit.engine.TestExecutionResultConditions.instanceOf
+import org.junit.platform.testkit.engine.TestExecutionResultConditions.message
+
+class EngineTestKitFailedMethodDemo {
+    @Test
+    fun verifyJupiterMethodFailed() {
+        EngineTestKit
+            .engine("junit-jupiter") // <1>
+            .selectors(selectClass(ExampleTestCase::class.java)) // <2>
+            .execute() // <3>
+            .testEvents() // <4>
+            .assertThatEvents().haveExactly(1, // <5>
+                event(
+                    test("failingTest"),
+                    finishedWithFailure(
+                        instanceOf(ArithmeticException::class.java),
+                        message { it.endsWith("by zero") }
+                    )
+                )
+            )
+    }
+}
+// end::user_guide[]

--- a/documentation/src/test/kotlin/example/kotlin/testkit/EngineTestKitSkippedMethodDemo.kt
+++ b/documentation/src/test/kotlin/example/kotlin/testkit/EngineTestKitSkippedMethodDemo.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2015-2026 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package example.kotlin.testkit
+
+// tag::user_guide[]
+import example.kotlin.ExampleTestCase
+import org.junit.jupiter.api.Test
+import org.junit.platform.engine.discovery.DiscoverySelectors.selectMethod
+import org.junit.platform.testkit.engine.EngineTestKit
+import org.junit.platform.testkit.engine.EventConditions.event
+import org.junit.platform.testkit.engine.EventConditions.skippedWithReason
+import org.junit.platform.testkit.engine.EventConditions.test
+
+class EngineTestKitSkippedMethodDemo {
+    @Test
+    fun verifyJupiterMethodWasSkipped() {
+        val methodName = "skippedTest"
+
+        val testEvents = EngineTestKit // <5>
+                .engine("junit-jupiter") // <1>
+                .selectors(selectMethod(ExampleTestCase::class.java, methodName)) // <2>
+                .execute() // <3>
+                .testEvents() // <4>
+
+        testEvents.assertStatistics { stats -> stats.skipped(1) } // <6>
+
+        testEvents
+            .assertThatEvents() // <7>
+            .haveExactly(1, event(test(methodName), skippedWithReason("for demonstration purposes")))
+    }
+}
+// end::user_guide[]

--- a/documentation/src/test/kotlin/example/kotlin/testkit/EngineTestKitStatisticsDemo.kt
+++ b/documentation/src/test/kotlin/example/kotlin/testkit/EngineTestKitStatisticsDemo.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2015-2026 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package example.kotlin.testkit
+
+// tag::user_guide[]
+import example.kotlin.ExampleTestCase
+import org.junit.jupiter.api.Test
+import org.junit.platform.engine.discovery.DiscoverySelectors.selectClass
+import org.junit.platform.testkit.engine.EngineTestKit
+
+class EngineTestKitStatisticsDemo {
+    @Test
+    fun verifyJupiterContainerStats() {
+        EngineTestKit
+            .engine("junit-jupiter") // <1>
+            .selectors(selectClass(ExampleTestCase::class.java)) // <2>
+            .execute() // <3>
+            .containerEvents() // <4>
+            .assertStatistics { stats -> stats.started(2).succeeded(2) } // <5>
+    }
+
+    @Test
+    fun verifyJupiterTestStats() {
+        EngineTestKit
+            .engine("junit-jupiter") // <1>
+            .selectors(selectClass(ExampleTestCase::class.java)) // <2>
+            .execute() // <3>
+            .testEvents() // <6>
+            .assertStatistics { stats ->
+                stats.skipped(1).started(3).succeeded(1).aborted(1).failed(1) // <7>
+            }
+    }
+}
+// end::user_guide[]


### PR DESCRIPTION
Adds Kotlin tabbed code snippets to the Advanced Topics section of the User Guide.

Pages updated:

* JUnit Platform Suite Engine
* JUnit Platform Test Kit
* JUnit Platform Launcher API
---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://docs.junit.org/snapshot/) and [Release Notes](https://docs.junit.org/snapshot/release-notes.html)
