### PR TITLE
Update to NullAway 0.14.1 and fix new warnings

### DIFF
--- a/documentation/src/test/java/example/CustomLauncherInterceptor.java
+++ b/documentation/src/test/java/example/CustomLauncherInterceptor.java
@@ -18,6 +18,7 @@ import java.net.URI;
 import java.net.URL;
 import java.net.URLClassLoader;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.platform.launcher.LauncherInterceptor;
 
 public class CustomLauncherInterceptor implements LauncherInterceptor {
@@ -30,7 +31,7 @@ public class CustomLauncherInterceptor implements LauncherInterceptor {
 	}
 
 	@Override
-	public <T> T intercept(Invocation<T> invocation) {
+	public <T extends @Nullable Object> T intercept(Invocation<T> invocation) {
 		Thread currentThread = Thread.currentThread();
 		ClassLoader originalClassLoader = currentThread.getContextClassLoader();
 		currentThread.setContextClassLoader(customClassLoader);

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -61,7 +61,7 @@ mockito-bom = { module = "org.mockito:mockito-bom", version = "5.23.0" }
 mockito-core = { module = "org.mockito:mockito-core" }
 mockito-junit-jupiter = { module = "org.mockito:mockito-junit-jupiter" }
 nohttp-checkstyle = { module = "io.spring.nohttp:nohttp-checkstyle", version = "0.0.11" }
-nullaway = { module = "com.uber.nullaway:nullaway", version = "0.13.8" }
+nullaway = { module = "com.uber.nullaway:nullaway", version = "0.14.1" }
 opentest4j = { module = "org.opentest4j:opentest4j", version.ref = "opentest4j" }
 openTestReporting-cli = { module = "org.opentest4j.reporting:open-test-reporting-cli", version.ref = "openTestReporting" }
 openTestReporting-events = { module = "org.opentest4j.reporting:open-test-reporting-events", version.ref = "openTestReporting" }

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/Arguments.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/Arguments.java
@@ -87,7 +87,8 @@ public interface Arguments {
 	default List<@Nullable Object> toList() {
 		// We could return List<?> here but the unbounded wildcard is painful
 		// to work with.
-		return new ArrayList<>(Arrays.asList(get()));
+		// The explicit type argument is temporary until NullAway's JSpecifyExperimental mode can be enabled.
+		return new ArrayList<@Nullable Object>(Arrays.asList(get()));
 	}
 
 	/**

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/ClasspathAlignmentCheckingLauncherInterceptor.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/ClasspathAlignmentCheckingLauncherInterceptor.java
@@ -12,6 +12,7 @@ package org.junit.platform.launcher.core;
 
 import java.util.Optional;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.platform.commons.JUnitException;
 import org.junit.platform.launcher.LauncherInterceptor;
 
@@ -20,7 +21,7 @@ class ClasspathAlignmentCheckingLauncherInterceptor implements LauncherIntercept
 	static final LauncherInterceptor INSTANCE = new ClasspathAlignmentCheckingLauncherInterceptor();
 
 	@Override
-	public <T> T intercept(Invocation<T> invocation) {
+	public <T extends @Nullable Object> T intercept(Invocation<T> invocation) {
 		try {
 			return invocation.proceed();
 		}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DefaultLauncherSession.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DefaultLauncherSession.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.platform.commons.PreconditionViolationException;
 import org.junit.platform.engine.support.store.Namespace;
 import org.junit.platform.engine.support.store.NamespacedHierarchicalStore;
@@ -36,7 +37,7 @@ class DefaultLauncherSession implements LauncherSession {
 
 	private static final LauncherInterceptor NOOP_INTERCEPTOR = new LauncherInterceptor() {
 		@Override
-		public <T> T intercept(Invocation<T> invocation) {
+		public <T extends @Nullable Object> T intercept(Invocation<T> invocation) {
 			return invocation.proceed();
 		}
 
@@ -153,7 +154,7 @@ class DefaultLauncherSession implements LauncherSession {
 					}
 
 					@Override
-					public <T> T intercept(Invocation<T> invocation) {
+					public <T extends @Nullable Object> T intercept(Invocation<T> invocation) {
 						return a.intercept(() -> b.intercept(invocation));
 					}
 				});

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/extension/KitchenSinkExtension.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/extension/KitchenSinkExtension.java
@@ -251,7 +251,7 @@ public class KitchenSinkExtension implements
 	}
 
 	@Override
-	public <T> T interceptTestFactoryMethod(Invocation<T> invocation,
+	public <T extends @Nullable Object> T interceptTestFactoryMethod(Invocation<T> invocation,
 			ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext) throws Throwable {
 		return InvocationInterceptor.super.interceptTestFactoryMethod(invocation, invocationContext, extensionContext);
 	}

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/InvocationInterceptorTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/InvocationInterceptorTests.java
@@ -345,7 +345,7 @@ class InvocationInterceptorTests extends AbstractJupiterTestEngineTests {
 		}
 
 		@Override
-		public <T> T interceptTestFactoryMethod(Invocation<T> invocation,
+		public <T extends @Nullable Object> T interceptTestFactoryMethod(Invocation<T> invocation,
 				ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext)
 				throws Throwable {
 			assertEquals(testClass, invocationContext.getTargetClass());

--- a/platform-tests/src/test/java/org/junit/platform/launcher/TestLauncherInterceptor1.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/TestLauncherInterceptor1.java
@@ -15,6 +15,8 @@ import java.io.UncheckedIOException;
 import java.net.URL;
 import java.net.URLClassLoader;
 
+import org.jspecify.annotations.Nullable;
+
 public class TestLauncherInterceptor1 implements LauncherInterceptor {
 
 	public static final String CLASSLOADER_NAME = "interceptor-loader";
@@ -30,7 +32,7 @@ public class TestLauncherInterceptor1 implements LauncherInterceptor {
 	}
 
 	@Override
-	public <T> T intercept(Invocation<T> invocation) {
+	public <T extends @Nullable Object> T intercept(Invocation<T> invocation) {
 		return invocation.proceed();
 	}
 

--- a/platform-tests/src/test/java/org/junit/platform/launcher/TestLauncherInterceptor2.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/TestLauncherInterceptor2.java
@@ -10,12 +10,14 @@
 
 package org.junit.platform.launcher;
 
+import org.jspecify.annotations.Nullable;
+
 public class TestLauncherInterceptor2 implements LauncherInterceptor {
 
 	public static boolean INTERCEPTING;
 
 	@Override
-	public <T> T intercept(Invocation<T> invocation) {
+	public <T extends @Nullable Object> T intercept(Invocation<T> invocation) {
 		INTERCEPTING = true;
 		try {
 			return invocation.proceed();


### PR DESCRIPTION
NullAway 0.14.0 release notes: https://github.com/uber/NullAway/releases/tag/v0.14.0
NullAway 0.14.1 release notes: https://github.com/uber/NullAway/releases/tag/v0.14.1

Most of the new warnings are due to inconsistent type variable upper bounds on method overrides, which are easily fixed.

In `Arguments.java` there is a new warning due to an inference limitation in NullAway related to wildcards.  This limitation is actually fixed when the `JSpecifyExperimental` flag is enabled (see [release notes](https://github.com/uber/NullAway/releases/tag/v0.14.0)), but that flag causes many other new warnings.  So for now, we add an explicit type argument and a comment.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.