### PR TITLE
Expand output dir placeholders in a single pass

### DIFF
--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/OutputDir.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/OutputDir.java
@@ -81,7 +81,7 @@ public class OutputDir {
 
 	private static String expandPlaceholders(String customDir, SecureRandom random) {
 		return OUTPUT_DIR_UNIQUE_NUMBER_PLACEHOLDER_PATTERN.matcher(customDir) //
-				.replaceAll(__ -> String.valueOf(positiveLong(random)));
+				.replaceAll(_ -> String.valueOf(positiveLong(random)));
 	}
 
 	private final Path path;

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/OutputDir.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/OutputDir.java
@@ -81,7 +81,7 @@ public class OutputDir {
 
 	private static String expandPlaceholders(String customDir, SecureRandom random) {
 		return OUTPUT_DIR_UNIQUE_NUMBER_PLACEHOLDER_PATTERN.matcher(customDir) //
-				.replaceAll(_ -> String.valueOf(positiveLong(random)));
+				.replaceAll(__ -> String.valueOf(positiveLong(random)));
 	}
 
 	private final Path path;

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/OutputDir.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/OutputDir.java
@@ -80,12 +80,8 @@ public class OutputDir {
 	}
 
 	private static String expandPlaceholders(String customDir, SecureRandom random) {
-		String customPath = customDir;
-		while (customPath.contains(OUTPUT_DIR_UNIQUE_NUMBER_PLACEHOLDER)) {
-			customPath = OUTPUT_DIR_UNIQUE_NUMBER_PLACEHOLDER_PATTERN.matcher(customPath) //
-					.replaceFirst(String.valueOf(positiveLong(random)));
-		}
-		return customPath;
+		return OUTPUT_DIR_UNIQUE_NUMBER_PLACEHOLDER_PATTERN.matcher(customDir) //
+				.replaceAll(__ -> String.valueOf(positiveLong(random)));
 	}
 
 	private final Path path;

--- a/platform-tests/src/test/java/org/junit/platform/launcher/listeners/OutputDirTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/listeners/OutputDirTests.java
@@ -18,6 +18,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
+import java.util.regex.MatchResult;
+import java.util.regex.Pattern;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -44,6 +46,20 @@ class OutputDirTests {
 				.hasParent(cwd.resolve("build")) //
 				.extracting(it -> it.getFileName().toString(), as(STRING)) //
 				.matches("junit-\\d+");
+	}
+
+	@Test
+	void getOutputDirExpandsEachPlaceholderIndividuallyAndPreservesLiteralText() {
+		var placeholder = LauncherConstants.OUTPUT_DIR_UNIQUE_NUMBER_PLACEHOLDER;
+		var customDir = cwd.resolve("build").resolve("junit-" + placeholder + "-" + placeholder + "-$literal");
+
+		var outputDir = OutputDir.create(Optional.of(customDir.toAbsolutePath().toString())).toPath();
+
+		var fileName = outputDir.getFileName().toString();
+		assertThat(outputDir).exists().hasParent(cwd.resolve("build"));
+		assertThat(fileName).matches("junit-\\d+-\\d+-\\$literal");
+		assertThat(Pattern.compile("\\d+").matcher(fileName).results().map(MatchResult::group)) //
+				.doesNotHaveDuplicates();
 	}
 
 	@Test


### PR DESCRIPTION
## Overview

`OutputDir.expandPlaceholders()` expands every `{uniqueNumber}` placeholder in a custom
output directory path. It currently does so with a loop that restarts from the beginning
of the string for each placeholder:

```java
String customPath = customDir;
while (customPath.contains(OUTPUT_DIR_UNIQUE_NUMBER_PLACEHOLDER)) {
    customPath = OUTPUT_DIR_UNIQUE_NUMBER_PLACEHOLDER_PATTERN.matcher(customPath) //
            .replaceFirst(String.valueOf(positiveLong(random)));
}
return customPath;
```

Every iteration scans the whole path again (`contains`) and copies the whole path again
(`replaceFirst`). `Matcher.replaceAll(Function)` does the same work in one pass:

```java
return OUTPUT_DIR_UNIQUE_NUMBER_PLACEHOLDER_PATTERN.matcher(customDir) //
        .replaceAll(__ -> String.valueOf(positiveLong(random)));
```

With N as the path length and K as the number of placeholders, this changes the string
work from O(K(N + K)) - quadratic when K grows with N - to O(N + K). The number of
`SecureRandom` calls is K in both versions.

This is a small, low-risk cleanup rather than a fix for a reported problem: in practice K
is usually 1, where the two versions are equally fast. Please treat the benchmark below as
a description of the shape of the change, not as a claim about overall test execution
time.

## Why the behavior is unchanged

* **Each placeholder still gets its own number.** The `Function` overload is evaluated
  once per match, so `positiveLong(random)` is called exactly K times, in the same
  left-to-right order as before. Using `replaceAll(String)` instead would have reused a
  single number for all placeholders; the added test fails against that variant.
* **One pass is enough.** The loop could only need more than one pass if a replacement
  created a new placeholder. `positiveLong()` always yields a non-empty sequence of
  digits, and `{uniqueNumber}` contains no digits, so a replacement can neither contain a
  placeholder nor join the surrounding text into one.
* **The same matches are replaced.** The pattern is `Pattern.quote(...)` with no capture
  groups, and both versions replace leftmost, non-overlapping matches in the same order.
* **Escaping is unchanged.** Both `replaceFirst(String)` and `replaceAll(Function)` expand
  `$` and `\` in the replacement, so even a hypothetical non-numeric replacement would
  behave identically. Literal `$` in the *input* path is preserved either way, which the
  added test covers.
* **Nothing else changes.** Path resolution, normalization, directory creation, exception
  wrapping and `positiveLong()` are untouched, and the method remains `private static`.

To confirm this beyond reasoning, both implementations were compiled and loaded through
separate class loaders and compared on 200,033 inputs (33 hand-written edge cases plus
200,000 generated ones) built from fragments such as `{`, `}`, `unique`, `Number`,
`{uniqueNumber}`, `$`, `\`, digits and non-ASCII characters, including partial, adjacent
and nested placeholder shapes. Output strings, `nextLong()` call counts and thrown
exception types matched in every case on both JDK 21 and JDK 25.

## Tests

`OutputDirTests` gains one test that pins the behavior the refactoring must preserve: all
placeholders expanded, each with its own number, and literal text (including `$`) kept as
is. It passes with the change and fails against a naive `replaceAll(String)` version.

```
./gradlew :platform-tests:test --tests "*OutputDirTests*"
9 tests, 0 failures, 0 skipped
```

`:junit-platform-launcher:spotlessCheck` and `:platform-tests:spotlessCheck` pass; the
code was formatted with `spotlessApply`.

## Benchmark

JMH 1.37, 1 thread, 2 forks, warmup 3x200ms, measurement 5x200ms, `-prof gc`, JDK 25.0.1
(arm64). Input is `"p{uniqueNumber}/".repeat(K) + "end"`. This is a microbenchmark of the
string expansion only - `SecureRandom` and file system work are excluded - and the numbers
should not be read as an improvement factor for a test run.

| K | before | after | speedup | before B/op | after B/op |
|---:|---:|---:|---:|---:|---:|
| 1 | 0.134 ± 0.003 us | 0.131 ± 0.002 us | 1.02x | 323.2 | 323.2 |
| 2 | 0.308 ± 0.005 us | 0.207 ± 0.001 us | 1.49x | 768.0 | 414.4 |
| 4 | 0.585 ± 0.016 us | 0.341 ± 0.007 us | 1.72x | 1894.4 | 643.2 |
| 8 | 1.045 ± 0.058 us | 0.553 ± 0.005 us | 1.89x | 5020.8 | 1062.4 |
| 16 | 2.547 ± 0.090 us | 1.013 ± 0.011 us | 2.51x | 15120.1 | 1884.8 |

## Notes

* No release notes entry is included: `OutputDir` is `@API(status = INTERNAL)` and there
  is no observable behavior change. Happy to add one if you would prefer it.
* There is no corresponding issue. I am glad to open one first if that is the preferred
  process for a change of this size.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.
