### PR TITLE
Fix non deterministic OutputDirTests

### DIFF
--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/LauncherConstants.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/LauncherConstants.java
@@ -211,8 +211,8 @@ public class LauncherConstants {
 	public static final String OUTPUT_DIR_PROPERTY_NAME = "junit.platform.reporting.output.dir";
 
 	/**
-	 * Placeholder for use in {@link #OUTPUT_DIR_PROPERTY_NAME} that will be
-	 * replaced with a unique number.
+	 * Placeholder for use in {@link #OUTPUT_DIR_PROPERTY_NAME}. Each instance
+	 * will be replaced with a randomly chosen number.
 	 *
 	 * <p>This can be used to create a unique output directory for each test
 	 * run. For example, if multiple forks are used, each fork can be configured

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/OutputDir.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/OutputDir.java
@@ -47,15 +47,16 @@ public class OutputDir {
 		}
 	}
 
-	/**
-	 * Package private for testing purposes.
-	 */
-	static OutputDir createSafely(Optional<String> customDir, Supplier<Path> currentWorkingDir) throws IOException {
+	private static OutputDir createSafely(Optional<String> customDir, Supplier<Path> currentWorkingDir)
+			throws IOException {
 		return createSafely(customDir, currentWorkingDir, new SecureRandom());
 	}
 
-	private static OutputDir createSafely(Optional<String> customDir, Supplier<Path> currentWorkingDir,
-			SecureRandom random) throws IOException {
+	/**
+	 * Package private for testing purposes.
+	 */
+	static OutputDir createSafely(Optional<String> customDir, Supplier<Path> currentWorkingDir, SecureRandom random)
+			throws IOException {
 		Path cwd = currentWorkingDir.get().toAbsolutePath();
 		Path outputDir;
 

--- a/platform-tests/src/test/java/org/junit/platform/launcher/listeners/OutputDirTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/listeners/OutputDirTests.java
@@ -10,6 +10,7 @@
 
 package org.junit.platform.launcher.listeners;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.as;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.InstanceOfAssertFactories.STRING;
@@ -17,15 +18,16 @@ import static org.assertj.core.api.InstanceOfAssertFactories.STRING;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.SecureRandom;
 import java.util.Optional;
-import java.util.regex.MatchResult;
-import java.util.regex.Pattern;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.platform.launcher.LauncherConstants;
 
 class OutputDirTests {
+
+	private final SecureRandom random = new SecureRandom("20260909".getBytes(UTF_8));
 
 	@TempDir
 	Path cwd;
@@ -55,11 +57,11 @@ class OutputDirTests {
 
 		var outputDir = OutputDir.create(Optional.of(customDir.toAbsolutePath().toString())).toPath();
 
-		var fileName = outputDir.getFileName().toString();
-		assertThat(outputDir).exists().hasParent(cwd.resolve("build"));
-		assertThat(fileName).matches("junit-\\d+-\\d+-\\$literal");
-		assertThat(Pattern.compile("\\d+").matcher(fileName).results().map(MatchResult::group)) //
-				.doesNotHaveDuplicates();
+		assertThat(outputDir).exists() //
+				.hasParent(cwd.resolve("build")) //
+				.extracting(it -> it.getFileName().toString(), as(STRING)) //
+				.matchesSatisfying("junit-(\\d+)-(\\d+)-\\$literal",
+					matcher -> assertThat(matcher.group(1)).isNotEqualTo(matcher.group(2)));
 	}
 
 	@Test
@@ -110,7 +112,7 @@ class OutputDirTests {
 	}
 
 	private void assertOutputDirIsDetected(Path expected) throws IOException {
-		var outputDir = OutputDir.createSafely(Optional.empty(), () -> cwd).toPath();
+		var outputDir = OutputDir.createSafely(Optional.empty(), () -> cwd, random).toPath();
 		assertThat(Files.isSameFile(expected, outputDir)).isTrue();
 		assertThat(outputDir).exists();
 	}


### PR DESCRIPTION
Fixes https://github.com/junit-team/junit-framework/pull/6046 which introduced a non-deterministic test. Additionally this updates the documentation to clarify that each use of `{uniqueNumber}` is replaced with a random number.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://docs.junit.org/snapshot/) and [Release Notes](https://docs.junit.org/snapshot/release-notes.html)
