### PR TITLE
Support comments in CsvSource value and deprecate textBlock

### DIFF
--- a/documentation/modules/ROOT/nav.adoc
+++ b/documentation/modules/ROOT/nav.adoc
@@ -24,6 +24,7 @@
 ** xref:writing-tests/parallel-execution.adoc[]
 ** xref:writing-tests/built-in-extensions.adoc[]
 * xref:migrating-from-junit4.adoc[]
+* xref:migrating-to-junit7.adoc[]
 * xref:running-tests/intro.adoc[]
 ** xref:running-tests/ide-support.adoc[]
 ** xref:running-tests/build-support.adoc[]

--- a/documentation/modules/ROOT/pages/migrating-to-junit7.adoc
+++ b/documentation/modules/ROOT/pages/migrating-to-junit7.adoc
@@ -1,0 +1,15 @@
+= Migrating to JUnit 7
+
+This page describes changes that require attention when migrating from JUnit 6 to JUnit 7.
+
+[[csv-source]]
+== `@CsvSource`
+
+Before upgrading to JUnit 7, upgrade to the latest JUnit 6.x release and run your test
+suite. JUnit 6.x rejects CSV records in `@CsvSource.value[]` that begin with the configured
+comment character. This check prevents a comment from silently removing a test case when
+the suite is upgraded to JUnit 7.
+
+In JUnit 7, comment records in `@CsvSource.value[]` are ignored, and the `textBlock`
+attribute is deprecated for removal. Use the `value` attribute for both regular strings and
+text blocks instead.

--- a/documentation/modules/ROOT/pages/overview.adoc
+++ b/documentation/modules/ROOT/pages/overview.adoc
@@ -70,6 +70,7 @@ corresponding sections of this User Guide, organized by topic.
 
 * xref:writing-tests/intro.adoc[Writing Tests in JUnit Jupiter]
 * xref:migrating-from-junit4.adoc[Migrating from JUnit 4 to JUnit Jupiter]
+* xref:migrating-to-junit7.adoc[Migrating to JUnit 7]
 * xref:running-tests/intro.adoc[]
 * xref:extensions/overview.adoc[Extension Model for JUnit Jupiter]
 * Advanced Topics

--- a/documentation/modules/ROOT/pages/writing-tests/parameterized-classes-and-tests.adoc
+++ b/documentation/modules/ROOT/pages/writing-tests/parameterized-classes-and-tests.adoc
@@ -1061,12 +1061,12 @@ by default. This behavior can be changed by setting the
 | `@CsvSource(value = { " apple , banana" }, ignoreLeadingAndTrailingWhitespace = false)` | `" apple "`, `" banana"`
 |===
 
-If the programming language you are using supports Java _text blocks_  or equivalent
-multi-line string literals, you can alternatively use the `textBlock` attribute of
-`@CsvSource`. Each record within a text block represents a CSV record and results in one
-invocation of the parameterized class or test. The first record may optionally be used to
-supply CSV headers by setting the `useHeadersInDisplayName` attribute to `true` as in the
-example below.
+If the programming language you are using supports Java _text blocks_ or equivalent
+multi-line string literals, you can alternatively use the `value` attribute of
+`@CsvSource` with a text block. Each record within a text block represents a CSV record
+and results in one invocation of the parameterized class or test. The first record may
+optionally be used to supply CSV headers by setting the `useHeadersInDisplayName` attribute
+to `true` as in the example below.
 
 Using a text block, the previous example can be implemented as follows.
 
@@ -1097,7 +1097,7 @@ Kotlin::
 [source,kotlin,indent=0]
 ----
 @ParameterizedTest
-@CsvSource(useHeadersInDisplayName = true, textBlock = """
+@CsvSource(useHeadersInDisplayName = true, value = """
 	FRUIT,         RANK
 	apple,         1
 	banana,        2
@@ -1120,11 +1120,10 @@ The generated display names for the previous example include the CSV header name
 [4] FRUIT = "strawberry", RANK = "700_000"
 ----
 
-In contrast to CSV records supplied via the `value` attribute, a text block can contain
-comments. Any line beginning with the value of the `commentCharacter` attribute (`+++#+++`
-by default) will be treated as a comment and ignored. Note that there is one exception
-to this rule: if the comment character appears within a quoted field, it loses
-its special meaning.
+Lines beginning with the value of the `commentCharacter` attribute (`+++#+++` by default)
+are treated as comments and ignored. This applies to CSV records supplied via the `value`
+attribute, including text blocks. There is one exception to this rule: if the comment
+character appears within a quoted field, it loses its special meaning.
 
 The comment character must be the first character on the line without any leading
 whitespace. It is therefore recommended that the closing text block delimiter (`"""`)
@@ -1140,7 +1139,7 @@ Java::
 [source,java,indent=0]
 ----
 @ParameterizedTest
-@CsvSource(delimiter = '|', quoteCharacter = '"', textBlock = """
+@CsvSource(delimiter = '|', quoteCharacter = '"', value = """
 	#-----------------------------
 	#    FRUIT     |     RANK
 	#-----------------------------
@@ -1165,7 +1164,7 @@ Kotlin::
 [source,kotlin,indent=0]
 ----
 @ParameterizedTest
-@CsvSource(delimiter = '|', quoteCharacter = '"', textBlock = """
+@CsvSource(delimiter = '|', quoteCharacter = '"', value = """
 	#-----------------------------
 	#    FRUIT     |     RANK
 	#-----------------------------

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvArgumentsProvider.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvArgumentsProvider.java
@@ -36,6 +36,7 @@ import org.junit.platform.commons.util.UnrecoverableExceptions;
 class CsvArgumentsProvider extends AnnotationBasedArgumentsProvider<CsvSource> {
 
 	@Override
+	@SuppressWarnings("removal")
 	protected Stream<? extends Arguments> provideArguments(ParameterDeclarations parameters, ExtensionContext context,
 			CsvSource csvSource) {
 
@@ -53,7 +54,6 @@ class CsvArgumentsProvider extends AnnotationBasedArgumentsProvider<CsvSource> {
 		for (String data : values) {
 			try (var reader = CsvReaderFactory.createReaderFor(configuration, data)) {
 				for (CsvRecord record : reader) {
-					requireNoCsvComments(record, configuration);
 					if (isFirstRecord && useHeadersInDisplayName) {
 						headers = record.getFields();
 					}
@@ -68,12 +68,6 @@ class CsvArgumentsProvider extends AnnotationBasedArgumentsProvider<CsvSource> {
 			}
 		}
 		return arguments.stream();
-	}
-
-	private static void requireNoCsvComments(CsvRecord record, CsvReaderConfiguration configuration) {
-		Preconditions.condition(!record.isComment(),
-			() -> "Comments may not be used when using @CsvSourve.value. Either change the comment character to something other than [%s] or enclose the field in [%s]".formatted(
-				configuration.commentCharacter(), configuration.quoteCharacter()));
 	}
 
 	private static Stream<Arguments> provideArgumentsFromTextBlock(CsvSource csvSource, String textBlock) {

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvReaderConfiguration.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvReaderConfiguration.java
@@ -42,8 +42,7 @@ record CsvReaderConfiguration( //
 		validateValueAndTextBlock(csvSource);
 		Preconditions.condition(csvSource.value().length > 0, () -> "@CsvSource must be declared with `value`");
 		return validate(csvSource, new CsvReaderConfiguration( //
-			// Comments in CsvSource.value are rejected manually.
-			CommentStrategy.READ,
+			CommentStrategy.SKIP,
 			// For CsvSource.value we manually process the header.
 			false, //
 			csvSource.commentCharacter(), //
@@ -57,6 +56,7 @@ record CsvReaderConfiguration( //
 		));
 	}
 
+	@SuppressWarnings("removal")
 	static CsvReaderConfiguration fromTextBlockCsvSource(CsvSource csvSource) {
 		validateValueAndTextBlock(csvSource);
 		Preconditions.condition(!csvSource.textBlock().isEmpty(),
@@ -90,6 +90,7 @@ record CsvReaderConfiguration( //
 		));
 	}
 
+	@SuppressWarnings("removal")
 	private static void validateValueAndTextBlock(CsvSource csvSource) {
 		var values = csvSource.value();
 		Preconditions.condition(values.length > 0 ^ !csvSource.textBlock().isEmpty(),

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvSource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvSource.java
@@ -10,6 +10,7 @@
 
 package org.junit.jupiter.params.provider;
 
+import static org.apiguardian.api.API.Status.DEPRECATED;
 import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.STABLE;
 
@@ -27,7 +28,7 @@ import org.junit.jupiter.params.ParameterizedInvocationConstants;
 /**
  * {@code @CsvSource} is a {@linkplain Repeatable repeatable}
  * {@link ArgumentsSource} which reads comma-separated values (CSV) from one
- * or more CSV records supplied via the {@link #value} attribute or
+ * or more CSV records supplied via the {@link #value} attribute or the deprecated
  * {@link #textBlock} attribute.
  *
  * <p>The supplied values will be provided as arguments to the annotated
@@ -91,10 +92,10 @@ public @interface CsvSource {
 	 * The CSV records to use as the source of arguments; must not be empty.
 	 *
 	 * <p>Defaults to an empty array. You therefore must supply CSV content
-	 * via this attribute or the {@link #textBlock} attribute.
+	 * via this attribute or the deprecated {@link #textBlock} attribute.
 	 *
-	 * <p>Each value corresponds to a record in a CSV file and will be split using
-	 * the specified {@link #delimiter} or {@link #delimiterString}. Note that
+	 * <p>Each value corresponds to a CSV document and will be split into one or more records
+	 * using the specified {@link #delimiter} or {@link #delimiterString}. Note that
 	 * the first value may optionally be used to supply CSV headers (see
 	 * {@link #useHeadersInDisplayName}). Moreover, each specified value must
 	 * not be blank.
@@ -115,8 +116,8 @@ public @interface CsvSource {
 	 * <h4>Text Blocks</h4>
 	 *
 	 * <p>If <em>text block</em> syntax is supported by your programming language,
-	 * you may also declare your CSV content as a textblock. Note that unlike
-	 * {@link #textBlock()} {@code value} does not support comments.
+	 * you may also declare your CSV content as a text block. Lines beginning with the
+	 * configured {@link #commentCharacter} are ignored.
 	 *
 	 * <p>When using text blocks each value corresponds to a CSV document and
 	 * will be split using the specified {@link #delimiter} or
@@ -166,11 +167,9 @@ public @interface CsvSource {
 	 * Note that the first record may optionally be used to supply CSV headers (see
 	 * {@link #useHeadersInDisplayName}).
 	 *
-	 * <p>In contrast to CSV records supplied via {@link #value}, a text block
-	 * can contain comments. Any line beginning with a {@link #commentCharacter}
-	 * will be treated as a comment and ignored. Note that there is one exception
-	 * to this rule: if the comment character appears within a quoted field,
-	 * it loses its special meaning.
+	 * <p>Lines beginning with a {@link #commentCharacter} will be treated as comments
+	 * and ignored. Note that there is one exception to this rule: if the comment
+	 * character appears within a quoted field, it loses its special meaning.
 	 *
 	 * <p>The comment character must be the first character on the line without
 	 * any leading whitespace. It is therefore recommended that the closing text block
@@ -200,10 +199,12 @@ public @interface CsvSource {
 	 * }</pre>
 	 *
 	 * @since 5.8.1
+	 * @deprecated Use {@link #value()} instead. This attribute will be removed in JUnit 7.
 	 * @see #value
 	 * @see #quoteCharacter
 	 */
-	@API(status = STABLE, since = "5.10")
+	@Deprecated(since = "7.0", forRemoval = true)
+	@API(status = DEPRECATED, since = "7.0")
 	String textBlock() default "";
 
 	/**

--- a/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedInvocationNameFormatterTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedInvocationNameFormatterTests.java
@@ -331,7 +331,7 @@ class ParameterizedInvocationNameFormatterTests {
 	class QuotedTextTests {
 
 		@ParameterizedTest
-		@CsvSource(delimiterString = "->", textBlock = """
+		@CsvSource(delimiterString = "->", value = """
 				'Jane Smith' -> 'Jane Smith'
 				\\           -> \\\\
 				"            -> \\"
@@ -352,7 +352,7 @@ class ParameterizedInvocationNameFormatterTests {
 		}
 
 		@ParameterizedTest
-		@CsvSource(quoteCharacter = '"', delimiterString = "->", textBlock = """
+		@CsvSource(quoteCharacter = '"', delimiterString = "->", value = """
 				X        -> X
 				\\       -> \\\\
 				'        -> \\'

--- a/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java
@@ -132,6 +132,7 @@ import org.opentest4j.TestAbortedException;
 /**
  * @since 5.0
  */
+@SuppressWarnings("removal")
 class ParameterizedTestIntegrationTests extends AbstractJupiterTestEngineTests {
 
 	private final Locale originalLocale = Locale.getDefault(Locale.Category.FORMAT);

--- a/jupiter-tests/src/test/java/org/junit/jupiter/params/provider/CsvArgumentsProviderTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/params/provider/CsvArgumentsProviderTests.java
@@ -29,6 +29,7 @@ import org.junit.platform.commons.JUnitException;
 /**
  * @since 5.0
  */
+@SuppressWarnings("removal")
 class CsvArgumentsProviderTests {
 
 	@Test
@@ -405,12 +406,23 @@ class CsvArgumentsProviderTests {
 	}
 
 	@Test
-	void rejectCommentCharacterWhenUsingValueAttribute() {
-		var annotation = csvSource("#foo", "#bar,baz", "baz,#quux");
+	void ignoresCommentCharacterWhenUsingValueAttribute() {
+		var annotation = csvSource("#foo", "#bar,baz", "baz,#quux", "'#quoted', #comment");
 
-		assertPreconditionViolationFor(() -> provideArguments(annotation).findAny())//
-				.withMessageStartingWith(
-					"Comments may not be used when using @CsvSourve.value. Either change the comment character to something other than [#] or enclose the field in [']");
+		assertThat(provideArguments(annotation)).containsExactly(//
+				array("baz", "#quux"), //
+				array("#quoted", "#comment"));
+	}
+
+	@Test
+	void ignoresCommentCharacterWhenUsingValueTextBlock() {
+		var annotation = csvSource().lines("""
+				#foo
+				bar, #baz
+				'#bar', baz
+				""").build();
+
+		assertThat(provideArguments(annotation)).containsExactly(array("bar", "#baz"), array("#bar", "baz"));
 	}
 
 	@Test
@@ -504,7 +516,7 @@ class CsvArgumentsProviderTests {
 	@Test
 	void supportsCsvHeadersWhenUsingValueAttribute() {
 		var annotation = csvSource().useHeadersInDisplayName(true)//
-				.lines("FRUIT, RANK", "apple, 1", "banana, 2").build();
+				.lines("# A comment before the headers", "FRUIT, RANK", "apple, 1", "banana, 2").build();
 
 		assertThat(headersToValues(annotation)).containsExactly(//
 			array("FRUIT = apple", "RANK = 1"), //

--- a/jupiter-tests/src/test/java/org/junit/jupiter/params/provider/MockCsvAnnotationBuilder.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/params/provider/MockCsvAnnotationBuilder.java
@@ -98,6 +98,7 @@ abstract class MockCsvAnnotationBuilder<A extends Annotation, B extends MockCsvA
 
 	// -------------------------------------------------------------------------
 
+	@SuppressWarnings("removal")
 	static class MockCsvSourceBuilder extends MockCsvAnnotationBuilder<CsvSource, MockCsvSourceBuilder> {
 
 		private String[] lines = new String[0];

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/AbstractTestDescriptorTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/AbstractTestDescriptorTests.java
@@ -171,7 +171,7 @@ class AbstractTestDescriptorTests implements TestDescriptorOrderChildrenTests {
 
 	@ParameterizedTest(name = "{0} \u27A1 {1}")
 	// NOTE: "\uFFFD" is the Unicode replacement character: �
-	@CsvSource(delimiterString = "->", textBlock = """
+	@CsvSource(delimiterString = "->", value = """
 			'carriage \r return'           -> 'carriage <CR> return'
 			'line \n feed'                 -> 'line <LF> feed'
 			'form \f feed'                 -> 'form \uFFFD feed'


### PR DESCRIPTION
## Summary

- Allow comment records in `@CsvSource.value[]`, including text blocks supplied through `value`.
- Deprecate `@CsvSource.textBlock` for removal in JUnit 7 and migrate documentation and tests to `value`.
- Add JUnit 6 to JUnit 7 migration guidance for this behavior change.

## Merge constraint

This implements the JUnit 7 behavior. The current `main` branch is still
`6.2.0-SNAPSHOT`, whose release notes intentionally require `@CsvSource.value[]`
comment records to fail so that users can find cases that would disappear after
upgrading to JUnit 7. Keep this PR as a draft until the JUnit 7 development line is
ready; merging it into the current 6.x line would remove that migration guard early.

## Why

`value[]` is the common representation for regular CSV records and text blocks, while the legacy `textBlock` attribute is scheduled for removal in JUnit 7. Supporting comments consistently in `value[]` makes the migration path explicit and prevents duplicated CSV configuration behavior.

## Validation

- `GRADLE_USER_HOME=.gradle JAVA_HOME=/opt/homebrew/opt/openjdk@25/libexec/openjdk.jdk/Contents/Home ./gradlew --no-daemon :jupiter-tests:test --tests org.junit.jupiter.params.provider.CsvArgumentsProviderTests --tests org.junit.jupiter.params.ParameterizedInvocationNameFormatterTests --tests org.junit.jupiter.params.ParameterizedTestIntegrationTests` — passed (133 tests).
- `GRADLE_USER_HOME=.gradle JAVA_HOME=/opt/homebrew/opt/openjdk@25/libexec/openjdk.jdk/Contents/Home ./gradlew --no-daemon :platform-tests:test --tests org.junit.platform.engine.support.descriptor.AbstractTestDescriptorTests` — passed (28 tests).
- `GRADLE_USER_HOME=.gradle JAVA_HOME=/opt/homebrew/opt/openjdk@25/libexec/openjdk.jdk/Contents/Home ./gradlew --offline --no-daemon :documentation:spotlessAsciidoctorCheck` — passed.

## Related issue

Closes #5887
