### PR TITLE
Remove unnecessary simulated test duration

### DIFF
--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ParallelExecutionIntegrationTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ParallelExecutionIntegrationTests.java
@@ -10,7 +10,7 @@
 
 package org.junit.platform.engine.support.hierarchical;
 
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -67,6 +67,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.TestReporter;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
 import org.junit.jupiter.api.extension.DynamicTestInvocationContext;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -94,6 +95,7 @@ import org.junit.platform.testkit.engine.Events;
  */
 @ParameterizedClass
 @EnumSource(ParallelExecutorServiceType.class)
+@Timeout(value = 5, unit = SECONDS)
 record ParallelExecutionIntegrationTests(ParallelExecutorServiceType executorServiceType) {
 
 	@Test
@@ -321,7 +323,7 @@ record ParallelExecutionIntegrationTests(ParallelExecutorServiceType executorSer
 		@BeforeAll
 		static void initialize() {
 			sharedResource = new AtomicInteger();
-			countDownLatch = new CountDownLatch(2);
+			countDownLatch = new CountDownLatch(1);
 		}
 
 		@Test
@@ -1044,37 +1046,20 @@ record ParallelExecutionIntegrationTests(ParallelExecutorServiceType executorSer
 		assertEquals(value, sharedResource.get());
 	}
 
-	@SuppressWarnings("ResultOfMethodCallIgnored")
 	private static int incrementAndBlock(AtomicInteger sharedResource, CountDownLatch countDownLatch)
 			throws InterruptedException {
 		var value = sharedResource.incrementAndGet();
 		countDownLatch.countDown();
-		countDownLatch.await(estimateSimulatedTestDurationInMilliseconds(), MILLISECONDS);
+		countDownLatch.await();
 		return value;
 	}
 
-	@SuppressWarnings("ResultOfMethodCallIgnored")
 	private static void storeAndBlockAndCheck(AtomicInteger sharedResource, CountDownLatch countDownLatch)
 			throws InterruptedException {
 		var value = sharedResource.get();
 		countDownLatch.countDown();
-		countDownLatch.await(estimateSimulatedTestDurationInMilliseconds(), MILLISECONDS);
+		countDownLatch.await();
 		assertEquals(value, sharedResource.get());
-	}
-
-	/*
-	 * To simulate tests running in parallel tests will modify a shared
-	 * resource, simulate work by waiting, then check if the shared resource was
-	 * not modified by any other thread.
-	 *
-	 * Depending on system performance the simulation of work needs to be longer
-	 * on slower systems to ensure tests can run in parallel.
-	 *
-	 * Currently, CI is known to be slow.
-	 */
-	private static long estimateSimulatedTestDurationInMilliseconds() {
-		var runningInCi = Boolean.parseBoolean(System.getenv("CI"));
-		return runningInCi ? 1000 : 100;
 	}
 
 	@NullMarked


### PR DESCRIPTION
The count-down latch releases either the moment all threads have reached the latch or when the simulated duration has passed. In this case the simulated duration acts like timeout and isn't necessary, in normal circumstances the latch will release wll before that time has passed.

The only exception here was the `IsolatedTestCase` which requires two threads to unlock its count-down latch. This isn't possible, isolated tests are all executed on the same thread. This test would always time out.

The Timeout at test level takes care of any actual time-outs due to programming errors.


---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://docs.junit.org/snapshot/) and [Release Notes](https://docs.junit.org/snapshot/release-notes.html)
