### PR TITLE
Add TestMethodReturnValueHandler SPI for non-void @Test methods

### DIFF
--- a/documentation/antora.yml
+++ b/documentation/antora.yml
@@ -212,6 +212,7 @@ asciidoc:
     TestInstancePreDestroyCallback: '{javadoc-root}/org.junit.jupiter.api/org/junit/jupiter/api/extension/TestInstancePreDestroyCallback.html[TestInstancePreDestroyCallback]'
     TestTemplateInvocationContext: '{javadoc-root}/org.junit.jupiter.api/org/junit/jupiter/api/extension/TestTemplateInvocationContext.html[TestTemplateInvocationContext]'
     TestTemplateInvocationContextProvider: '{javadoc-root}/org.junit.jupiter.api/org/junit/jupiter/api/extension/TestTemplateInvocationContextProvider.html[TestTemplateInvocationContextProvider]'
+    TestMethodReturnValueHandler: '{javadoc-root}/org.junit.jupiter.api/org/junit/jupiter/api/extension/TestMethodReturnValueHandler.html[TestMethodReturnValueHandler]'
     TestWatcher: '{javadoc-root}/org.junit.jupiter.api/org/junit/jupiter/api/extension/TestWatcher.html[TestWatcher]'
     PreInterruptCallback: '{javadoc-root}/org.junit.jupiter.api/org/junit/jupiter/api/extension/PreInterruptCallback.html[PreInterruptCallback]'
     # Jupiter Conditions

--- a/documentation/modules/ROOT/nav.adoc
+++ b/documentation/modules/ROOT/nav.adoc
@@ -49,6 +49,7 @@
 ** xref:extensions/exception-handling.adoc[]
 ** xref:extensions/pre-interrupt-callback.adoc[]
 ** xref:extensions/intercepting-invocations.adoc[]
+** xref:extensions/test-method-return-value-handling.adoc[]
 ** xref:extensions/providing-invocation-contexts-for-class-templates.adoc[]
 ** xref:extensions/providing-invocation-contexts-for-test-templates.adoc[]
 ** xref:extensions/keeping-state-in-extensions.adoc[]

--- a/documentation/modules/ROOT/pages/extensions/test-method-return-value-handling.adoc
+++ b/documentation/modules/ROOT/pages/extensions/test-method-return-value-handling.adoc
@@ -1,0 +1,71 @@
+= Test Method Return Value Handling
+
+`{TestMethodReturnValueHandler}` defines an extension point that allows `@Test` methods
+to return non-void types. By default, JUnit Jupiter requires `@Test` methods to return
+`void`. A registered `TestMethodReturnValueHandler` relaxes this requirement for return
+types it supports.
+
+[[registration]]
+== Registration
+
+Implementations are discovered via Java's `{ServiceLoader}` mechanism and must be
+registered in a file named
+`META-INF/services/org.junit.jupiter.api.extension.TestMethodReturnValueHandler` on the
+classpath.
+
+[[how-it-works]]
+== How It Works
+
+A `TestMethodReturnValueHandler` has two responsibilities:
+
+1. **Declare supported return types** via `supportsReturnType(Class<?>)` — during
+   discovery, JUnit calls this method to decide whether a non-void `@Test` method should
+   be accepted.
+
+2. **Execute the test method** via `execute(Invocation<Object>, ExtensionContext)` — at
+   execution time, the handler receives an `{InvocationInterceptor}.Invocation` that wraps
+   the test method call. The handler must call `invocation.proceed()` to invoke the test
+   and obtain the return value. It is then responsible for processing the result — for
+   example, subscribing to a reactive type and awaiting completion.
+
+Because the handler controls _when_ `proceed()` is called, it can set up a custom
+execution context beforehand — for example, running the test on a specific thread or
+executor.
+
+[[example]]
+== Example
+
+The following handler adds support for `@Test` methods that return `CompletableFuture`:
+
+[source,java,indent=0]
+----
+public class CompletableFutureHandler implements TestMethodReturnValueHandler {
+
+    @Override
+    public boolean supportsReturnType(Class<?> returnType) {
+        return CompletableFuture.class.isAssignableFrom(returnType);
+    }
+
+    @Override
+    public void execute(InvocationInterceptor.Invocation<Object> invocation,
+            ExtensionContext context) throws Throwable {
+        Object result = invocation.proceed();
+        if (result != null) {
+            ((CompletableFuture<?>) result).get(30, TimeUnit.SECONDS);
+        }
+    }
+}
+----
+
+With this handler registered, the following test is discovered and executed:
+
+[source,java,indent=0]
+----
+@Test
+CompletableFuture<String> asyncTest() {
+    return CompletableFuture.supplyAsync(() -> {
+        // test logic
+        return "result";
+    });
+}
+----

--- a/documentation/modules/ROOT/partials/release-notes/release-notes-6.2.0-M1.adoc
+++ b/documentation/modules/ROOT/partials/release-notes/release-notes-6.2.0-M1.adoc
@@ -71,6 +71,11 @@ repository on GitHub.
   and `@DisabledOnOs`.
 * Failures caused by `@Timeout` expirations now include a hint about enabling
   xref:writing-tests/timeouts.adoc#debugging-thread-dump[thread dumps].
+* Added `TestMethodReturnValueHandler` extension point that allows `@Test` methods to
+  return non-void types. Handlers are discovered via Java's `ServiceLoader` mechanism and
+  can control test method invocation — for example, to execute the test on a specific
+  thread or executor and then process the return value (e.g. awaiting a reactive type).
+  See xref:extensions/test-method-return-value-handling.adoc[] for details.
 
 
 [[v6.2.0-M1-junit-vintage]]

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/TestMethodReturnValueHandler.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/TestMethodReturnValueHandler.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2015-2026 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.api.extension;
+
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+
+import org.apiguardian.api.API;
+
+/**
+ * {@code TestMethodReturnValueHandler} allows extensions to support
+ * {@link org.junit.jupiter.api.Test @Test} methods that return a non-void
+ * value.
+ *
+ * <p>By default, JUnit Jupiter requires {@code @Test} methods to return
+ * {@code void}. A registered {@code TestMethodReturnValueHandler} relaxes
+ * this requirement for return types it {@linkplain #supportsReturnType
+ * supports}. The handler is responsible for invoking the test method
+ * (via {@link InvocationInterceptor.Invocation#proceed()
+ * invocation.proceed()}) and processing the return value.
+ *
+ * <p>Because the handler controls the invocation, it can set up a
+ * custom execution context before calling {@code proceed()} &mdash; for
+ * example, running the test method on a specific thread or executor.
+ *
+ * <p>Implementations are discovered via Java's {@link java.util.ServiceLoader}
+ * mechanism and must be registered in
+ * {@code META-INF/services/org.junit.jupiter.api.extension.TestMethodReturnValueHandler}.
+ *
+ * <h2>Example</h2>
+ * <pre>{@code
+ * public class CompletableFutureHandler implements TestMethodReturnValueHandler {
+ *
+ *     @Override
+ *     public boolean supportsReturnType(Class<?> returnType) {
+ *         return CompletableFuture.class.isAssignableFrom(returnType);
+ *     }
+ *
+ *     @Override
+ *     public void execute(InvocationInterceptor.Invocation<Object> invocation,
+ *             ExtensionContext context) throws Throwable {
+ *         Object result = invocation.proceed();
+ *         if (result != null) {
+ *             ((CompletableFuture<?>) result).get(30, TimeUnit.SECONDS);
+ *         }
+ *     }
+ * }
+ * }</pre>
+ *
+ * @since 6.2
+ * @see org.junit.jupiter.api.Test
+ */
+@API(status = EXPERIMENTAL, since = "6.2")
+public interface TestMethodReturnValueHandler extends Extension {
+
+	/**
+	 * Determine if this handler supports the supplied return type.
+	 *
+	 * @param returnType the return type of the test method; never {@code null}
+	 * @return {@code true} if this handler can handle the return type
+	 */
+	boolean supportsReturnType(Class<?> returnType);
+
+	/**
+	 * Execute a {@code @Test} method that returns a supported type.
+	 *
+	 * <p>The handler must call {@link InvocationInterceptor.Invocation#proceed()
+	 * invocation.proceed()} to invoke the test method and obtain the return
+	 * value. The handler is then responsible for processing the result
+	 * &mdash; for example, subscribing to a reactive type and awaiting
+	 * completion.
+	 *
+	 * <p>Because the handler controls when {@code proceed()} is called, it
+	 * can set up a custom execution context beforehand &mdash; for example,
+	 * running the test on a specific thread or executor.
+	 *
+	 * <p>If this method throws, the test is marked as failed with the thrown
+	 * exception.
+	 *
+	 * @param invocation the invocation that executes the test method;
+	 * calling {@code proceed()} invokes the method and returns its result;
+	 * never {@code null}
+	 * @param context the current extension context; never {@code null}
+	 * @throws Throwable if the return value indicates a test failure
+	 */
+	void execute(InvocationInterceptor.Invocation<Object> invocation, ExtensionContext context) throws Throwable;
+
+}

--- a/junit-jupiter-engine/src/main/java/module-info.java
+++ b/junit-jupiter-engine/src/main/java/module-info.java
@@ -28,6 +28,7 @@ module org.junit.jupiter.engine {
 	requires org.opentest4j;
 
 	uses org.junit.jupiter.api.extension.Extension;
+	uses org.junit.jupiter.api.extension.TestMethodReturnValueHandler;
 
 	provides org.junit.platform.engine.TestEngine
 			with org.junit.jupiter.engine.JupiterTestEngine;

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestMethodTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestMethodTestDescriptor.java
@@ -23,6 +23,7 @@ import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 
 import org.apiguardian.api.API;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
@@ -30,7 +31,9 @@ import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.BeforeTestExecutionCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.InvocationInterceptor;
+import org.junit.jupiter.api.extension.InvocationInterceptor.Invocation;
 import org.junit.jupiter.api.extension.LifecycleMethodExecutionExceptionHandler;
+import org.junit.jupiter.api.extension.TestMethodReturnValueHandler;
 import org.junit.jupiter.api.extension.TestExecutionExceptionHandler;
 import org.junit.jupiter.api.extension.TestInstancePreDestroyCallback;
 import org.junit.jupiter.api.extension.TestInstances;
@@ -39,10 +42,12 @@ import org.junit.jupiter.engine.config.JupiterConfiguration;
 import org.junit.jupiter.engine.execution.AfterEachMethodAdapter;
 import org.junit.jupiter.engine.execution.BeforeEachMethodAdapter;
 import org.junit.jupiter.engine.execution.InterceptingExecutableInvoker;
+import org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.ReflectiveInterceptorCall;
 import org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.ReflectiveInterceptorCall.VoidMethodInterceptorCall;
 import org.junit.jupiter.engine.execution.JupiterEngineExecutionContext;
 import org.junit.jupiter.engine.extension.ExtensionRegistry;
 import org.junit.jupiter.engine.extension.MutableExtensionRegistry;
+import org.junit.jupiter.engine.support.MethodReflectionUtils;
 import org.junit.platform.commons.util.UnrecoverableExceptions;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.TestExecutionResult;
@@ -216,14 +221,48 @@ public class TestMethodTestDescriptor extends MethodBasedTestDescriptor {
 			try {
 				Method testMethod = getTestMethod();
 				Object instance = extensionContext.getRequiredTestInstance();
-				executableInvoker.invokeVoid(testMethod, instance, extensionContext, context.getExtensionRegistry(),
-					interceptorCall);
+				TestMethodReturnValueHandler handler = MethodReflectionUtils.findReturnValueHandler(testMethod);
+				if (handler != null) {
+					handler.execute(invokeTestMethodCapturingResult(testMethod, instance,
+						extensionContext, context.getExtensionRegistry()), extensionContext);
+				}
+				else {
+					executableInvoker.invokeVoid(testMethod, instance, extensionContext,
+						context.getExtensionRegistry(), interceptorCall);
+				}
 			}
 			catch (Throwable throwable) {
 				UnrecoverableExceptions.rethrowIfUnrecoverable(throwable);
 				invokeTestExecutionExceptionHandlers(context.getExtensionRegistry(), extensionContext, throwable);
 			}
 		});
+	}
+
+	@SuppressWarnings("NullAway")
+	private InvocationInterceptor.Invocation<Object> invokeTestMethodCapturingResult(Method testMethod, Object instance,
+			ExtensionContext extensionContext, ExtensionRegistry extensionRegistry) {
+		return () -> executableInvoker.<@Nullable Object> invoke(testMethod, instance,
+			extensionContext, extensionRegistry, returnValueCapturingInterceptorCall());
+	}
+
+	@SuppressWarnings("NullAway")
+	private static ReflectiveInterceptorCall<Method, @Nullable Object> returnValueCapturingInterceptorCall() {
+		return (interceptor, invocation, invocationContext, extensionContext) -> {
+			Object[] resultHolder = new Object[1];
+			interceptor.interceptTestMethod(new InvocationInterceptor.Invocation<@Nullable Void>() {
+				@Override
+				public @Nullable Void proceed() throws Throwable {
+					resultHolder[0] = invocation.proceed();
+					return null;
+				}
+
+				@Override
+				public void skip() {
+					invocation.skip();
+				}
+			}, invocationContext, extensionContext);
+			return resultHolder[0];
+		};
 	}
 
 	private void invokeTestExecutionExceptionHandlers(ExtensionRegistry registry, ExtensionContext context,

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/predicates/IsTestableMethod.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/predicates/IsTestableMethod.java
@@ -14,6 +14,8 @@ import static org.junit.jupiter.engine.support.MethodReflectionUtils.getReturnTy
 import static org.junit.platform.commons.support.AnnotationSupport.isAnnotated;
 import static org.junit.platform.commons.support.ModifierSupport.isNotAbstract;
 
+import org.junit.jupiter.engine.support.MethodReflectionUtils;
+
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.function.BiFunction;
@@ -65,7 +67,9 @@ abstract class IsTestableMethod implements Predicate<Method> {
 
 	protected static Condition<Method> hasVoidReturnType(Class<? extends Annotation> annotationType,
 			DiscoveryIssueReporter issueReporter) {
-		return issueReporter.createReportingCondition(method -> getReturnType(method) == void.class,
+		return issueReporter.createReportingCondition(
+			method -> getReturnType(method) == void.class
+					|| MethodReflectionUtils.hasReturnValueHandler(method),
 			method -> createIssue(annotationType, method, "must not return a value"));
 	}
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/support/MethodReflectionUtils.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/support/MethodReflectionUtils.java
@@ -21,14 +21,40 @@ import static org.junit.platform.commons.util.KotlinReflectionUtils.isKotlinType
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.util.Arrays;
+import java.util.List;
+import java.util.ServiceLoader;
 
 import org.apiguardian.api.API;
 import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.extension.TestMethodReturnValueHandler;
 import org.junit.platform.commons.support.ReflectionSupport;
+import org.junit.platform.commons.util.ClassLoaderUtils;
 import org.junit.platform.commons.util.KotlinReflectionUtils;
 
 @API(status = INTERNAL, since = "6.0")
 public class MethodReflectionUtils {
+
+	private static List<TestMethodReturnValueHandler> getReturnValueHandlers() {
+		return ServiceLoader //
+				.load(TestMethodReturnValueHandler.class, ClassLoaderUtils.getDefaultClassLoader()) //
+				.stream() //
+				.map(ServiceLoader.Provider::get) //
+				.toList();
+	}
+
+	public static boolean hasReturnValueHandler(Method method) {
+		Class<?> returnType = method.getReturnType();
+		return returnType != void.class
+				&& getReturnValueHandlers().stream().anyMatch(h -> h.supportsReturnType(returnType));
+	}
+
+	public static @Nullable TestMethodReturnValueHandler findReturnValueHandler(Method method) {
+		Class<?> returnType = method.getReturnType();
+		return getReturnValueHandlers().stream() //
+				.filter(h -> h.supportsReturnType(returnType)) //
+				.findFirst() //
+				.orElse(null);
+	}
 
 	public static Class<?> getReturnType(Method method) {
 		return isKotlinSuspendingFunction(method) //

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/CompletableFutureReturnValueHandler.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/CompletableFutureReturnValueHandler.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2015-2026 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.engine;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.InvocationInterceptor;
+import org.junit.jupiter.api.extension.TestMethodReturnValueHandler;
+
+public class CompletableFutureReturnValueHandler implements TestMethodReturnValueHandler {
+
+	@Override
+	public boolean supportsReturnType(Class<?> returnType) {
+		return CompletableFuture.class.isAssignableFrom(returnType);
+	}
+
+	@Override
+	public void execute(InvocationInterceptor.Invocation<Object> invocation, ExtensionContext context) throws Throwable {
+		Object result = invocation.proceed();
+		if (result == null) {
+			return;
+		}
+		try {
+			((CompletableFuture<?>) result).get(30, TimeUnit.SECONDS);
+		}
+		catch (ExecutionException ex) {
+			throw ex.getCause();
+		}
+		catch (TimeoutException ex) {
+			throw new AssertionError("CompletableFuture did not complete within 30 seconds", ex);
+		}
+	}
+
+}

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/TestMethodReturnValueHandlerTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/TestMethodReturnValueHandlerTests.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2015-2026 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.engine;
+
+import static org.junit.platform.testkit.engine.EventConditions.event;
+import static org.junit.platform.testkit.engine.EventConditions.finishedSuccessfully;
+import static org.junit.platform.testkit.engine.EventConditions.finishedWithFailure;
+import static org.junit.platform.testkit.engine.EventConditions.test;
+import static org.junit.platform.testkit.engine.TestExecutionResultConditions.instanceOf;
+import static org.junit.platform.testkit.engine.TestExecutionResultConditions.message;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration tests for {@link org.junit.jupiter.api.extension.TestMethodReturnValueHandler}.
+ *
+ * @since 6.2
+ */
+class TestMethodReturnValueHandlerTests extends AbstractJupiterTestEngineTests {
+
+	@Test
+	void testMethodReturningCompletableFutureIsDiscoveredAndExecuted() {
+		var results = executeTestsForClass(CompletableFutureTestCase.class);
+
+		results.testEvents().assertStatistics(
+			stats -> stats.started(3).succeeded(2).failed(1));
+	}
+
+	@Test
+	void successfulCompletableFutureTestSucceeds() {
+		var results = executeTestsForClass(CompletableFutureTestCase.class);
+
+		results.testEvents().succeeded().assertEventsMatchLoosely(
+			event(test("successfulAsyncTest"), finishedSuccessfully()),
+			event(test("voidTestStillWorks"), finishedSuccessfully()));
+	}
+
+	@Test
+	void failedCompletableFutureTestFails() {
+		var results = executeTestsForClass(CompletableFutureTestCase.class);
+
+		results.testEvents().failed().assertEventsMatchExactly(
+			event(test("failingAsyncTest"), finishedWithFailure(
+				instanceOf(RuntimeException.class), message("async failure"))));
+	}
+
+	@Test
+	void nullReturnValueIsHandledGracefully() {
+		var results = executeTestsForClass(NullReturnTestCase.class);
+
+		results.testEvents().assertStatistics(stats -> stats.started(1).succeeded(1));
+		results.testEvents().succeeded().assertEventsMatchExactly(
+			event(test("returnsNull"), finishedSuccessfully()));
+	}
+
+	@Test
+	void unsupportedReturnTypeIsNotDiscovered() {
+		var results = executeTestsForClass(UnsupportedReturnTypeTestCase.class);
+
+		results.testEvents().assertStatistics(stats -> stats.started(0));
+	}
+
+	// -------------------------------------------------------------------
+
+	static class CompletableFutureTestCase {
+
+		@Test
+		CompletableFuture<String> successfulAsyncTest() {
+			return CompletableFuture.completedFuture("hello");
+		}
+
+		@Test
+		CompletableFuture<String> failingAsyncTest() {
+			return CompletableFuture.failedFuture(new RuntimeException("async failure"));
+		}
+
+		@Test
+		void voidTestStillWorks() {
+		}
+	}
+
+	static class NullReturnTestCase {
+
+		@SuppressWarnings("NullAway")
+		@Test
+		CompletableFuture<Void> returnsNull() {
+			return null;
+		}
+	}
+
+	static class UnsupportedReturnTypeTestCase {
+
+		@Test
+		String unsupportedReturnType() {
+			return "not supported";
+		}
+	}
+
+}

--- a/jupiter-tests/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.TestMethodReturnValueHandler
+++ b/jupiter-tests/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.TestMethodReturnValueHandler
@@ -1,0 +1,1 @@
+org.junit.jupiter.engine.CompletableFutureReturnValueHandler


### PR DESCRIPTION
Quarkus supports reactive programming, so methods typically can return `void` and be blocking, or return a reactive type and we handle the plumbing to get it executed in the proper reactive context. But JUnit does not accept non-void test methods.

Supporting this without JUnit modifications requires us to run bytecode modification to move the non-`void` method under a different suffixed name, and generate a `void` method that is just for show so JUnit accepts it and then later our existing JUnit extension will replace any method it finds with that special suffix with the real one that returns a `Uni` and then handle the plumbing. That is pretty convoluted and requires a custom `ClassLoader` and bytecode manipulation.

Apparently, JUnit already has _some_ support for non-`void` test methods for Kotlin, but it did not turn into an extension SPI.

This PR introduces a new extension point that allows frameworks to support `@Test` methods with non-`void` return types. This enables reactive frameworks (e.g., Quarkus with Mutiny Uni) to let test methods return their native types instead of requiring bytecode transformation to work around the void limitation.

The SPI is discovered via ServiceLoader. During discovery, IsTestableMethod accepts methods with a registered handler. During execution, the handler receives an Invocation it must proceed() on, giving it control over both the execution context and return value processing.

I am not entirely happy with the new SPI, given that all the other extensions are registered under the regular `Extension` SPI, but apparently that happens later after tests are discovered, making it too late, and hence Claude advised to introduce a new SPI. We could still use the same SPI and just ignore the `TestMethodReturnValueHandler` extensions in the regular extension loading (since it's too late to use them) if you prefer.

What do you think of this PR? I know non-`void` test methods have generated a lot of debate and issues in the past, but this looks clean enough as an extension point, no?

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://docs.junit.org/snapshot/) and [Release Notes](https://docs.junit.org/snapshot/release-notes.html)
