### PR TITLE
Document that LauncherSession support needs Surefire 3.5.4

### DIFF
--- a/documentation/modules/ROOT/pages/advanced-topics/launcher-api.adoc
+++ b/documentation/modules/ROOT/pages/advanced-topics/launcher-api.adoc
@@ -159,7 +159,7 @@ registered with `LauncherSession` (unless automatic registration is disabled.)
 The following build tools and IDEs are known to provide full support for `LauncherSession`:
 
 * Gradle 4.6 and later
-* Maven Surefire/Failsafe 3.0.0-M6 and later
+* Maven Surefire/Failsafe 3.5.4 and later
 * IntelliJ IDEA 2017.3 and later
 
 Other tools might also work but have not been tested explicitly.


### PR DESCRIPTION
Updates the `LauncherSession` tool support list, as suggested in #6058.

You mentioned 3.5.2, but the fix looks like it landed in 3.5.4, so I used that — happy to
change it if you would rather the list said something else. What I checked:

- apache/maven-surefire#863 describes it: `JUnitPlatformProvider` created multiple
  `LauncherSession`s "when rerunning failed tests", causing `ServiceLoader`-registered
  listeners "to be called multiple times".
- That commit is not in the `surefire-3.5.3` tag and is in `surefire-3.5.4`.
- Measured with `rerunFailingTestsCount=3` on one JVM: 3 sessions on 3.5.2 and 3.5.3,
  1 session on 3.5.4 and 3.5.6.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.
