### PR TITLE
Align nullness annotations with NullAway 0.14

### DIFF
--- a/documentation/src/test/java/example/CustomLauncherInterceptor.java
+++ b/documentation/src/test/java/example/CustomLauncherInterceptor.java
@@ -18,6 +18,7 @@ import java.net.URI;
 import java.net.URL;
 import java.net.URLClassLoader;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.platform.launcher.LauncherInterceptor;
 
 public class CustomLauncherInterceptor implements LauncherInterceptor {
@@ -30,7 +31,7 @@ public class CustomLauncherInterceptor implements LauncherInterceptor {
 	}
 
 	@Override
-	public <T> T intercept(Invocation<T> invocation) {
+	public <T extends @Nullable Object> T intercept(Invocation<T> invocation) {
 		Thread currentThread = Thread.currentThread();
 		ClassLoader originalClassLoader = currentThread.getContextClassLoader();
 		currentThread.setContextClassLoader(customClassLoader);

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/Arguments.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/Arguments.java
@@ -87,7 +87,7 @@ public interface Arguments {
 	default List<@Nullable Object> toList() {
 		// We could return List<?> here but the unbounded wildcard is painful
 		// to work with.
-		return new ArrayList<>(Arrays.asList(get()));
+		return new ArrayList<@Nullable Object>(Arrays.asList(get()));
 	}
 
 	/**

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/ClasspathAlignmentCheckingLauncherInterceptor.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/ClasspathAlignmentCheckingLauncherInterceptor.java
@@ -12,6 +12,7 @@ package org.junit.platform.launcher.core;
 
 import java.util.Optional;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.platform.commons.JUnitException;
 import org.junit.platform.launcher.LauncherInterceptor;
 
@@ -20,7 +21,7 @@ class ClasspathAlignmentCheckingLauncherInterceptor implements LauncherIntercept
 	static final LauncherInterceptor INSTANCE = new ClasspathAlignmentCheckingLauncherInterceptor();
 
 	@Override
-	public <T> T intercept(Invocation<T> invocation) {
+	public <T extends @Nullable Object> T intercept(Invocation<T> invocation) {
 		try {
 			return invocation.proceed();
 		}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DefaultLauncherSession.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DefaultLauncherSession.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.platform.commons.PreconditionViolationException;
 import org.junit.platform.engine.support.store.Namespace;
 import org.junit.platform.engine.support.store.NamespacedHierarchicalStore;
@@ -36,7 +37,7 @@ class DefaultLauncherSession implements LauncherSession {
 
 	private static final LauncherInterceptor NOOP_INTERCEPTOR = new LauncherInterceptor() {
 		@Override
-		public <T> T intercept(Invocation<T> invocation) {
+		public <T extends @Nullable Object> T intercept(Invocation<T> invocation) {
 			return invocation.proceed();
 		}
 
@@ -153,7 +154,7 @@ class DefaultLauncherSession implements LauncherSession {
 					}
 
 					@Override
-					public <T> T intercept(Invocation<T> invocation) {
+					public <T extends @Nullable Object> T intercept(Invocation<T> invocation) {
 						return a.intercept(() -> b.intercept(invocation));
 					}
 				});

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/extension/KitchenSinkExtension.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/extension/KitchenSinkExtension.java
@@ -251,7 +251,7 @@ public class KitchenSinkExtension implements
 	}
 
 	@Override
-	public <T> T interceptTestFactoryMethod(Invocation<T> invocation,
+	public <T extends @Nullable Object> T interceptTestFactoryMethod(Invocation<T> invocation,
 			ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext) throws Throwable {
 		return InvocationInterceptor.super.interceptTestFactoryMethod(invocation, invocationContext, extensionContext);
 	}

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/InvocationInterceptorTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/InvocationInterceptorTests.java
@@ -345,7 +345,7 @@ class InvocationInterceptorTests extends AbstractJupiterTestEngineTests {
 		}
 
 		@Override
-		public <T> T interceptTestFactoryMethod(Invocation<T> invocation,
+		public <T extends @Nullable Object> T interceptTestFactoryMethod(Invocation<T> invocation,
 				ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext)
 				throws Throwable {
 			assertEquals(testClass, invocationContext.getTargetClass());

--- a/platform-tests/src/test/java/org/junit/platform/launcher/TestLauncherInterceptor1.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/TestLauncherInterceptor1.java
@@ -15,6 +15,8 @@ import java.io.UncheckedIOException;
 import java.net.URL;
 import java.net.URLClassLoader;
 
+import org.jspecify.annotations.Nullable;
+
 public class TestLauncherInterceptor1 implements LauncherInterceptor {
 
 	public static final String CLASSLOADER_NAME = "interceptor-loader";
@@ -30,7 +32,7 @@ public class TestLauncherInterceptor1 implements LauncherInterceptor {
 	}
 
 	@Override
-	public <T> T intercept(Invocation<T> invocation) {
+	public <T extends @Nullable Object> T intercept(Invocation<T> invocation) {
 		return invocation.proceed();
 	}
 

--- a/platform-tests/src/test/java/org/junit/platform/launcher/TestLauncherInterceptor2.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/TestLauncherInterceptor2.java
@@ -10,12 +10,14 @@
 
 package org.junit.platform.launcher;
 
+import org.jspecify.annotations.Nullable;
+
 public class TestLauncherInterceptor2 implements LauncherInterceptor {
 
 	public static boolean INTERCEPTING;
 
 	@Override
-	public <T> T intercept(Invocation<T> invocation) {
+	public <T extends @Nullable Object> T intercept(Invocation<T> invocation) {
 		INTERCEPTING = true;
 		try {
 			return invocation.proceed();


### PR DESCRIPTION
## Summary

Completes the NullAway 0.14.1 upgrade in [Renovate PR #6000](https://github.com/junit-team/junit-framework/pull/6000).

NullAway 0.14 now checks that overriding method type-variable bounds preserve nullable upper bounds and that mutable generic copies retain nullable element types. The upgrade therefore rejected launcher interceptor implementations whose `<T>` declarations no longer matched the public interfaces, plus `Arguments.toList()` where diamond inference selected `ArrayList<Object>`.

## Change

- repeat the existing `T extends @Nullable Object` contract on every affected launcher and test-factory interceptor implementation, including documentation and test fixtures
- make the `ArrayList` element type explicit as `@Nullable Object` in `Arguments.toList()`
- preserve method behavior, public signatures, and returned collection mutability

## Verification

- reproduced the exact bot-head failures on `368036a87814a00afd6670f7327ab61654e91c99` in `:junit-platform-launcher:compileJava` and `:junit-jupiter-params:compileJava`
- compiled all changed production, test, and documentation modules together on the repository-required JDK 25
- `env -u NO_COLOR ./gradlew --no-daemon build`: passed all 536 reported tasks, including tests, Spotless, Checkstyle, Roseau API checks, OSGi verification, publication assembly, and tooling compatibility tests
- `env -u NO_COLOR ./gradlew --no-daemon jacocoRootReport`: passed all 191 reported tasks and generated the root coverage report
- `git diff --check` passed; the repair is one signed-off commit with 16 insertions and 9 deletions across eight files

`NO_COLOR` is removed only from the command environment because the host exports it globally, while JUnit's `parseNoArguments` test intentionally verifies the default behavior when that variable is absent, as it is in repository CI.

Built and verified with [JAIPilot](https://github.com/JAIPilot/jaipilot):
- Skills: `jaipilot-maintainer-intent`, `jaipilot-fast-execution`, and `jaipilot-review-diff`
- Execution profile: `gpt-5.6-sol · xhigh · fast`

---

I hereby agree to the terms of the JUnit Contributor License Agreement.
