### PR TITLE
Document that extensions should be stateless

### DIFF
--- a/documentation/modules/ROOT/pages/extensions/registering-extensions.adoc
+++ b/documentation/modules/ROOT/pages/extensions/registering-extensions.adoc
@@ -492,3 +492,13 @@ programmatically via `@RegisterExtension` or `@ExtendWith` on fields in a subcla
 NOTE: A specific extension implementation can only be registered once for a given
 extension context and its parent contexts. Consequently, any attempt to register a
 duplicate extension implementation will be ignored.
+
+[[registration-instances]]
+== Extension Instances and State
+
+You should not make any assumptions about when or how often the JUnit Platform instantiates
+a registered extension. In particular, a single extension instance is typically reused
+across multiple tests, so an extension should be _stateless_. Any state that needs to be
+kept between invocations should be stored in the `{ExtensionContext_Store}` rather than in
+instance fields, so that it is scoped correctly and does not leak between tests. See
+xref:extensions/keeping-state-in-extensions.adoc[Keeping State in Extensions] for details.


### PR DESCRIPTION
Closes #6004.

The "Registering Extensions" page explains how to register extensions but does not mention how often an extension is instantiated or that a single instance is typically reused across tests, which led to the confusion in #6004.

As @mpkorstanje noted there, it shouldn't matter how often an extension is created — state should be kept in the `ExtensionContext.Store`, not in the extension instance. This adds a short "Extension Instances and State" section to `registering-extensions.adoc` making that explicit and linking to "Keeping State in Extensions".
